### PR TITLE
npm,webpackの動作を変更（cpxをやめてwebpackにする、scssのコンパイルの走り方をかえるなど）

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,6 @@
     "develop": "run-p server develop:*",
     "build:css": "webpack --config webpack.style.config.babel.js --mode production",
     "develop:css": "webpack --config webpack.style.config.babel.js --mode development --watch --watch-options-stdin --progress",
-    "develop:css-chokidar": "chokidar 'app/assets/**/*.scss' -c \"if [ '{event}' = 'add' ];then npm run develop:css; fi;\"",
     "build:webpack": "webpack --config webpack.config.babel.js --mode production",
     "develop:webpack": "webpack --config webpack.config.babel.js --mode development  --watch --watch-options-stdin --progress",
     "build:pug": "pug -O build/pug.js app --out dist -s",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "develop": "run-p server develop:*",
     "build:css": "webpack --config webpack.style.config.babel.js --mode production",
     "develop:css": "webpack --config webpack.style.config.babel.js --mode development --watch --watch-options-stdin --progress",
+    "develop:css-chokidar": "chokidar 'app/assets/**/*.scss' -c \"if [ '{event}' = 'add' ];then npm run develop:css; fi;\"",
     "build:webpack": "webpack --config webpack.config.babel.js --mode production",
     "develop:webpack": "webpack --config webpack.config.babel.js --mode development  --watch --watch-options-stdin --progress",
     "build:pug": "pug -O build/pug.js app --out dist -s",

--- a/webpack.config.babel.js
+++ b/webpack.config.babel.js
@@ -110,10 +110,10 @@ module.exports = (env, argv) => {
                         from: path.resolve(__dirname, 'app/assets/images'),
                         to: path.resolve(__dirname, 'dist/assets/images'),
                     },
-                    {
-                        from: path.resolve(__dirname, 'app/assets/js/scripts.js'),
-                        to: path.resolve(__dirname, 'dist/assets/js'),
-                    },
+                    // {
+                    //     from: path.resolve(__dirname, 'app/assets/js/scripts.js'),
+                    //     to: path.resolve(__dirname, 'dist/assets/js'),
+                    // },
                     // {
                     //     context: path.resolve(__dirname, "app/assets"),
                     //     from: path.resolve(__dirname, 'app/assets/**/*.pdf'),

--- a/webpack.style.config.babel.js
+++ b/webpack.style.config.babel.js
@@ -13,12 +13,12 @@ module.exports = (env, argv) => {
     const configs = {
         mode: argv.mode,
         context: __dirname + '/app/',
-        cache: {
-            type: 'filesystem',
-            buildDependencies: {
-                config: [__filename]
-            }
-        },
+        // cache: {
+        //     type: 'filesystem',
+        //     buildDependencies: {
+        //         config: [__filename]
+        //     }
+        // },
         entry: {
             style: __dirname + '/app/assets/js/style.js',
         },


### PR DESCRIPTION
### ファイルをコピーするのにcpxをつかうのをやめて、webpack-copy-pluginにする
→ cpxがかかったタイミングでなぜかnpmが固まる（？）のを回避
→ ファイル拡張子ではなく、フォルダ単位でコピーするようになったことに注意

### scripts.jsをdist内にファイルとしてコピーするのをやめる
→ app.jsでimportしてるので、scripts.jsのファイル実体は不要のため

### style.scssのコンパイルを、webpack.config.babel.jsとwebpack.style.config.babel.jsで２回行っていたのを、
　webpack.style.config.babel.jsだけにする
→ npm start 中にscssを書き換えたとき、反映が遅い問題を解決

★ただし、npm start中に追加されたscssファイルはウォッチ対象外。
package.jsonに以下を追加すると直るが、**macでしか動かないので今回のプルリクでは除外**

```
    "develop:css-chokidar": "chokidar 'app/assets/**/*.scss' -c \"if [ '{event}' = 'add' ];then npm run develop:css; fi;\"",
```
　
