### PR TITLE
TOCのHTMLをWordPressの出力に合わせる／ l-post-content の中にclassを使っている箇所削除(twocol…

### DIFF
--- a/app/archive-twocolumns/page/index.pug
+++ b/app/archive-twocolumns/page/index.pug
@@ -21,68 +21,59 @@ block body
           li: +a("#") #タグ
           li: +a("#") #タグ
           li: +a("#") #タグ
-  +img("img-sample.jpg")
-  <div id="toc_container" class="no_bullets"><p class="toc_title">目次 <span class="toc_toggle">[<a href="#">非表示</a>]</span></p><ul class="toc_list"><li><a href="#Web"><span class="toc_number toc_depth_1">1.</span> Webマーケティングとは？</a></li><li><a href="#Web-2"><span class="toc_number toc_depth_1">2.</span> Webマーケティングのメリットとは？</a><ul><li><a href="#i"><span class="toc_number toc_depth_2">2.1</span> あらゆる方たちに配信ができる</a></li><li><a href="#i-2"><span class="toc_number toc_depth_2">2.2</span> 素早く情報を配信できる</a></li><li><a href="#i-3"><span class="toc_number toc_depth_2">2.3</span> 修正を簡単に実行できる</a></li><li><a href="#i-4"><span class="toc_number toc_depth_2">2.4</span> 少ない費用で情報を配信できる</a></li><li><a href="#i-5"><span class="toc_number toc_depth_2">2.5</span> ターゲットを細かく設定できる</a></li></ul></li></ul></div>
 
-  div.u-mbs.is-top.is-md
-    strong 見出し
+  .l-post-content.is-twocolumns
+    +img("img-sample.jpg")
+    <div id="toc_container" class="no_bullets"><p class="toc_title">目次 <span class="toc_toggle">[<a href="#">非表示</a>]</span></p><ul class="toc_list"><li><a href="#Web"><span class="toc_number toc_depth_1">1</span> Webマーケティングとは？</a></li><li><a href="#Web-2"><span class="toc_number toc_depth_1">2</span> Webマーケティングのメリットとは？</a><ul><li><a href="#i"><span class="toc_number toc_depth_2">2.1</span> あらゆる方たちに配信ができる</a></li><li><a href="#i-2"><span class="toc_number toc_depth_2">2.2</span> 素早く情報を配信できる</a></li><li><a href="#i-3"><span class="toc_number toc_depth_2">2.3</span> 修正を簡単に実行できる</a></li><li><a href="#i-4"><span class="toc_number toc_depth_2">2.4</span> 少ない費用で情報を配信できる</a></li><li><a href="#i-5"><span class="toc_number toc_depth_2">2.5</span> ターゲットを細かく設定できる</a></li></ul></li></ul></div>
 
-  div.u-mbs.is-top.is-md
-    h1 見出し壱
-
-  div.u-mbs.is-top.is-md
     h2 見出し弐
-
-  div.u-mbs.is-top.is-md
+    p テキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキスト
     h3 見出し参
-
-  div.u-mbs.is-top.is-md
+    p テキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキスト
     h4 見出し四
-
-  div.u-mbs.is-top.is-md
+    p テキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキスト
     h5 見出し五
-
-  div.u-mbs.is-top.is-md
+    p テキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキスト
     h6 見出し六
+    p テキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキスト
 
-  div.u-mbs.is-top.is-md
+    p
+      strong 強調テキスト強調テキスト強調テキスト強調テキスト強調テキスト強調テキスト強調テキスト強調テキスト強調テキスト強調テキスト強調テキスト強調テキスト強調テキスト強調テキスト強調テキスト強調テキスト強調テキスト
+    p
+      small 小さいテキスト小さいテキスト小さいテキスト小さいテキスト小さいテキスト小さいテキスト小さいテキスト小さいテキスト小さいテキスト小さいテキスト小さいテキスト小さいテキスト小さいテキスト小さいテキスト
+
     h2 引用 (Blockquote)
     | 一行の引用:
-    blockquote.c-blockquote 貪欲であれ、愚かであれ
-
-  div.u-mbs.is-top.is-md
+    blockquote 貪欲であれ、愚かであれ
     h2 引用 (Blockquote)
     | 引用元の参照のある複数行の引用:
-    blockquote.c-blockquote
+    blockquote
       | 集中という意味は集中しなくてはいけないことにイエスということだと、人は言います。しかし、それはまったく違います。そうではなく、そこにある何百ものいいアイディアにノーということなのです。慎重に選択しなくてはいけません。実際、私は成し遂げたことと同じように成し遂げられなかったことにも満足しています。革新というのは1000ものことにノーということなのです。
       cite スティーブ・ジョブズ - 1997年 Apple 世界的開発者会議
 
-  div.u-mbs.is-top.is-md
     h2 テーブル
     table
       tbody
         tr
           th 従業員
-          th.views 給与
+          th 給与
           th
-        tr.odd
-          td: a(href="http://example.com/") ジェーン
+        tr
+          td: a(href=".") ジェーン
           td $￥1
           td スティーブ・ジョブズの必要な給与。
-        tr.even
-          td: a(href="http://example.com/") ジョン
+        tr
+          td: a(href=".") ジョン
           td ￥10万
           td ブログのすべて。
-        tr.odd
-          td: a(href="http://example.com/") ジェーン
+        tr
+          td: a(href=".") ジェーン
           td ￥1億
           td 百聞は一見にしかず。だよね ? なのでトムは1000倍。
-        tr.even
-          td: a(href="http://example.com/") ジェーン
+        tr
+          td: a(href=".") ジェーン
           td ￥1000億
           td これみたいな髪?! もういいよね…
-
-  div.u-mbs.is-top.is-md
     h2 定義リスト
     dl
       dt 定義リストタイトル
@@ -94,9 +85,8 @@ block body
       dt ライブでやろう
       dd ビル・オライリーが <a title="We'll Do It Live" href="https://www.youtube.com/watch?v=O_HyZ5aW76c">説明</a> してもらいましょう。
 
-  div.u-mbs.is-top
     h2 非順序リスト（ネスト化）
-    ul.c-list.is-disc
+    ul
       li リストアイテム1
         ul
           li リストアイテム1
@@ -112,9 +102,8 @@ block body
       li リストアイテム3
       li リストアイテム4
 
-  div.u-mbs.is-top
     h2 順序リスト
-    ol.c-list.is-outline
+    ol
       li リストアイテム1
         ol
           li リストアイテム1
@@ -129,25 +118,23 @@ block body
       li リストアイテム2
       li リストアイテム3
       li リストアイテム4
-
-  div.u-mbs.is-top.is-md
     h2 HTML　要素タグテスト
-    | 他の HTML タグは <a href="http://ja.support.wordpress.com/code/" rel="nofollow">FAQ</a> をご覧ください。
+    p 他の HTML タグは <a href="http://ja.support.wordpress.com/code/" rel="nofollow" target="_blank">FAQ</a> をご覧ください。
 
-    div.u-mbs.is-top.is-sm
+    p
       strong 住所タグ<br>
       | 以下は住所の例です。<br>
       code &lt;address&gt;
       | タグを使用しています:
       address 〒100-0000 東京都千代田区1-1-1 日本
 
-    div.u-mbs.is-top.is-sm
+    p
       strong anchor タグ (リンク)<br>
       | これは
-      a(href="http://example.com/", rel="nofollow")
+      a(href=".", rel="nofollow")
         code &lt;anchor&gt;
 
-    div.u-mbs.is-top.is-sm
+    p
       strong abbr タグ<br>
       | この
       abbr(title="abbreviation") abbr
@@ -155,49 +142,49 @@ block body
       code &lt;abbr&gt;
       | タグの例です。
 
-    div.u-mbs.is-top.is-sm
+    p
       strong Acronym タグ (<em>HTML5 では非推奨</em>)<br>
       | これは <code>&lt;acronym&gt;</code> タグを使用した
       acronym(title="three-letter acronym") TLA
       | です。
 
-    div.u-mbs.is-top.is-sm
+    p
       strong Big タグ(<em>HTML5 では非推奨</em>)
       | このテストは
       big 大きな
       | 文字を表す <code>&lt;big&gt;</code> タグの例ですが、このタグは HTML5 ではサポートされていません。
 
-    div.u-mbs.is-top.is-sm
+    p
       strong Cite タグ<br>
       | "Code is poetry." --
       cite WordPress
 
-    div.u-mbs.is-top.is-sm
+    p
       strong Code タグ<br>
       code &lt;code&gt;
       |  タグはこのように使います:<br>
       code word-wrap: break-word;
 
-    div.u-mbs.is-top.is-sm
+    p
       strong Delete タグ<br>
       code &lt;del&gt;
       |  タグは
       del 打ち消し線
       | などで表現されますが、このタグは HTML5 ではサポートされていません (代わりに <code>&lt;strike&gt;</code> を使ってください)。
 
-    div.u-mbs.is-top.is-sm
+    p
       strong Emphasize タグ<br>
       code &lt;em&gt;
       |  タグは<em>文章の強調</em>に使われます。欧文では斜体になっていることがよくあります。
 
-    div.u-mbs.is-top.is-sm
+    p
       strong Insert タグ<br>
       code &lt;ins&gt;
       |  タグは
       ins 挿入されたコンテンツ
       | を意味します。
 
-    div.u-mbs.is-top.is-sm
+    p
       strong Keyboard タグ<br>
       | このあまり知られていない
       code &lt;kbd&gt;
@@ -205,7 +192,7 @@ block body
       kbd Ctrl
       |  のようにキーボードテキストをエミュレートします。通常、<code>&lt;code&gt;</code> タグと同じようにスタイリングされます。
 
-    div.u-mbs.is-top.is-sm
+    p
       strong Preformatted タグ<br>
       code &lt;pre&gt;
       |  タグは複数行のコードのスタイリングに使います。
@@ -218,24 +205,24 @@ block body
         |     and here's a line of some really, really, really, really long text, just to see how the PRE tag handles it and to find out how it overflows;
         | }
 
