### PR TITLE
assets/fonts がデフォルトで dist にコピーされるようにする

### DIFF
--- a/webpack.config.babel.js
+++ b/webpack.config.babel.js
@@ -110,6 +110,10 @@ module.exports = (env, argv) => {
                         from: path.resolve(__dirname, 'app/assets/images'),
                         to: path.resolve(__dirname, 'dist/assets/images'),
                     },
+                    {
+                        from: path.resolve(__dirname, 'app/assets/fonts'),
+                        to: path.resolve(__dirname, 'dist/assets/fonts'),
+                    },
                     // {
                     //     from: path.resolve(__dirname, 'app/assets/js/scripts.js'),
                     //     to: path.resolve(__dirname, 'dist/assets/js'),


### PR DESCRIPTION
app/assets/fonts が dist/assets/fonts にコピーされるように
webpack.config.babel.js を変更