### PR TITLE
.js-accordionが、アコーディオンinアコーディオンに耐えられる用に調整

### DIFF
--- a/app/assets/js/app/accordion.js
+++ b/app/assets/js/app/accordion.js
@@ -69,8 +69,8 @@ export default class Accordion {
         return false;
       }
 
-      target.title = target.find('*[' + this.options.titleTargetAttr + ']');
-      target.content = target.find('*[' + this.options.contentTargetAttr + ']');
+      target.title = target.find('*[' + this.options.titleTargetAttr + ']').eq(0);
+      target.content = target.find('*[' + this.options.contentTargetAttr + ']').eq(0);
       this.accordion(target);
       if (this.options.defaultOpen) {
         target.content.slideDown();


### PR DESCRIPTION
## 元の処理
もともとの処理だとfind()で.js-accordion内のすべての「data-accordion-content」がついている要素を
target.content として判定し
アコーディオンを入れ子にすると内側のアコーディオンも連動して動いてしまっていた

```
target.title = target.find('*[' + this.options.titleTargetAttr + ']');
target.content = target.find('*[' + this.options.contentTargetAttr + ']');
```

## 変更したこと
`eq(0)` を使い、find() でとってきた要素の1番目だけを変数に入れるように変更。

```
target.title = target.find('*[' + this.options.titleTargetAttr + ']').eq(0);
target.content = target.find('*[' + this.options.contentTargetAttr + ']').eq(0);
```

これで仮に以下のような構造になっていても、
.js-accordionごとに最初に出てくるdata-accordion-contentだけが展開するようになる

```
    +e.block.js-accordion
      +e.head(data-accordion-title="accordion-title")
      +e.content(data-accordion-content="accordion--text")
        +e.block.js-accordion
          +e.head(data-accordion-title="accordion-title")
          +e.content(data-accordion-content="accordion--text")
```