-    div.u-mbs.is-top.is-sm
+    p
       strong Quote タグ<br>
       q デベロッパーズ、デベロッパーズ, デベロッパーズ...
       | --スティーブ・バルマー
 
-    div.u-mbs.is-top.is-sm
+    p
       strong Strike タグ (<em>HTML5 では非推奨</em>)<br>
       | このタグは
       strike 打ち消し線
       | を表しています。
 
-    div.u-mbs.is-top.is-sm
+    p
       strong Strong タグ<br>
       | このタグは
       strong 太字
       | テキストを表しています。
 
-    div.u-mbs.is-top.is-sm
+    p
       strong Subscript タグ<br>
       | Subscript タグ
       code &lt;sub&gt;
@@ -243,7 +230,7 @@ block body
       sub 2
       | O のような表示の際に「2」が下付きになります。
 
-    div.u-mbs.is-top.is-sm
+    p
       strong Superscript タグ<br>
       |  Superscript タグ
       code &lt;sup&gt;
@@ -251,19 +238,20 @@ block body
       sup 2
       | のような表示の際に「2」が上付きになります。
 
-    div.u-mbs.is-top.is-sm
+    p
       strong Teletype タグ (<em>HTML5 では非推奨</em>)<br>
       code &lt;tt&gt;
       |  はあまり使われないタグですが、
       tt テレタイプテキスト
       |  として通常 <code>&lt;code&gt;</code> タグのようにスタイリングされます。
 
