### PR TITLE
formとgridのscss調整、slidebarの開閉ボタンをbuttonタグへ、anchor.pugのコメントと警告を出ないようにする

### DIFF
--- a/app/assets/scss/object/components/_forms.scss
+++ b/app/assets/scss/object/components/_forms.scss
@@ -131,7 +131,7 @@
     }
 
     span {
-      &:last-child {
+      &:last-of-type {
         label {
           margin-right: 0;
         }

--- a/app/assets/scss/object/components/_grid.scss
+++ b/app/assets/scss/object/components/_grid.scss
@@ -92,6 +92,24 @@ $susy: (
   }
 }
 
+// グリッド : デスクトップ
+//
+// デスクトップ時のグリッドアイテム
+// Styleguide 2.2.4
+
+@include breakpoint(medium up) {
+  @for $i from 1 through $grid-column-count {
+    .large-#{$i} {
+      width: span($i);
+      padding-left: (map_get($grid-column-responsive-gutter,medium)/2);
+      padding-right: (map_get($grid-column-responsive-gutter,medium)/2);
+    }
+    .is-push-lg-#{$i} {
+      margin-left: span($i);
+    }
+  }
+}
+
 // グリッド : タブレット
 //
 // タブレット時のグリッドアイテム
@@ -106,24 +124,6 @@ $susy: (
       padding-right: (map_get($grid-column-responsive-gutter,medium)/2);
     }
     .is-push-md-#{$i} {
-      margin-left: span($i);
-    }
-  }
-}
-
-// グリッド : デスクトップ
-//
-// デスクトップ時のグリッドアイテム
-// Styleguide 2.2.4
-
-@include breakpoint(medium up) {
-  @for $i from 1 through $grid-column-count {
-    .large-#{$i} {
-      width: span($i);
-      padding-left: (map_get($grid-column-responsive-gutter,medium)/2);
-      padding-right: (map_get($grid-column-responsive-gutter,medium)/2);
-    }
-    .is-push-lg-#{$i} {
       margin-left: span($i);
     }
   }

--- a/app/assets/scss/object/components/_slidebar.scss
+++ b/app/assets/scss/object/components/_slidebar.scss
@@ -25,8 +25,8 @@ $slidebar-container-bg: rgba(0, 0, 0, 0.8) !default;
     justify-content: center;
     flex-direction: column;
     position: fixed;
-    right: 0px;
-    top: 0px;
+    right: 0;
+    top: 0;
     text-align: center;
     font-size: rem-calc(12);
     z-index: 9999;
@@ -37,6 +37,7 @@ $slidebar-container-bg: rgba(0, 0, 0, 0.8) !default;
     width: rem-calc(55);
     height: rem-calc(55);
     padding-top: rem-calc(6);
+    border: none;
 
     &:active,
     &:hover {
@@ -44,7 +45,7 @@ $slidebar-container-bg: rgba(0, 0, 0, 0.8) !default;
     }
 
     &__inner{
-
+      display: block;
     }
 
     // ボーダー

--- a/app/inc/mixins/_anchor.pug
+++ b/app/inc/mixins/_anchor.pug
@@ -3,7 +3,7 @@ mixin a(href)
   a(href!= config.rootpath + href )&attributes(attributes)
     block
 
-// external link
+//- external link
 mixin a-ex(href)
-  a(href!= href )&attributes(attributes)(target="_blank")
+  a(href!= href target="_blank")&attributes(attributes)
     block

--- a/app/inc/mixins/_slidebar.pug
+++ b/app/inc/mixins/_slidebar.pug
@@ -1,8 +1,8 @@
 //- スマホメニュー
 mixin c_slidebar
   //-> スマホメニューのボタン
-  a(href="#").c-slidebar-button.js-slidebar-button
-    .c-slidebar-button__inner
+  button(type="button").c-slidebar-button.js-slidebar-button
+    span.c-slidebar-button__inner
       span.c-slidebar-button__line
         span
         span


### PR DESCRIPTION
##  _forms.scss

-  WP化した際に、ラジオボタン・チェックボタンのlast-childが効いていないので、last-of-typeに変更
   ※WPではinput type="hidden"の要素が追加で入るので、狙った要素がlast-childになっていないため

## _grid.scss
- largeとmediumのscssの記述順を変更
  ※ .large-4.medium-6.small-12 という記述で３段階のレスポンシブ対応ができるようにするため

## _anchor.pug
- コメントアウトがhtmlに出力されていたので修正
- コンパイル時にでる You should not have pug tags with multiple attributes. を出ないように修正

## _slidebar.pug / _slidebar.scss
- .c-slidebar-buttonをaタグからbuttonタグに変更
  ※ ページ遷移を伴わないボタンは button type="button" にできればしたいため