### PR TITLE
MW WP Form用にc_forms__submitのボタンのマークアップを書き換え

### DIFF
--- a/app/assets/scss/object/components/_forms.scss
+++ b/app/assets/scss/object/components/_forms.scss
@@ -207,8 +207,28 @@
     @include breakpoint(small only) {
       margin-top: rem-calc(32);
     }
-    //横並び
-    &.is-two-columns {
+    &__back{
+      width: calc(25% - 28px);
+      // -2px はタグの改行によって発生するホワイトスペースの距離
+      margin-right:(map_get($grid-column-responsive-gutter,medium)/2) - 2px;
+      @include breakpoint(medium down) {
+        width: calc(33.33333% - 28px);
+      }
+      @include breakpoint(small only) {
+        width: calc(50% - 10px);
+        margin-right: map_get($grid-column-responsive-gutter,small)/2 - 2px;
+      }
+    }
+    &__submit{
+      width: calc(25% - 28px);
+      margin-left: map_get($grid-column-responsive-gutter,medium)/2 - 2px;
+      @include breakpoint(medium down) {
+        width: calc(33.33333% - 28px);
+      }
+      @include breakpoint(small only) {
+        width: calc(50% - 10px);
+        margin-left: map_get($grid-column-responsive-gutter,small)/2 - 2px;
+      }
     }
   }
 }

--- a/app/contact/confirm/index.pug
+++ b/app/contact/confirm/index.pug
@@ -76,9 +76,6 @@ block body
                   +e.title.is-vertical-top お問い合わせ内容
                   +e.content
                     +e.textarea サービスについてご不明点のある方はこちらにご記載ください。
-          +e.submit.is-two-columns
-            .row
-              .large-3.is-push-lg-3.small-6
-                button.c-button.is-lg.is-secondary.is-arrow-left 戻る
-              .large-3.small-6
-                button.c-button.is-lg 送信する
+          +e.submit
+            button.c-button.c-forms__submit__back.is-lg.is-secondary.is-arrow-left 戻る
+            button.c-button.c-forms__submit__submit.is-lg 送信する

--- a/app/contact/index.pug
+++ b/app/contact/index.pug
@@ -180,3 +180,5 @@ block body
                   | へ同意する
               +e.submit
                 button.c-button.is-xlg 確認画面へ
+                //button.c-button.c-forms__submit__back.is-lg.is-secondary.is-arrow-left 戻る
+                //button.c-button.c-forms__submit__submit.is-lg 送信する


### PR DESCRIPTION
フォームの入力・確認画面のボタンを
WordPress実装時に同じひとつのdivに入れるだけで機能するように、
マークアップとCSSを変更しました。


# もともとはこのような感じ
<img width="659" alt="image" src="https://user-images.githubusercontent.com/97862690/154893807-a346c991-fd57-4af5-9652-e1a90cb8f74e.png">


# 変更後はこのようなイメージ
<img width="779" alt="image" src="https://user-images.githubusercontent.com/97862690/154893831-6a44091e-8cf2-4c29-82cf-83f3c398702d.png">



# WordPress実装時のコードはこうなります
```
<div class="c-forms__submit">
[mwform_bconfirm class="c-button is-xlg" value="confirm"]確認画面へ[/mwform_bconfirm]
[mwform_bback class="c-button c-forms__submit__back is-lg is-secondary is-arrow-left" value="back"]戻る[/mwform_bback]
[mwform_bsubmit name="submit" class="c-button c-forms__submit__submit is-lg" value="send"]送信する[/mwform_bsubmit]
</div>
```