### PR TITLE
_margin.scss不要な箇所削除、olの中にulを入れてもスタイルが正しく当たるよう調整

### DIFF
--- a/app/assets/scss/layout/_post-content.scss
+++ b/app/assets/scss/layout/_post-content.scss
@@ -143,20 +143,20 @@
     }
   }
 
-  ul {
-    padding-left: rem-calc(24px);
-
-    li {
-      list-style: disc;
+  ol,ul{
+    li{
+      list-style: inherit;
     }
   }
-
+  ul {
+    padding-left: rem-calc(24px);
+    list-style: disc;
+    //@extend .c-list.is-icon;
+  }
   ol {
     padding-left: rem-calc(24px);
-
-    li {
-      list-style: decimal;
-    }
+    list-style: decimal;
+    //@extend .c-list.is-outline;
   }
 
   iframe {

--- a/app/assets/scss/object/components/_list.scss
+++ b/app/assets/scss/object/components/_list.scss
@@ -1,5 +1,7 @@
 .c-list {
+  list-style: none;
   li {
+    list-style: inherit;
   }
 }
 
@@ -13,9 +15,9 @@ category: Base
 */
 
 .c-list.is-disc {
+  padding-left: 1em;
   li {
     text-indent: -1em;
-    padding-left: 1em;
 
     &:before {
       content: "・";
@@ -24,16 +26,23 @@ category: Base
   }
 
   ul {
+    list-style: none;
     margin-left: rem-calc(24);
+    padding-left: 1em;
     li {
       text-indent: -1em;
-      padding-left: 1em;
+      list-style: none;
 
       &:before {
         content: "・";
         color: $font-base-color;
       }
     }
+  }
+
+  // is-outline の中に入れた場合にmaker削除
+  >li{
+    list-style: none!important;
   }
 }
 
@@ -45,12 +54,13 @@ category: Base
 
 */
 .c-list.is-icon {
+  padding-left: rem-calc(20);
+
+  @include breakpoint(small only) {
+    padding-left: rem-calc(18);
+  }
   li {
     position: relative;
-    padding-left: rem-calc(20);
-    @include breakpoint(small only) {
-      padding-left: rem-calc(18);
-    }
 
     &:before {
       content: "\f111";
@@ -59,17 +69,18 @@ category: Base
       color: $color-primary;
       position: absolute;
       top: rem-calc(4);
-      left: 0;
+      left: -1.5em;
       @include breakpoint(small only) {
         top: rem-calc(4);
       }
     }
 
     ul {
+      list-style: none;
       margin-left: rem-calc(24);
+      padding-left: rem-calc(18);
 
       li {
-        padding-left: rem-calc(18);
 
         &:before {
           content: "・";
@@ -77,6 +88,11 @@ category: Base
         }
       }
     }
+  }
+
+  // is-outline の中に入れた場合にmaker削除
+  >li{
+    list-style: none!important;
   }
 }
 
@@ -88,16 +104,26 @@ category: Base
 
 */
 .c-list.is-outline {
-  padding-left: rem-calc(20) !important;
-
+  padding-left: 0;
+  list-style: decimal inside;
   li {
     position: relative;
-    list-style: decimal;
-
-    ul {
-      li {
-        margin-left: rem-calc(38);
-      }
+    li {
+      margin-left: rem-calc(38);
     }
+  }
+  ol{
+    padding-left: 0;
+  }
+
+
+  // is-disc等の中に入れた場合にbefore削除用
+  >li::before{
+    content: none;
+  }
+  // 中に is-disc等入れた場合の調整用
+  ul{
+    padding-left: 0;
+    margin-left: 1em;
   }
 }

--- a/app/assets/scss/object/components/_toc.scss
+++ b/app/assets/scss/object/components/_toc.scss
@@ -29,12 +29,16 @@ category: PostContent
     }
   }
 
+  .toc_list{
+    list-style: none;
+  }
   .toc_list li {
     &:before {
       display: none;
     }
 
     ul {
+      list-style: none;
       padding-left: 24px;
       margin-left: 0;
     }

--- a/app/assets/scss/object/utility/_margin.scss
+++ b/app/assets/scss/object/utility/_margin.scss
@@ -98,10 +98,6 @@
     }
   }
 
-  &.is-xs {
-    margin-top: rem-calc(8);
-    margin-bottom: rem-calc(8);
-  }
 
   &.is-top {
     margin-bottom: 0 !important;

--- a/app/format/components/_text.pug
+++ b/app/format/components/_text.pug
@@ -70,7 +70,7 @@ div.u-mbs.is-bottom
     ol.c-list.is-outline
         li リスト1
         li リスト2
-            ul
+            ol
                 li リスト2の子要素
                 li リスト2の子要素
         li リスト2


### PR DESCRIPTION
## _margin.scss
`&.is-xs` が２回出てきていたので、不要そうな２回目の `&.is-xs` を削除

## _list.scss , _post-content.scss
`ol`の中に`ul`を入れても、スタイルが正しく当たるように調整（最後にスクショを添付しました）

## _toc.scss
_post-content.scssの修正の影響を受けている箇所を調整

## text.pug
`ol.c-list.is-outline` の中のリストが `ol` ではなく `ul` になっていたので、  
今までの見かけ通りの`ol`に修正

## olの中にulを入れてもスタイルが正しく当たる のイメージ
### _list.scss
<img width="369" alt="スクリーンショット 2022-02-04 17 14 12" src="https://user-images.githubusercontent.com/97862690/152496082-fb5f6145-c4b8-4a1b-bf0f-6b743ad600e9.png">

### _post-content.scss
<img width="546" alt="スクリーンショット 2022-02-04 17 13 43" src="https://user-images.githubusercontent.com/97862690/152496092-a0967f81-3a29-48ef-838e-6ff921af138c.png">