-    div.u-mbs.is-top.is-sm
+    p
       strong Variable タグ<br>
       code &lt;tt&gt;
       |  変数や引数を表す
       var variables
       |  タグです。
+
 
   div.u-mbs.is-bottom
     +c.button-social
@@ -287,11 +275,7 @@ block body
           div.u-text-right.u-mbs.is-top.is-xxs
             +a("").c-button.is-xs この執筆者の記事一覧
   hr.c-hr
-  +c.post-navs
-    ul
-      li.c-post-navs__prev: +a("#").c-button.is-sm.is-arrow-left 前の記事へ
-      li.c-post-navs__archive: +a("#").c-button.is-sm <i class="fa fa-th" aria-hidden="true"></i>記事一覧へ
-      li.c-post-navs__next: +a("#").c-button.is-sm 次の記事へ
+  +c_post_nav()
   h3 関連コンテンツ
   +c.news-lg.is-image-display
     +a("#").c-news-lg__block

--- a/app/inc/mixins/_misc.pug
+++ b/app/inc/mixins/_misc.pug
@@ -26,8 +26,9 @@ mixin loop(count)
 mixin c_post_nav()
   nav.c-post-navs
     ul
-      li.c-post-navs__prev: +a("#") 前の記事へ
-      li.c-post-navs__next: +a("#") 次の記事へ
+      li.c-post-navs__prev: +a("#").c-button.is-sm.is-arrow-left 前の記事へ
+      li.c-post-navs__archive: +a("#").c-button.is-sm <i class="fa fa-th" aria-hidden="true"></i>記事一覧へ
+      li.c-post-navs__next: +a("#").c-button.is-sm 次の記事へ
 
 //- table row
 mixin tr(th, td)

--- a/app/news/page/index.pug
+++ b/app/news/page/index.pug
@@ -30,9 +30,10 @@ block body
                     li: +a("#") #タグ
                     li: +a("#") #タグ
                     li: +a("#") #タグ
-            .l-post-content.is-twocolumns
+            .l-post-content
               +img("img-sample.jpg")
