### PR TITLE
$font-base-letter-spacing が各要素に正しく（見かけ上正しく）効くようにする

### DIFF
--- a/app/assets/scss/foundation/_mixin.scss
+++ b/app/assets/scss/foundation/_mixin.scss
@@ -495,11 +495,15 @@
   align-items: $align-items;
 }
 
-@mixin font-format($size : $font-base-size,$letter: $font-base-letter-spacing,$height: 24,$weight: $font-base-weight){
+@mixin font-format($size : $font-base-size,$letter:null,$height: 24,$weight:null){
   font-size: rem-calc($size);
-  letter-spacing: $letter + em;
   line-height: math.div($height, $size) * 1;
-  font-weight: $weight;
+  @if ($letter){//line-heightはnullにするとCSS出力をスキップします
+    letter-spacing: $letter + em;
+  }
+  @if ($weight){//font-weightはnullもしくは記載しないとCSS出力をスキップします
+    font-weight: $weight;
+  }
 }
 
 @mixin font-format-light($size : $font-base-size,$height: 24){

--- a/app/assets/scss/foundation/_normalize.scss
+++ b/app/assets/scss/foundation/_normalize.scss
@@ -6,6 +6,16 @@
  *    without disabling user zoom.
  */
 
+// # CSS 変数の定義
+:root{
+  --letter-spacing:#{$font-base-letter-spacing};
+
+  //スマホのとき値を変更したい場合は以下に
+  @include breakpoint(small down){
+  }
+}
+
+
 html {
   font-size: $font-base-size;
   font-family: $font-base-family;
@@ -17,6 +27,7 @@ html {
   -webkit-box-sizing: border-box;
   -moz-box-sizing: border-box;
   box-sizing: border-box;
+  letter-spacing: var(--letter-spacing);//全要素へ基準のletter-spacingを当てる
 }
 
 /**
@@ -27,7 +38,7 @@ body {
   color: $font-base-color;
   margin: 0;
   line-height: $font-base-line-height;
-  letter-spacing: $font-base-letter-spacing;
+  //letter-spacing: $font-base-letter-spacing;
   font-size: $font-base-size;
   font-feature-settings: 'liga';
   -webkit-font-smoothing: antialiased;

--- a/app/assets/scss/object/components/_breadcrumb.scss
+++ b/app/assets/scss/object/components/_breadcrumb.scss
@@ -15,7 +15,7 @@
     }
 
     span {
-      @include font-format(12,.05,19);
+      @include font-format-light(12,19);
 
       &.is-arrow {
         margin:0 rem-calc(8);
@@ -28,7 +28,7 @@
       }
 
       a {
-        @include font-format(12,.05,19);
+        @include font-format-light(12,19);
       }
     }
   }

--- a/app/assets/scss/object/components/_heading.scss
+++ b/app/assets/scss/object/components/_heading.scss
@@ -30,7 +30,7 @@ category: Heading
     &.is-eng {
       display: block;
       @include webfont();
-      @include font-format(42, 0.1, 52, 700);
+      @include font-format(42, 0.1, 52);
       @include breakpoint(small only) {
         font-size: rem-calc(42)*0.8;
       }
@@ -41,7 +41,7 @@ category: Heading
 
     &.is-ja {
       display: block;
-      @include font-format(16, .1, 26, 700);
+      @include font-format-light(16, 26);
       @include breakpoint(small only) {
         font-size: rem-calc(16)*0.8;
       }
@@ -52,7 +52,7 @@ category: Heading
 // h2
 .c-heading.is-lg {
   color: $color-primary;
-  @include font-format(32, .1, 40, bold);
+  @include font-format-light(32,40);
   margin-bottom: rem-calc(24);
   @include breakpoint(small only) {
     font-size: rem-calc(32)*0.8;
@@ -71,7 +71,7 @@ category: Heading
     &.is-ja {
       display: block;
       @include webfont();
-      @include font-format(14, .1, 20, normal);
+      @include font-format(14,null,20,normal);//line-heightはnullにするとCSS出力をスキップします
       margin-top: rem-calc(6);
       @include breakpoint(small only) {
         font-size: rem-calc(14)*0.8;
@@ -82,7 +82,7 @@ category: Heading
 
 // h3
 .c-heading.is-md {
-  @include font-format(28, .1, 38, 700);
+  @include font-format-light(28,38);
   margin-bottom: rem-calc(20);
   @include breakpoint(small only) {
     font-size: rem-calc(28)*0.8;
@@ -92,7 +92,7 @@ category: Heading
 
 // h4
 .c-heading.is-sm {
-  @include font-format(24, .1, 34, 700);
+  @include font-format-light(24, 34);
   @include breakpoint(small only) {
     font-size: rem-calc(24)*0.8;
   }
@@ -100,7 +100,7 @@ category: Heading
 
 // h5
 .c-heading.is-xs {
-  @include font-format(20, .1, 30, 700);
+  @include font-format-light(20,30);
   margin-bottom: rem-calc(16);
   @include breakpoint(small only) {
     font-size: rem-calc(20)*0.8;
@@ -110,7 +110,7 @@ category: Heading
 
 // h6
 .c-heading.is-xxs {
-  @include font-format(18, .1, 28, 700);
+  @include font-format-light(18, 28);
   margin-bottom: rem-calc(6);
   @include breakpoint(small only) {
     font-size: rem-calc(18)*0.8;

--- a/app/assets/scss/object/components/_label.scss
+++ b/app/assets/scss/object/components/_label.scss
@@ -7,7 +7,8 @@
   min-width: rem-calc(116);
   padding: rem-calc(1) rem-calc(8);
   border: 1px solid $color-primary;
-  @include font-format(14,0.05,20,700);
+  @include font-format-light(14,20);
+  font-weight: 700;
 
   @include breakpoint(small only) {
     font-size: rem-calc(13);

--- a/app/assets/scss/object/components/_pagination.scss
+++ b/app/assets/scss/object/components/_pagination.scss
@@ -29,8 +29,7 @@ category: Navigation
   ul li > span,
   ul li > a {
     @include webfont();
-    @include font-format(16,13);
-    font-weight: bold;
+    @include font-format(16,null,13,bold);
     display: flex;
     justify-content: center;
     align-items: center;

--- a/app/assets/scss/object/components/_pagination.scss
+++ b/app/assets/scss/object/components/_pagination.scss
@@ -29,7 +29,8 @@ category: Navigation
   ul li > span,
   ul li > a {
     @include webfont();
-    @include font-format(16,0.05,13,700);
+    @include font-format(16,13);
+    font-weight: bold;
     display: flex;
     justify-content: center;
     align-items: center;


### PR DESCRIPTION
以下を行いました。
- $font-base-letter-spacing をCSS変数に入れて各要素に効くようにする
- font-formatでもletter-spacingを省けるように

# $font-base-letter-spacing をCSS変数に入れて各要素に効くようにする

### 基本の設定は以下のような感じ
```
:root{
   --spacing:0.05em;/*実際には $font-base-letter-spacing が入る*/
}
*{
   letter-spacing: var(--spacing);
}
```
これで、font-size 変更するたびに letter-spacingを指定する必要はなくなる。


参考：https://deep-space.blue/web/2240

### 特定の要素内で全体的にletter-spacingを変更したい場合
```
.hoge{
   --spacing:0.1em;
}
```
これで、.hoge も .hoge .fuga も全部letter-spacing:0.1em になる。

### 特定の要素だけletter-spacingを変更したい場合
```
.fuga{
   letter-spacing:0.1em;
}
```
これの場合 .fuga は letter-spacing:0.1em、
.fuga .piyo はletter-spacing:0.05emという感じになる（はず）

# font-formatでもletter-spacingを省けるように
font-formatでもletter-spacingを省けるようにしました。

### 説明
SCSS
```
 @include font-format(14,null,20,normal);
```

CSS
```
  font-size: 0.875rem;
  line-height: 1.4285714286;
  font-weight: normal;
```

ついでに以下も実施。

SCSS
```
 @include font-format(14,null,20);
```

CSS
```
  font-size: 0.875rem;
  line-height: 1.4285714286;
```
