### PR TITLE
gsapがconsoleに target not found を出すのを止める

### DIFF
--- a/app/assets/js/app/gsap.js
+++ b/app/assets/js/app/gsap.js
@@ -50,7 +50,7 @@ export default class GsapAnimation {
 
   /**
    * インスタンス化後に呼び出せる関数
-   * 例) app.js　から　this.gsap.animate　を呼び出す
+   * 例) app.js　から　this.gsap._animate　を呼び出す
    */
   get animate() {
     if(document.querySelector(".c-card.is-top")) {

--- a/app/assets/js/app/gsap.js
+++ b/app/assets/js/app/gsap.js
@@ -12,7 +12,7 @@ export default class GsapAnimation {
    */
   constructor(options) {
     this.options = $.extend(options);
-    // this.animate = this.animate;
+    //this._animate = this.animate;
     this.init();
   }
 
@@ -28,7 +28,7 @@ export default class GsapAnimation {
    * インスタンス化直後に呼ばれる関数
    */
   run() {
-
+    if(document.querySelector(".c-main-visual")) {
     gsap
       .timeline({
         defaults: {},
@@ -44,7 +44,7 @@ export default class GsapAnimation {
           duration: 1,
         }
       )
-
+    }
   }
 
 
@@ -53,7 +53,7 @@ export default class GsapAnimation {
    * 例) app.js　から　this.gsap.animate　を呼び出す
    */
   get animate() {
-
+    if(document.querySelector(".c-card.is-top")) {
     gsap
       .timeline({
         defaults: {},
@@ -74,5 +74,6 @@ export default class GsapAnimation {
           }
         }
       )
+    }
   }
 }


### PR DESCRIPTION
## gsapで動かす要素がないページで出るtarget not foundをとめる
gsap.jsが、使われていないページ（targetに設定した要素が存在しないページ）で
下記スクショの通りtarget not foundを出しているのを止めました。

<img width="678" alt="スクリーンショット 2022-02-16 18 21 32" src="https://user-images.githubusercontent.com/97862690/154236141-5a000fe8-f287-43a8-8b92-b0d2ac51c4aa.png">

参考にしたもの：
https://greensock.com/forums/topic/22491-gsap3-target-object-not-found/

## インスタンス化後に呼び出せる方を呼び出すとエラーが出る
```
//this.animate = this.animate;
```
のコメントを解除して
app.js　から　this.gsap.animate　を呼び出すと下記のスクショのエラーが出たので、
エラーが出ないようにしました。

<img width="677" alt="スクリーンショット 2022-02-16 18 30 31" src="https://user-images.githubusercontent.com/97862690/154236159-c7bc8aaa-b370-47f3-b5b8-d38168ea2e51.png">

参考にしたもの：
https://mebee.info/2020/10/12/post-20168/