-              <div id="toc_container" class="no_bullets"><p class="toc_title">目次 <span class="toc_toggle">[<a href="#">非表示</a>]</span></p><ul class="toc_list"><li><a href="#Web"><span class="toc_number toc_depth_1">1.</span> Webマーケティングとは？</a></li><li><a href="#Web-2"><span class="toc_number toc_depth_1">2.</span> Webマーケティングのメリットとは？</a><ul><li><a href="#i"><span class="toc_number toc_depth_2">2.1</span> あらゆる方たちに配信ができる</a></li><li><a href="#i-2"><span class="toc_number toc_depth_2">2.2</span> 素早く情報を配信できる</a></li><li><a href="#i-3"><span class="toc_number toc_depth_2">2.3</span> 修正を簡単に実行できる</a></li><li><a href="#i-4"><span class="toc_number toc_depth_2">2.4</span> 少ない費用で情報を配信できる</a></li><li><a href="#i-5"><span class="toc_number toc_depth_2">2.5</span> ターゲットを細かく設定できる</a></li></ul></li></ul></div>
+              <div id="toc_container" class="no_bullets"><p class="toc_title">目次 <span class="toc_toggle">[<a href="#">非表示</a>]</span></p><ul class="toc_list"><li><a href="#Web"><span class="toc_number toc_depth_1">1</span> Webマーケティングとは？</a></li><li><a href="#Web-2"><span class="toc_number toc_depth_1">2</span> Webマーケティングのメリットとは？</a><ul><li><a href="#i"><span class="toc_number toc_depth_2">2.1</span> あらゆる方たちに配信ができる</a></li><li><a href="#i-2"><span class="toc_number toc_depth_2">2.2</span> 素早く情報を配信できる</a></li><li><a href="#i-3"><span class="toc_number toc_depth_2">2.3</span> 修正を簡単に実行できる</a></li><li><a href="#i-4"><span class="toc_number toc_depth_2">2.4</span> 少ない費用で情報を配信できる</a></li><li><a href="#i-5"><span class="toc_number toc_depth_2">2.5</span> ターゲットを細かく設定できる</a></li></ul></li></ul></div>
+
               h2 見出し弐
               p テキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキスト
               h3 見出し参
@@ -51,10 +52,10 @@ block body
 
               h2 引用 (Blockquote)
               | 一行の引用:
-              blockquote.c-blockquote 貪欲であれ、愚かであれ
+              blockquote 貪欲であれ、愚かであれ
               h2 引用 (Blockquote)
               | 引用元の参照のある複数行の引用:
-              blockquote.c-blockquote.
+              blockquote
                 | 集中という意味は集中しなくてはいけないことにイエスということだと、人は言います。しかし、それはまったく違います。そうではなく、そこにある何百ものいいアイディアにノーということなのです。慎重に選択しなくてはいけません。実際、私は成し遂げたことと同じように成し遂げられなかったことにも満足しています。革新というのは1000ものことにノーということなのです。
                 cite スティーブ・ジョブズ - 1997年 Apple 世界的開発者会議
 
@@ -63,21 +64,21 @@ block body
                 tbody
                   tr
                     th 従業員
-                    th.views 給与
+                    th 給与
                     th
-                  tr.odd
+                  tr
                     td: a(href=".") ジェーン
                     td $￥1
                     td スティーブ・ジョブズの必要な給与。
-                  tr.even
+                  tr
                     td: a(href=".") ジョン
                     td ￥10万
                     td ブログのすべて。
-                  tr.odd
+                  tr
                     td: a(href=".") ジェーン
                     td ￥1億
                     td 百聞は一見にしかず。だよね ? なのでトムは1000倍。
-                  tr.even
+                  tr
                     td: a(href=".") ジェーン
                     td ￥1000億
                     td これみたいな髪?! もういいよね…
@@ -283,11 +284,7 @@ block body
                     div.u-text-right.u-mbs.is-top.is-xxs
                       +a("").c-button.is-xs この執筆者の記事一覧
             hr.c-hr
-            +c.post-navs
-              ul
-                li.c-post-navs__prev: +a("#").c-button.is-sm.is-arrow-left 前の記事へ
-                li.c-post-navs__archive: +a("#").c-button.is-sm <i class="fa fa-th" aria-hidden="true"></i>記事一覧へ
-                li.c-post-navs__next: +a("#").c-button.is-sm 次の記事へ
+            +c_post_nav()
             h3 関連コンテンツ
             +c.news-lg.is-image-display
               +a("#").c-news-lg__block


### PR DESCRIPTION
## TOCのHTMLをWordPressの出力に合わせる
数字のあとの . の有無がHTMLとWordPressで違うので、WordPressの出力に合わせました

▼改善事項DBこちら
https://www.notion.so/growgroup/TOC-HTML-WordPress-ba9b696151914cc88aea990a4fd22245

以下、同じファイルだったのでついでに。

##  l-post-content の中にclassを使っている箇所削除
.l-post-content の中で　.c-breadcrumbsとかあったので消しました。
archive-twocolumns の方はそもそも　.l-post-content 仕様じゃなかったので変更しました。

## c-post-navsについてmiscにあるやつを読み込むように
misc.pug にもそれぞれのpage.pug にも、
それぞれの .c-post-navs が存在したので、miscにあるやつを読み込むようにしました。
