### PR TITLE
webfont.js 廃止・fontsource でのGoogleFonts読み込みのコードに変更

### DIFF
--- a/app/assets/js/app.js
+++ b/app/assets/js/app.js
@@ -1,8 +1,13 @@
-import "@fontsource/material-icons";
-import "@fontsource/material-icons-rounded";
+//import "@fontsource/material-icons";
+//import "@fontsource/material-icons-rounded";
 import "@fontsource/material-icons-outlined";
-import "@fontsource/material-icons-sharp";
-import "@fontsource/material-icons-two-tone";
+//import "@fontsource/material-icons-sharp";
+//import "@fontsource/material-icons-two-tone";
+import "@fontsource/roboto/400.css"
+import "@fontsource/roboto/700.css"
+import "@fontsource/noto-sans-jp/400.css"
+import "@fontsource/noto-sans-jp/700.css"
+
 import Utils from './app/utils.js';
 import Accordion from './app/accordion.js';
 import Anchor from './app/anchor.js';

--- a/app/assets/scss/layout/_footer.scss
+++ b/app/assets/scss/layout/_footer.scss
@@ -46,7 +46,7 @@ category: Layout
       background-color: $font-base-color;
       &::before {
         content: "chevron_right";
-        font-family: 'Material Icons Round';
+        font-family: 'Material Icons Outlined';
         line-height: 1;
         letter-spacing: 0;
         color: $color-primary;

--- a/app/assets/scss/layout/_offer.scss
+++ b/app/assets/scss/layout/_offer.scss
@@ -52,7 +52,7 @@ category: Layout
     }
     &::after {
       content: "chevron_right";
-      font-family: 'Material Icons Round';
+      font-family: 'Material Icons Outlined';
       position: absolute;
       font-size: rem-calc(20);
       top: 50%;

--- a/app/assets/scss/layout/_post-content.scss
+++ b/app/assets/scss/layout/_post-content.scss
@@ -70,7 +70,7 @@
 
     &::before {
       content: "check";
-      font-family: 'Material Icons Round';
+      font-family: 'Material Icons Outlined';
       letter-spacing: 0;
       float: left;
       margin-right: 0.3rem;

--- a/app/assets/scss/object/components/_accordion.scss
+++ b/app/assets/scss/object/components/_accordion.scss
@@ -36,7 +36,7 @@ category: Components
     //*矢印
     &::after {
       content: "expand_less";
-      font-family: 'Material Icons Round';
+      font-family: 'Material Icons Outlined';
       color: $color-primary;
       position: absolute;
       line-height: 1;

--- a/app/assets/scss/object/components/_banners.scss
+++ b/app/assets/scss/object/components/_banners.scss
@@ -24,7 +24,7 @@ category: Banners
     // *アイコン
     &::after {
       content: "chevron_right";
-      font-family: 'Material Icons Round';
+      font-family: 'Material Icons Outlined';
       line-height: 1;
       letter-spacing: 0;
       font-size: rem-calc(36);

--- a/app/assets/scss/object/components/_blockquote.scss
+++ b/app/assets/scss/object/components/_blockquote.scss
@@ -19,7 +19,7 @@ category: Base
   }
   &::before {
     content: "format_quote";
-    font-family: 'Material Icons Round';
+    font-family: 'Material Icons Outlined';
     line-height: 1;
     letter-spacing: 0;
     font-size: rem-calc(20);

--- a/app/assets/scss/object/components/_box-archive.scss
+++ b/app/assets/scss/object/components/_box-archive.scss
@@ -39,7 +39,7 @@ category: Navigation
       }
       &::before {
         content: "chevron_right";
-        font-family: 'Material Icons Round';
+        font-family: 'Material Icons Outlined';
         line-height: 1;
         letter-spacing: 0;
         color: $color-primary;

--- a/app/assets/scss/object/components/_buttons.scss
+++ b/app/assets/scss/object/components/_buttons.scss
@@ -19,7 +19,7 @@ category: Buttons
   // *アイコン
   &::after {
     content: "chevron_right";
-    font-family: 'Material Icons Round';
+    font-family: 'Material Icons Outlined';
     line-height: 1;
     letter-spacing: 0;
     position: absolute;

--- a/app/assets/scss/object/components/_hero-block-line.scss
+++ b/app/assets/scss/object/components/_hero-block-line.scss
@@ -161,7 +161,7 @@
 
       &::after {
         content: "chevron_right";
-        font-family: 'Material Icons Round';
+        font-family: 'Material Icons Outlined';
         line-height: 1;
         letter-spacing: 0;
         color: $color-primary;

--- a/app/assets/scss/object/components/_list.scss
+++ b/app/assets/scss/object/components/_list.scss
@@ -67,7 +67,7 @@ category: Base
 
     &::before {
       content: "circle";
-      font-family: 'Material Icons Round';
+      font-family: 'Material Icons Outlined';
       font-size: rem-calc(10);
       color: $color-primary;
       position: absolute;

--- a/app/assets/scss/object/components/_menu-list.scss
+++ b/app/assets/scss/object/components/_menu-list.scss
@@ -28,7 +28,7 @@ category: Navigation
 
         &::before {
           content: "chevron_right";
-          font-family: 'Material Icons Round';
+          font-family: 'Material Icons Outlined';
           line-height: 1;
           letter-spacing: 0;
           color: $color-primary;
@@ -108,7 +108,7 @@ category: Navigation
 
     &::after {
       content: "chevron_right";
-      font-family: 'Material Icons Round';
+      font-family: 'Material Icons Outlined';
       position: absolute;
       top: 50%;
       transform: translateY(-50%);

--- a/app/assets/scss/object/components/_news-lg.scss
+++ b/app/assets/scss/object/components/_news-lg.scss
@@ -39,7 +39,7 @@ category: News
 
     &::before {
       content: "schedule";
-      font-family: 'Material Icons Round';
+      font-family: 'Material Icons Outlined';
       letter-spacing: 0;
       margin-right: rem-calc(4);
       vertical-align: top;

--- a/app/assets/scss/object/components/_pagetop.scss
+++ b/app/assets/scss/object/components/_pagetop.scss
@@ -38,7 +38,7 @@
 
     &:after {
       content: "expand_less";
-      font-family: 'Material Icons Round';
+      font-family: 'Material Icons Outlined';
     }
 
     &:hover {

--- a/app/assets/scss/object/components/_slidebar.scss
+++ b/app/assets/scss/object/components/_slidebar.scss
@@ -199,7 +199,7 @@ $slidebar-container-bg: rgba(0, 0, 0, 0.8) !default;
 
       &::before {
         content: "mail";
-        font-family: 'Material Icons Round';
+        font-family: 'Material Icons Outlined';
         line-height: 1;
         letter-spacing: 0;
         color: $color-primary;

--- a/app/assets/scss/object/components/_tabs.scss
+++ b/app/assets/scss/object/components/_tabs.scss
@@ -37,7 +37,7 @@ category: Tabs
 
         &::after {
           content: "expand_more";
-          font-family: 'Material Icons Round';
+          font-family: 'Material Icons Outlined';
           position: absolute;
           font-size: rem-calc(24);
           font-weight: 400;

--- a/app/assets/scss/object/project/_post-item.scss
+++ b/app/assets/scss/object/project/_post-item.scss
@@ -22,7 +22,7 @@
   }
   &::before {
     content: "chevron_right";
-    font-family: 'Material Icons Round';
+    font-family: 'Material Icons Outlined';
     line-height: 1;
     letter-spacing: 0;
     color: $color-primary;

--- a/app/assets/scss/object/utility/_text.scss
+++ b/app/assets/scss/object/utility/_text.scss
@@ -54,7 +54,7 @@ a{
 
     &:after {
       content: "picture_as_pdf";
-      font-family: 'Material Icons Round';
+      font-family: 'Material Icons Outlined';
       line-height: 1;
       letter-spacing: 0;
     }
@@ -66,7 +66,7 @@ a{
 
     &::before {
       content: "location_on";
-      font-family: 'Material Icons Round';
+      font-family: 'Material Icons Outlined';
       line-height: 1;
       letter-spacing: 0;
     }
@@ -76,7 +76,7 @@ a{
 
     &::after {
       content: "open_in_new";
-      font-family: 'Material Icons Round';
+      font-family: 'Material Icons Outlined';
       line-height: 1;
       letter-spacing: 0;
     }

--- a/app/inc/foundation/_head.pug
+++ b/app/inc/foundation/_head.pug
@@ -53,28 +53,6 @@ html(lang="ja")
     block head_script
       | <script src="https://cdn.polyfill.io/v2/polyfill.min.js"></script>
       | <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.6.0/jquery.min.js"></script>
-      script.
-        window.WebFontConfig = {
-          // 以下にフォントを指定する
-          custom: {
-            families: ['Noto+Sans+JP:400,700'],
-            urls: [
-              "https://fonts.googleapis.com/css2?family=Noto+Sans+JP:wght@400;700&display=swap"
-            ],
-          },
-          active: function () {
-            sessionStorage.fonts = true;
-          }
-        };
-
-        (function () {
-          var wf = document.createElement('script');
-          wf.src = 'https://ajax.googleapis.com/ajax/libs/webfont/1.6.26/webfont.js';
-          wf.type = 'text/javascript';
-          wf.async = 'true';
-          var s = document.getElementsByTagName('script')[0];
-          s.parentNode.insertBefore(wf, s);
-        })();
 
   body(class!=current.bodyClass)
     //- スマホメニュー

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,8 @@
         "@fontsource/material-icons-rounded": "^4.5.4",
         "@fontsource/material-icons-sharp": "^4.5.4",
         "@fontsource/material-icons-two-tone": "^4.5.4",
+        "@fontsource/noto-sans-jp": "^4.5.12",
+        "@fontsource/roboto": "^4.5.8",
         "animejs": "^3.2.1",
         "copy-webpack-plugin": "^11.0.0",
         "gsap": "^3.9.1",
@@ -1707,6 +1709,16 @@
       "version": "4.5.4",
       "resolved": "https://registry.npmjs.org/@fontsource/material-icons-two-tone/-/material-icons-two-tone-4.5.4.tgz",
       "integrity": "sha512-w0/v62w5GIUe9xrpiF+7uR84K2NExE9f9Z/8gluCWtFT8pbSYoiilvqCd/kAe89pQj+2I4cxsKrRMkkZrYkz7w=="
+    },
+    "node_modules/@fontsource/noto-sans-jp": {
+      "version": "4.5.12",
+      "resolved": "https://registry.npmjs.org/@fontsource/noto-sans-jp/-/noto-sans-jp-4.5.12.tgz",
+      "integrity": "sha512-tdJAUEyuyyCRD4Ot4ZE8+3uyGeSJQD/soSHr7LoltEQr22IotDDWOlqQKF7CpTaJPwt4iOBoXWtAoSN0huVW6A=="
+    },
+    "node_modules/@fontsource/roboto": {
+      "version": "4.5.8",
+      "resolved": "https://registry.npmjs.org/@fontsource/roboto/-/roboto-4.5.8.tgz",
+      "integrity": "sha512-CnD7zLItIzt86q4Sj3kZUiLcBk1dSk81qcqgMGaZe7SQ1P8hFNxhMl5AZthK1zrDM5m74VVhaOpuMGIL4gagaA=="
     },
     "node_modules/@markuplint/create-rule-helper": {
       "version": "2.3.7",
@@ -14973,6 +14985,16 @@
       "version": "4.5.4",
       "resolved": "https://registry.npmjs.org/@fontsource/material-icons-two-tone/-/material-icons-two-tone-4.5.4.tgz",
       "integrity": "sha512-w0/v62w5GIUe9xrpiF+7uR84K2NExE9f9Z/8gluCWtFT8pbSYoiilvqCd/kAe89pQj+2I4cxsKrRMkkZrYkz7w=="
+    },
+    "@fontsource/noto-sans-jp": {
+      "version": "4.5.12",
+      "resolved": "https://registry.npmjs.org/@fontsource/noto-sans-jp/-/noto-sans-jp-4.5.12.tgz",
+      "integrity": "sha512-tdJAUEyuyyCRD4Ot4ZE8+3uyGeSJQD/soSHr7LoltEQr22IotDDWOlqQKF7CpTaJPwt4iOBoXWtAoSN0huVW6A=="
+    },
+    "@fontsource/roboto": {
+      "version": "4.5.8",
+      "resolved": "https://registry.npmjs.org/@fontsource/roboto/-/roboto-4.5.8.tgz",
+      "integrity": "sha512-CnD7zLItIzt86q4Sj3kZUiLcBk1dSk81qcqgMGaZe7SQ1P8hFNxhMl5AZthK1zrDM5m74VVhaOpuMGIL4gagaA=="
     },
     "@markuplint/create-rule-helper": {
       "version": "2.3.7",

--- a/package.json
+++ b/package.json
@@ -68,6 +68,8 @@
     "@fontsource/material-icons-rounded": "^4.5.4",
     "@fontsource/material-icons-sharp": "^4.5.4",
     "@fontsource/material-icons-two-tone": "^4.5.4",
+    "@fontsource/noto-sans-jp": "^4.5.12",
+    "@fontsource/roboto": "^4.5.8",
     "animejs": "^3.2.1",
     "copy-webpack-plugin": "^11.0.0",
     "gsap": "^3.9.1",


### PR DESCRIPTION
以下の3点を行いました
- webfont.js を利用したGoogle Fonts 等のフォント読み込みのscriptタグを削除
    - _head.pug
- fontsource を用いたGoogle Fonts（とMaterial Icons）の読み込みコードを追加
    - package.json
    - app.js
- gg-styleguide内で標準で利用している Material Icons が2種あったため、1種類に変更
    - 各種scssファイル

使用方法についての説明は以下
https://www.notion.so/growgroup/Web-90cc36baf41b4ba18b9d04dc1a2311c5