### PR TITLE
body.en のときのfont-size指定の調整、robotoについてのコメント追加

### DIFF
--- a/app/assets/js/app.js
+++ b/app/assets/js/app.js
@@ -3,6 +3,7 @@
 import "@fontsource/material-icons-outlined";
 //import "@fontsource/material-icons-sharp";
 //import "@fontsource/material-icons-two-tone";
+// 英語版作成時に本文書体で利用するためrobotoの400と700はコメントアウトしないでください
 import "@fontsource/roboto/400.css"
 import "@fontsource/roboto/700.css"
 import "@fontsource/noto-sans-jp/400.css"

--- a/app/assets/scss/foundation/_normalize.scss
+++ b/app/assets/scss/foundation/_normalize.scss
@@ -46,17 +46,7 @@ body {
     font-size: $font-base-size-en;
 
     @include breakpoint(small only) {
-      font-size: rem-calc(13);
-    }
-
-    small,
-    .u-text-small {
-      font-size: rem-calc(13);
-      line-height: 22.75/13*1;
-
-      @include breakpoint(small only) {
-        font-size: rem-calc(12);
-      }
+      font-size: $font-base-size-en*0.875;
     }
   }
 }

--- a/app/assets/scss/foundation/_settings.scss
+++ b/app/assets/scss/foundation/_settings.scss
@@ -52,7 +52,7 @@ $font-base-style: normal !default; // フォントスタイル
 
 //en
 $font-base-size-en: 15px !default; // body.en のフォントサイズ
-$font-base-line-height-en: 28/15*1 !default; // body.en のフォントサイズ
+$font-base-line-height-en: 1.8 !default; // body.en のフォントサイズ
 $font-base-letter-spacing-en: 0 !default; // body.en のフォントサイズ
 
 $font-heading-sizes: (// 見出しのフォントサイズ

--- a/app/assets/scss/object/utility/_text.scss
+++ b/app/assets/scss/object/utility/_text.scss
@@ -19,6 +19,12 @@ small,
 .u-text-small {
   font-size: 0.85em;
 }
+body.en{
+  //small,
+  //.u-text-small {
+  //  font-size: 0.85em;
+  //}
+}
 
 // テキスト - 強調
 //


### PR DESCRIPTION
[body.en を追加したコミット](https://github.com/growgroup/gg-styleguide/commit/95b559a533700a9aa147b79e2b380756d7673b4e)の内容に対して以下を行いました。

## body.en のときの フォントサイズについて調整
npm start 時に以下の警告が出ていたのと、
`Deprecation Using / for division outside of calc() is deprecated and will be removed in Dart Sass 2.0.0.`

もとの値（font-size: 0.85em;）から変更していなければ英語版で指定しなくても良い気がしたので、
削除して、_text.scssの方に必要に応じて指定するのが伝わるといいな…というお気持ちのコメントアウトを作成

スマホのときのフォントサイズもとりあえず日本語と同じ指定方法にとりあえず統一。

line-heightの指定も日本語の方と同様に計算式ではなくて数値で指定に統一。

## roboto についてのコメント追加
案件で使わないfontはapp.jsからコメントアウトする想定だが、
robotoは消してほしくないのでそれがわかるようにコメントを追加