### PR TITLE
dist直下に変なファイルができるのを修正

### DIFF
--- a/webpack.config.babel.js
+++ b/webpack.config.babel.js
@@ -53,7 +53,10 @@ export default {
                         loader: MiniCssExtractPlugin.loader,
                     },
                     {
-                        loader: 'css-loader'
+                        loader: 'css-loader',
+                        options: {
+                            esModule:false,
+                        }
                     },
                     {
                         loader: 'sass-loader',


### PR DESCRIPTION
app.js の slick-slider.jsが読み込む slick-theme.css が使っているフォント系のファイルが
正しく出力されていない問題を修正しました。

## 修正前
![image](https://user-images.githubusercontent.com/97862690/172077927-c4636f66-cfa9-4c38-81c5-fcca290f3dfe.png)

## 修正後
![image](https://user-images.githubusercontent.com/97862690/172077958-3f71d9b1-ae75-4382-9122-40efed4cb686.png)
