### PR TITLE
anchor.js ヘッダーの高さ分アンカーの位置をずらすためのオプション追加

### DIFF
--- a/app/assets/js/app/anchor.js
+++ b/app/assets/js/app/anchor.js
@@ -23,7 +23,8 @@ var defaultOptions = {
   selector: '.js-anchor',
   dataSelector: 'anchor-target',
   scrollSpeed: 300,
-  easing: 'linear'
+  easing: 'linear',
+  headerElement:'' // ヘッダーの高さ分ずらしたいとき '.l-header' のように
 };
 export default class Anchor {
   constructor(options) {
@@ -40,6 +41,7 @@ export default class Anchor {
   init() {
     this.target = $(this.options.selector);
     this.onClick();
+    this.run();
   }
 
   /**
@@ -74,6 +76,13 @@ export default class Anchor {
       }
       var top = anchorTarget.offset().top;
 
+      //headerElementの指定があればheaderの高さを測って top の値をずらす
+      var headerHeight;
+      if (self.options.headerElement) {
+        headerHeight = $(self.options.headerElement).outerHeight();
+        top = top - headerHeight
+      }
+
       // スクロールさせる
       $('body,html').animate({
         scrollTop: top
@@ -82,6 +91,30 @@ export default class Anchor {
         easing: self.options.easing
       });
     });
+  }
+
+
+  /**
+   * ページロード時に実行
+   */
+  run() {
+    var self = this;
+    //headerElementの指定があればheaderの高さを測って表示位置をずらす
+    var headerHeight;
+    var url = $(location).attr('href');
+    if (url.indexOf("#") !== -1) {
+      if (self.options.headerElement) {
+        window.onload = function() {
+          headerHeight = $(self.options.headerElement).outerHeight();
+          var id = url.split("#");
+          var $target = $('#' + id[id.length - 1]);
+          if ($target.length) {
+            var pos = $target.offset().top - headerHeight;
+            $("html, body").animate({scrollTop: pos}, 10);
+          }
+        };
+      }
+    }
   }
 }
 


### PR DESCRIPTION
# アンカーリンクのスクロール時の位置調整
27行目にヘッダーのclass名を記入すると、
自動でアンカーリンクの位置がヘッダーの高さ分だけずれるようにしました。

↓使用例

```
var defaultOptions = {
  selector: '.js-anchor',
  dataSelector: 'anchor-target',
  scrollSpeed: 300,
  easing: 'linear',
  headerElement:'.l-header' // ヘッダーの高さ分ずらしたいとき '.l-header' のように
};
```

# 別ページから移動してきた場合の対策

100行目からあとに記載した部分。

1. URLに#がついているか確認
2. defaultOptionsにheaderElementの指定があるか確認
3. window.onload のタイミングで、ヘッダーの高さをはかる・#のついている要素の位置を測る
4. 表示位置をずらす

というようなことをさせています。