### PR TITLE
c-news , c-post-navsのスタイルの微調整

### DIFF
--- a/app/assets/scss/object/components/_news.scss
+++ b/app/assets/scss/object/components/_news.scss
@@ -77,6 +77,7 @@ category: News
   &__text {
     font-weight: 700;
     @include breakpoint(small only) {
+      width:100%;
       margin-top: rem-calc(8);
     }
   }

--- a/app/assets/scss/object/components/_post-navs.scss
+++ b/app/assets/scss/object/components/_post-navs.scss
@@ -18,6 +18,7 @@ category: Navigation
 
     li {
       width: rem-calc(155);
+      max-width: 33%;
       @include breakpoint(small only) {
         width: calc(33% - 8px);
       }
@@ -44,14 +45,9 @@ category: Navigation
   }
 
   &__archive {
-    position: absolute;
-    left: 50%;
-    top: 0;
-    transform: translateX(-50%);
-
     a {
-      display: inline-flex;
       align-items: center;
+      margin: auto;
 
       &:after {
         display: none;


### PR DESCRIPTION
# c-news の調整
テキストの長さによってはレイアウトが崩れるのを修正しました
![image](https://user-images.githubusercontent.com/97862690/161724821-caac559c-6fef-4f58-a81b-b93695a181c3.png)

# c-post-nav の調整
主に「一覧を見る」ボタンに対してposition を使わないようにする対応をしました。


あわせて微妙な横幅のときのレイアウトも調整しています。
![image](https://user-images.githubusercontent.com/97862690/161725679-879204bf-8996-4822-b2fd-e6be8105e0ad.png)