### PR TITLE
ページネーション系・お問合せフォーム系

### DIFF
--- a/app/assets/scss/object/components/_form-head.scss
+++ b/app/assets/scss/object/components/_form-head.scss
@@ -13,6 +13,7 @@
     font-size: rem-calc(24);
     letter-spacing: 0.1em;
     line-height: math.div(42, 24)*1;
+    margin-top: 0;
     @include breakpoint(medium down) {
       font-size: rem-calc(18);
     }

--- a/app/assets/scss/object/components/_pagination.scss
+++ b/app/assets/scss/object/components/_pagination.scss
@@ -12,12 +12,14 @@ category: Navigation
 
   ul {
     display: flex;
+    flex-wrap: wrap;
     justify-content: center;
     align-items: center;
   }
 
   ul li {
     list-style: none !important;
+    margin-bottom: rem-calc(6);
 
     &:not(:last-child) {
       margin-right: rem-calc(6);

--- a/app/contact/complete/index.pug
+++ b/app/contact/complete/index.pug
@@ -10,11 +10,11 @@ block page_header
 
 block body
   main.l-main
-    section.l-section.is-lg.is-bg-color
+    section.l-section.is-lg.is-color-secondary
       .l-container
         +c.form-head
           +e.block
-            +e.title お問い合わせ
+            +h1.title お問い合わせ
             +e.list
               +e.item
                 +e.item-number 1

--- a/app/contact/confirm/index.pug
+++ b/app/contact/confirm/index.pug
@@ -10,11 +10,11 @@ block page_header
 
 block body
   main.l-main
-    section.l-section.is-lg.is-bg-color
+    section.l-section.is-lg.is-color-secondary
       .l-container
         +c.form-head
           +e.block
-            +e.title お問い合わせ
+            +h1.title お問い合わせ
             +e.list
               +e.item
                 +e.item-number 1
@@ -26,7 +26,6 @@ block body
                 +e.item-number 3
                 +e.item-text 送信完了
         +c.forms
-          form(action="/contact/complete/")
           +e.inner
             .row
               .large-10.is-push-lg-1.small-12

--- a/app/contact/index.pug
+++ b/app/contact/index.pug
@@ -8,13 +8,16 @@ block append config
 
 block page_header
 
+  //- ★★★★★★★★★★★★★★★★★★★★★★★★★★★★★★★★★★★
+  //- /confirm/ と /complete/ もCSS調整必須！
+  //- ★★★★★★★★★★★★★★★★★★★★★★★★★★★★★★★★★★★
 block body
   main.l-main
     section.l-section.is-lg.is-color-secondary
       .l-container
         +c.form-head
           +e.block
-            +e.title お問い合わせ
+            +h1.title お問い合わせ
             +e.list
               +e.item.is-current
                 +e.item-number 1
@@ -27,7 +30,6 @@ block body
                 +e.item-text 送信完了
         <script src="https://ajaxzip3.github.io/ajaxzip3.js" charset="UTF-8"></script>
         +c.forms
-          form(action="/contact/confirm/")
           .row
             .large-10.is-push-lg-1.small-12
               +e.text 下記のフォームに必須項目を入力して<br class="u-visible-sm">送信してください。

--- a/app/news/index.pug
+++ b/app/news/index.pug
@@ -30,15 +30,7 @@ block body
                     +e.inner
                       +e.text お知らせの投稿タイトルがここに入ります。
                       +e.excerpt 本文内容の一文が抜粋されてここに掲載を行います。本文内容の一文が抜粋されてここに掲載を行います。本文内容の一文が抜粋されてここに掲載を行います…[続きを見る]
-              +c.pagination
-                ul
-                  li: +a("/news/page/").c-pagination__prev <i class="fa fa-angle-left" aria-hidden="true"></i></a></li>
-                  li: span.is-current 1
-                  li: +a("/news/page/") 2
-                  li: +a("/news/page/") 3
-                  li: +a("/news/page/") 4
-                  li: +a("/news/page/") 5
-                  li: +a("/news/page/").c-pagination__next <i class="fa fa-angle-right" aria-hidden="true"></i>
+              +c_pagination()
               div.u-mbs.is-top.is-lg
                 +c.box-archive
                   +e.block
@@ -91,14 +83,6 @@ block body
                         span.c-card-post__label.c-label カテゴリ名
                         +e.date 2018.01.01
                       +e.title タイトルが入ります。タイトルが入ります。
-          +c.pagination
-            ul
-              li: +a("/news/page/").c-pagination__prev <i class="fa fa-angle-left" aria-hidden="true"></i></a></li>
-              li: span.is-current 1
-              li: +a("/news/page/") 2
-              li: +a("/news/page/") 3
-              li: +a("/news/page/") 4
-              li: +a("/news/page/") 5
-              li: +a("/news/page/").c-pagination__next <i class="fa fa-angle-right" aria-hidden="true"></i>
+          +c_pagination()
   +l_offer
 


### PR DESCRIPTION
ページネーション系と、お問合せフォーム系に以下の変更を加えました。


## ページネーション系
### +c_pagination() を使うように
 /news/index.pugで　+c_pagination() を使うようにしてみました。
（class追加している左寄せの方は直書きのままです…）

### WP実装後にliがめちゃくちゃ増えたとき、折り返すように
.c-pagination ul に flex-wrap:wrap を追加
.c-pagination ul li にmargin-bottomを追加（折り返した場合にくっつかないように）
これで、スマホでも突き抜けません！

▼改善事項DB
https://www.notion.so/growgroup/pagination-0ba2bbeda6824c169d2341f3ec8702d5

## お問合せフォーム系
### .c-form-head__title をh1にする（＋それに合わせてCSS調整）
page-headerがないことが多く、h1紛失がちだったのでデフォルトをh1にしてみました。

▼改善事項DB
https://www.notion.so/growgroup/gg-styleguide-c-form-head__title-h1-36a20e0bd51e4f62bf1eaf973fb794be

### 増田さんより
- /contact/index.pug に、confirmとcompleteの調整が必要な旨のコメント追加
    - それに伴い、 /confirm/と/complete/のl-sectionにつけている背景色classを
      /contact/と同じにしてみました（同じにして大丈夫だったでしょうか…）
- formタグを削除して、クライアント確認時ページ遷移されないようにする