### PR TITLE
image-rendering: -webkit-optimize-contrast; の入れ方調整

### DIFF
--- a/app/assets/scss/foundation/_normalize.scss
+++ b/app/assets/scss/foundation/_normalize.scss
@@ -36,7 +36,13 @@ body {
     font-size:  $font-base-size*0.875;
   }
 }
-
+/* chrome opera /
+/! autoprefixer: ignore next */
+@media screen and (-webkit-min-device-pixel-ratio: 0) and (min-resolution: .001dpcm) {
+  body {
+    image-rendering: -webkit-optimize-contrast;
+  }
+}
 /* HTML5 display definitions
    ========================================================================== */
 
@@ -235,7 +241,6 @@ img {
   max-width: 100%;
   height: auto;
   vertical-align: top;
-  image-rendering: -webkit-optimize-contrast;
 }
 
 /**


### PR DESCRIPTION
こちらの件です。
https://www.notion.so/growgroup/af0da5c508e74d12850353b952f04868
<img width="217" alt="image" src="https://user-images.githubusercontent.com/97862690/177737791-4ccb5321-14b4-49c5-ae70-0b69da003924.png">


案件にてiOSで細部のギザギザが気になり修正したため、
そのコードをこちらに展開します…！

## メモ
` /! autoprefixer: ignore next */ ` をつけないと、
AutoprefixerにCSSハックを殺されました。