### PR TITLE
_slidebar.scss importantなしで機能するように、など微調整

### DIFF
--- a/app/assets/scss/object/components/_slidebar.scss
+++ b/app/assets/scss/object/components/_slidebar.scss
@@ -10,10 +10,10 @@ $slidebar-container-bg: rgba(0, 0, 0, 0.8) !default;
 
 @include breakpoint(large up) {
   .c-slidebar-button {
-    display: none !important;
+    display: none;
   }
   .c-slidebar-menu {
-    display: none !important;
+    display: none;
   }
 }
 
@@ -41,7 +41,7 @@ $slidebar-container-bg: rgba(0, 0, 0, 0.8) !default;
 
     &:active,
     &:hover {
-      opacity: 1 !important;
+      opacity: 1;
     }
 
     &__inner{
@@ -50,7 +50,7 @@ $slidebar-container-bg: rgba(0, 0, 0, 0.8) !default;
 
     // ボーダー
     &__line {
-      height: rem-calc(16) !important;
+      height: rem-calc(16);
       display: block;
       > span {
         display: block;
@@ -85,13 +85,12 @@ $slidebar-container-bg: rgba(0, 0, 0, 0.8) !default;
 
   // メニュー自体
   .c-slidebar-menu {
-    height: calc(100vh - 55px) !important;
-    padding: 0 rem-calc(16) rem-calc(104);
+    height: calc(100vh - 55px);
+    padding: 0 0 rem-calc(104);
     position: fixed;
     background-color: $color-primary;
     z-index: 9980;
     width: $slidebar-menu-width;
-    -webkit-transform: translateX(100%);
     transform: translate3d(100%, 0px, 0px);
     right: 0;
     -webkit-transition: $slidebar-menu-eaasing;
@@ -101,33 +100,50 @@ $slidebar-container-bg: rgba(0, 0, 0, 0.8) !default;
     -webkit-overflow-scrolling: touch;
 
     &.is-active {
-      height: calc(100% - 65px) !important;
+      height: calc(100% - 65px);
     }
 
     // 上から下へ
     &.is-top-to-bottom {
-      -webkit-transform: translateY(-100%);
       transform: translate3d(0px, -100%, 0px);
-      height: auto;
       width: 100%;
       opacity: 0;
     }
 
+
+    // メニュー要素（通常）
+    &__list{
+      width: 100%;
+      background: $color-primary;
+      li {
+        border-bottom: 1px solid $border-base-color;
+      }
+      a,
+      span {
+        font-size: rem-calc(15);
+        display: block;
+        padding: rem-calc(14) rem-calc(16);
+        text-decoration: none;
+        color: $color-white;
+        font-weight: 400;
+      }
+    }
+
+    // メニュー要素（子）
     &__children {
       width: 100%;
       padding: 0 rem-calc(16);
       display: none;
-      background-color: $color-primary-dark !important;
+      background-color: $color-primary-dark;
 
       li {
         &:last-child {
-          border-bottom: none !important;
+          border-bottom: none;
         }
 
         a {
-          color: $color-white !important;
-          padding: rem-calc(16) 0 !important;
-
+          color: $color-white;
+          padding: rem-calc(16) 0;
           &:before,
           &:after {
             display: none;
@@ -136,6 +152,7 @@ $slidebar-container-bg: rgba(0, 0, 0, 0.8) !default;
       }
     }
 
+    // メニュー要素（親）
     &__parent {
       a,
       span {
@@ -171,24 +188,7 @@ $slidebar-container-bg: rgba(0, 0, 0, 0.8) !default;
       }
     }
 
-    ul {
-      width: 100%;
-      background: $color-primary;
 
-      li {
-        border-bottom: 1px solid $border-base-color;
-
-        a,
-        span {
-          font-size: rem-calc(15);
-          display: block;
-          padding: rem-calc(14) rem-calc(16);
-          text-decoration: none;
-          color: $color-white;
-          font-weight: 400;
-        }
-      }
-    }
 
     &__button {
       margin-top: rem-calc(32);

--- a/app/inc/layout/_header.pug
+++ b/app/inc/layout/_header.pug
@@ -14,7 +14,7 @@ else
       else
         .l-header__heading: +a("/"): +img("logo.png","株式会社サンプル")
       nav.l-header__nav
-        ul.l-header__nav-list
+        ul
           li: +a("/onecolumn/") 1COLUMN
           li: +a("/twocolumns/") 2COLUMN
           li: +a("/news/") NEWS
@@ -27,12 +27,13 @@ else
                   span FORMAT
                   small フォーマット
                 .l-header__submenu__content
-                  +a("/format/").l-header__submenu__content__block
-                    div: +img("img-sample-sm.jpg", "フォーマット")
-                    span フォーマット
-                  +a("/blocks/").l-header__submenu__content__block
-                    div: +img("img-sample-sm.jpg", "ブロック編集ページ")
-                    span ブロック編集ページ
+                  .l-header__submenu__flex
+                    +a("/format/").l-header__submenu__block
+                      .l-header__submenu__image: +img("img-sample-sm.jpg", "フォーマット")
+                      span フォーマット
+                    +a("/blocks/").l-header__submenu__block
+                      .l-header__submenu__image: +img("img-sample-sm.jpg", "ブロック編集ページ")
+                      span ブロック編集ページ
           li: +a("/recruit/") RECRUIT
       +a("/contact/").l-header__button.c-button.is-sm <i class="fa fa-envelope" aria-hidden="true"></i>お問い合わせ
 

--- a/app/inc/layout/_header.pug
+++ b/app/inc/layout/_header.pug
@@ -14,7 +14,7 @@ else
       else
         .l-header__heading: +a("/"): +img("logo.png","株式会社サンプル")
       nav.l-header__nav
-        ul
+        ul.l-header__nav-list
           li: +a("/onecolumn/") 1COLUMN
           li: +a("/twocolumns/") 2COLUMN
           li: +a("/news/") NEWS
@@ -27,13 +27,12 @@ else
                   span FORMAT
                   small フォーマット
                 .l-header__submenu__content
-                  .l-header__submenu__flex
-                    +a("/format/").l-header__submenu__block
-                      .l-header__submenu__image: +img("img-sample-sm.jpg", "フォーマット")
-                      span フォーマット
-                    +a("/blocks/").l-header__submenu__block
-                      .l-header__submenu__image: +img("img-sample-sm.jpg", "ブロック編集ページ")
-                      span ブロック編集ページ
+                  +a("/format/").l-header__submenu__content__block
+                    div: +img("img-sample-sm.jpg", "フォーマット")
+                    span フォーマット
+                  +a("/blocks/").l-header__submenu__content__block
+                    div: +img("img-sample-sm.jpg", "ブロック編集ページ")
+                    span ブロック編集ページ
           li: +a("/recruit/") RECRUIT
       +a("/contact/").l-header__button.c-button.is-sm <i class="fa fa-envelope" aria-hidden="true"></i>お問い合わせ
 

--- a/app/inc/mixins/_slidebar.pug
+++ b/app/inc/mixins/_slidebar.pug
@@ -10,7 +10,7 @@ mixin c_slidebar
       span.c-slidebar-button__text.is-open MENU
       span.c-slidebar-button__text.is-close CLOSE
   .c-slidebar-menu.js-slidebar-menu.is-top-to-bottom
-    ul
+    ul.c-slidebar-menu__list
       li: +a("#") メニュー1
       li: +a("#") メニュー2
       li.c-slidebar-menu__parent.js-accordion
@@ -22,7 +22,8 @@ mixin c_slidebar
       li: +a("#") メニュー4
       li: +a("#") メニュー5
       li: +a("#") メニュー6
-    +a("#").c-slidebar-menu__button.c-button.is-contact お問い合わせ
-    .c-slidebar-menu__sns-btns
-      +a("#").c-slidebar-menu__sns-btn <i class="fa fa-twitter" aria-hidden="true"></i>
-      +a("#").c-slidebar-menu__sns-btn <i class="fa fa-facebook" aria-hidden="true"></i>
+    .l-container
+      +a("#").c-slidebar-menu__button.c-button.is-contact お問い合わせ
+      .c-slidebar-menu__sns-btns
+        +a("#").c-slidebar-menu__sns-btn <i class="fa fa-twitter" aria-hidden="true"></i>
+        +a("#").c-slidebar-menu__sns-btn <i class="fa fa-facebook" aria-hidden="true"></i>


### PR DESCRIPTION
# _slidebar.scss の !important 各種をなしでも同じレイアウトになるようにする
下記を行いました。
- 何とも競合していない部分の!importantを消す
- !importat なしでも負けないように詳細度を上げ下げする


# メニュー本体の左右のmarginをなくす
この部分の余白がない案件が多そうかな？と考えて、余白を消しました。
　※ こちらは必要そうであれば戻します！
<img width="219" alt="スクリーンショット 2022-02-09 10 47 49" src="https://user-images.githubusercontent.com/97862690/153106421-45ce781b-9fc2-481d-974f-f15c7908f8aa.png">

