### PR TITLE
filesディレクトリの追加とdistへのコピー設定

### DIFF
--- a/webpack.config.babel.js
+++ b/webpack.config.babel.js
@@ -111,9 +111,14 @@ module.exports = (env, argv) => {
                         to: path.resolve(__dirname, 'dist/assets/images'),
                     },
                     {
+                        from: path.resolve(__dirname, 'app/assets/files'),
+                        to: path.resolve(__dirname, 'dist/assets/files'),
+                    },
+                    {
                         from: path.resolve(__dirname, 'app/assets/fonts'),
                         to: path.resolve(__dirname, 'dist/assets/fonts'),
                     },
+                    //その他設定追加したい場合は以下を参考に
                     // {
                     //     from: path.resolve(__dirname, 'app/assets/js/scripts.js'),
                     //     to: path.resolve(__dirname, 'dist/assets/js'),


### PR DESCRIPTION
PDFやMP4などimagesに入れないようなファイルを入れるためのディレクトリの準備をしました。

- app/assets/files ディレクトリを新規作成
- webpack.config.babel.jsへ「appからdistにコピーする」の設定追記


