### PR TITLE
サイト内検索フォームのコンポーネント全体的に変更、slidebarの孫階層追加とCSS整理

### DIFF
--- a/app/assets/js/app/custom.js
+++ b/app/assets/js/app/custom.js
@@ -13,7 +13,7 @@ export default class CustomFunctions {
    * 実行する
    */
   init() {
-    this.formModal();
+    this.searchFormModal();
   }
 
   /**
@@ -21,25 +21,35 @@ export default class CustomFunctions {
    */
 
   // headerのフォーム
-  formModal() {
-    const triggerbtn = $(".js-header-form");
-    const closebtn = $(".c-block-modal-form__close");
+  searchFormModal() {
+    const triggerbtnName = ".js-header-searchform-open";
+    const contentName = ".js-header-searchform-content";
+    // const closebtnName = ".js-header-searchform-close";
+    const $triggerbtn = $(triggerbtnName);
+    const $content = $(contentName);
+    // const $closebtn = $(closebtnName);
 
-    triggerbtn.click(function (e) {
-      $("body").toggleClass("is-search-modal-open");
-      $(triggerbtn).toggleClass("is-active");
-    })
-
-    closebtn.click(function (e) {
-      $("body").toggleClass("is-search-modal-open");
-      $(triggerbtn).toggleClass("is-active");
-    })
-
-
-    $(".c-block-modal-form__bg").click(function (e) {
-      $("body").toggleClass("is-search-modal-open");
-      $(triggerbtn).toggleClass("is-active");
-    })
+    $triggerbtn.click(function (e) {
+      //トリガーボタンを押したときの動作
+      if($("body").hasClass('is-search-modal-open')){
+        $("body").removeClass("is-search-modal-open");
+        $triggerbtn.removeClass("is-active");
+      }else{
+        $("body").addClass("is-search-modal-open");
+        $triggerbtn.addClass("is-active");
+      }
+    });
+    $(document).on('click', function(e) {
+      //bodyに.is-search-modal-openがついているときに、
+      //検索フォーム本体でもトリガーボタンでも無い要素が押されたら
+      if(!$(e.target).closest(contentName).length && !$(e.target).closest(triggerbtnName).length){
+        if($("body").hasClass('is-search-modal-open')){
+          //bodyの.is-search-modal-openと、トリガーボタンの.is-activeを外す
+          $("body").removeClass("is-search-modal-open");
+          $triggerbtn.removeClass("is-active");
+        }
+      }
+    });
   }
 
   // ループスライダー

--- a/app/assets/scss/layout/_searchform.scss
+++ b/app/assets/scss/layout/_searchform.scss
@@ -1,0 +1,146 @@
+.l-searchform {
+  position: fixed;
+  top: rem-calc(80);
+  left: 0;
+  width: 100%;
+  z-index: 99999;
+  visibility: hidden;
+  opacity: 0;
+  transition: all 0.2s ease;
+  padding: rem-calc(90) 0;
+
+  @include breakpoint(medium down) {
+    top: rem-calc(55);
+  }
+  @include breakpoint(small down) {
+    padding: rem-calc(60) 0;
+  }
+
+  &__inner {
+    width: 100%;
+    max-width: rem-calc(748);
+    position: relative;
+    margin: auto;
+  }
+
+  &__overlay {
+    position: absolute;
+    background: rgba($font-base-color, .9);
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+  }
+
+  &__close {
+    position: absolute;
+    right: rem-calc(-66);
+    top: rem-calc(-66);
+    color: $color-white;
+    background: transparent;
+    border: none;
+    padding: 0;
+    @include breakpoint(medium down) {
+      right: rem-calc(-4);
+      top: rem-calc(-48);
+    }
+    &:hover {
+      opacity: 0.5;
+    }
+    &__icon {
+      font-size: rem-calc(48);
+    }
+  }
+
+
+
+  //検索フォーム本体部分
+  &__form{
+    display: flex;
+    align-items: center;
+    height: rem-calc(72);
+    width: 100%;
+    max-width: rem-calc(748);
+    margin: auto;
+    position: relative;
+    background: $color-white;
+
+    @include breakpoint(small only) {
+      height: rem-calc(46);
+    }
+
+    &__icon {
+      color: $font-base-color;
+      line-height: 1;
+      letter-spacing: 0;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      padding: rem-calc(20);
+
+      span{
+        font-size: rem-calc(30);
+      }
+
+      @include breakpoint(small only) {
+        padding: rem-calc(10);
+        span{
+          font-size: rem-calc(20);
+        }
+      }
+    }
+
+    input {
+      border: none;
+      border-left: solid 1px $border-base-color;
+      font-family: inherit;
+      position: relative;
+      height: rem-calc(40);
+      padding-left: rem-calc(22);
+      line-height: 1;
+      @include breakpoint(small only) {
+        height: rem-calc(22);
+        padding-top: 0;
+        padding-bottom: rem-calc(4);
+      }
+
+      &::placeholder {
+        line-height: 1;
+        color: $color-gray;
+        @include breakpoint(small only) {
+          font-size: rem-calc(11);
+        }
+      }
+    }
+
+    button {
+      width: rem-calc(130);
+      flex-shrink: 0;
+      background: $color-primary;
+      border: none;
+      padding: 0;
+      color: $color-white;
+      font-size: rem-calc(16);
+      font-weight: bold;
+      height: 100%;
+      transition: all 0.2s ease-out;
+
+      @include breakpoint(small only) {
+        width: rem-calc(78);
+        font-size: rem-calc(12);
+      }
+
+      &:hover {
+        opacity: 0.5;
+      }
+    }
+  }
+
+}
+
+body.is-search-modal-open {
+  .l-searchform {
+    visibility: visible;
+    opacity: 1;
+  }
+}

--- a/app/assets/scss/object/components/_slidebar.scss
+++ b/app/assets/scss/object/components/_slidebar.scss
@@ -4,9 +4,10 @@
 // Styleguide 4.5
 
 $slidebar-menu-bg: $color-primary !default;
-$slidebar-menu-width: 75% !default;
+$slidebar-menu-width: 100% !default;
 $slidebar-menu-eaasing: all ease-in-out .2s !default;
 $slidebar-container-bg: rgba(0, 0, 0, 0.8) !default;
+$slidebar-header-height: 55 !default; // スマホ時のヘッダーの高さ
 
 @include breakpoint(large up) {
   .c-slidebar-button {
@@ -34,8 +35,8 @@ $slidebar-container-bg: rgba(0, 0, 0, 0.8) !default;
     background-color: $color-primary;
     line-height: 1;
     color: $color-white;
-    width: rem-calc(55);
-    height: rem-calc(55);
+    width: rem-calc($slidebar-header-height);
+    height: rem-calc($slidebar-header-height);
     padding-top: rem-calc(6);
     border: none;
 
@@ -83,162 +84,208 @@ $slidebar-container-bg: rgba(0, 0, 0, 0.8) !default;
     }
   }
 
+
+  //***********************************************
   // メニュー自体
+  //***********************************************
   .c-slidebar-menu {
-    height: calc(100vh - 55px);
+    height: calc(100vh - #{$slidebar-header-height}px);
     padding: 0 0 rem-calc(104);
     position: fixed;
-    background-color: $color-primary;
+    background-color: $slidebar-menu-bg;
     z-index: 9980;
     width: $slidebar-menu-width;
     transform: translate3d(100%, 0px, 0px);
     right: 0;
-    -webkit-transition: $slidebar-menu-eaasing;
     transition: $slidebar-menu-eaasing;
     overflow-x: scroll;
     top: 0;
     -webkit-overflow-scrolling: touch;
 
     &.is-active {
-      height: calc(100% - 65px);
+      height: calc(100% - 60px);
     }
 
     // 上から下へ
     &.is-top-to-bottom {
       transform: translate3d(0px, -100%, 0px);
+      //transform: translate3d(0, 0, 0); // 表示デバッグ時
       width: 100%;
-      opacity: 0;
+      opacity: 0; // 表示デバッグ時は1
     }
 
-
-    // メニュー要素（通常）
-    &__list{
+    // メニュー要素（一番外・全体で共通する設定）
+    &__list {
       width: 100%;
       background: $color-primary;
-      li {
-        border-bottom: 1px solid $border-base-color;
-      }
-      a,
-      span {
-        font-size: rem-calc(15);
+      font-size: rem-calc(14);
+      font-weight: 700;
+
+      a, span {
         display: block;
-        padding: rem-calc(14) rem-calc(16);
+        color: inherit;
+        font-weight: inherit;
         text-decoration: none;
-        color: $color-white;
-        font-weight: 400;
-      }
-    }
-
-    // メニュー要素（子）
-    &__children {
-      width: 100%;
-      padding: 0 rem-calc(16);
-      display: none;
-      background-color: $color-primary;
-
-      li {
-        &:last-child {
-          border-bottom: none;
-        }
-
-        a {
-          color: $color-white;
-          padding: rem-calc(16) 0;
-          &::before,
-          &::after {
-            display: none;
-          }
-        }
-      }
-    }
-
-    // メニュー要素（親）
-    &__parent {
-      a,
-      span {
         position: relative;
+      }
 
+      [data-accordion-title] {
         &::after,
         &::before {
           content: "";
           display: block;
-          width: rem-calc(2);
-          height: rem-calc(18);
-          background-color: $color-white;
+          width: rem-calc(1);
+          height: rem-calc(13);
+          background-color: currentColor;
           position: absolute;
           top: 50%;
-          right: rem-calc(24);
+          right: rem-calc(26);
           transform: translateY(-50%);
         }
 
         &::after {
-          width: rem-calc(18);
-          height: rem-calc(2);
-          right: rem-calc(16);
+          width: rem-calc(13);
+          height: rem-calc(1);
+          right: rem-calc(20);
         }
       }
+    }
 
-      &.is-open {
-        a,
-        span {
-          &::before {
-            display: none;
+    &__parent { //親li
+      color: $color-white;
+      border-bottom: solid 1px rgba(255,255,255,0.4);
+      &.is-open{
+        //background: $color-white;
+        //color: $color-primary;
+        & > [data-accordion-title]{
+          &::before{
+            content: none;
           }
         }
       }
     }
 
+    &__parent-link { //親a, span
+      cursor: pointer;
+      padding:rem-calc(18) rem-calc(46) rem-calc(18) rem-calc(20);
+    }
 
+    // メニュー要素（子）
+    &__children {
+      font-size: rem-calc(13);
+      width: 100%;
+      padding-left: rem-calc(20);
+      padding-bottom: rem-calc(20);
+      display: none;
+    }
 
-    &__button {
-      margin-top: rem-calc(32);
-      max-width: 100%;
-      background-color: $color-white;
-      color: $color-primary;
-      font-size: rem-calc(16);
+    &__child { //子li
+      //color: $color-white;
+      background: rgba(0,0,0,0.2);
+      margin-bottom: rem-calc(4);
 
-      &::before {
-        content: "mail";
-        font-family: 'Material Icons Outlined';
-        line-height: 1;
-        letter-spacing: 0;
-        color: $color-primary;
-        vertical-align: sub;
-        font-size: rem-calc(18);
-        margin-right: rem-calc(12);
+      &.is-open{
+        //color: $color-primary;
+        & > [data-accordion-title]{
+          &::before{
+            content: none;
+          }
+        }
       }
+
+      >[data-accordion-title] {
+        &::before {
+          height: rem-calc(10);
+          right: rem-calc(24.5);
+        }
+        &::after {
+          width: rem-calc(10);
+        }
+      }
+    }
+
+    &__child-link { //子a, span
+      padding:rem-calc(13) rem-calc(48) rem-calc(13) rem-calc(20);
+    }
+
+    // メニュー要素（孫）
+    &__grandchildren {
+      font-size: rem-calc(12);
+      font-weight: 400;
+      width: 100%;
+      display: none;
+      border-top: solid 1px $border-base-color;
+      padding-left: rem-calc(26);
+    }
+
+    &__grandchild { //孫li
+      //color: $color-white;
+      border-top: solid 1px $border-base-color;
+      &:first-child{
+        border-top: 0;
+      }
+    }
+
+    &__grandchild-link { //孫a, span
+      padding:rem-calc(12) rem-calc(40) rem-calc(12) rem-calc(0);
+    }
+
+    //大きいボタン（お問い合わせなど）
+    &__buttons{
+      margin-top: rem-calc(20);
+      padding:0 rem-calc(20);
+    }
+    &__button + &__button{
+      margin-top: rem-calc(8);
+    }
+    &__button {
+      max-width: 100%;
+      font-weight: bold;
+      font-size: rem-calc(18);
+      color: $color-primary;
+      background-color: $color-white;
+      padding:rem-calc(24);
+      text-align: center;
 
       &::after {
         content: none;
       }
+      &__icon {
+        display: inline;
+        vertical-align: rem-calc(-6);
+        line-height: 1;
+        font-size: rem-calc(24);
+        margin-right: rem-calc(8);
+      }
     }
 
+    //SNSボタンなど小さいボタン
     &__sns-btns {
       max-width: 100%;
-      margin-top: rem-calc(40);
+      margin-top: rem-calc(24);
       display: flex;
       justify-content: center;
+      line-height: 1;
     }
 
     &__sns-btn {
+      background: $color-white;
+      color: $color-primary;
+      text-decoration: none;
+      //font-size: rem-calc(24);
+      margin: 0 rem-calc(8);
+      width: rem-calc(44);
+      height: rem-calc(44);
+      border-radius: rem-calc(44);
       display: flex;
       align-items: center;
       justify-content: center;
-      width: rem-calc(44);
-      height: rem-calc(44);
-      background-color: $color-white;
-      border-radius: 1000px;
-      font-size: rem-calc(20);
-      margin: 0 rem-calc(10);
-      text-decoration: none;
     }
   }
 
   // メニュー以外をラップする要素
-  // メニュー以外をラップする要素
   .c-slidebar-container {
     height: 100%;
-    -webkit-transition: $slidebar-menu-eaasing;
     transition: $slidebar-menu-eaasing;
 
     &::after {
@@ -250,7 +297,6 @@ $slidebar-container-bg: rgba(0, 0, 0, 0.8) !default;
       top: 0;
       left: 0;
       opacity: 0;
-      -webkit-transition: $slidebar-menu-eaasing;
       transition: $slidebar-menu-eaasing;
       display: none;
       z-index: 999;
@@ -277,21 +323,9 @@ $slidebar-container-bg: rgba(0, 0, 0, 0.8) !default;
           }
         }
       }
-
-      &__text {
-        &.is-close {
-          display: block;
-          margin-top: rem-calc(8);
-        }
-
-        &.is-open {
-          display: none;
-        }
-      }
     }
 
     .c-slidebar-container {
-      -webkit-transform: translateX(-$slidebar-menu-width);
       transform: translate3d(-$slidebar-menu-width, 0px, 0px);
 
       &::after {
@@ -308,24 +342,68 @@ $slidebar-container-bg: rgba(0, 0, 0, 0.8) !default;
 
       // 上から下の場合
       &.is-top-to-bottom {
-        -webkit-transform: translateX(0px);
         transform: translate3d(0px, 0px, 0px);
 
         &::after {
-          top: 55px;
+          top: #{$slidebar-header-height}px;
         }
       }
     }
 
     .c-slidebar-menu {
-      -webkit-transform: translateX(0);
       transform: translate3d(0, 0, 0);
 
       &.is-top-to-bottom {
-        -webkit-transform: translateY(55px);
-        transform: translate3d(0, 55px, 0);
+        transform: translate3d(0, #{$slidebar-header-height}px, 0);
         opacity: 1;
       }
     }
   }
+
+  .c-slidebar-menu {
+    &__search {
+      //border: 1px solid $border-base-color;
+      //color: $font-base-color;
+      position: relative;
+      display: block;
+      margin-bottom: rem-calc(22);
+      max-width: 100%;
+      width: 100%;
+      border: 1px solid $color-primary;
+      color: $color-gray;
+      background: $color-white;
+      border-radius: rem-calc(23);
+      font-size: rem-calc(16);
+      letter-spacing: 0.1em;
+      line-height: 1.5;
+      font-weight: 400;
+      height: rem-calc(46);
+      transition: all 0.2s ease-out;
+
+      &:before {
+        position: absolute;
+        left: rem-calc(18);
+        top: 50%;
+        transform: translateY(-50%);
+        line-height: 1;
+        background-repeat: no-repeat;
+        background-position: center center;
+        background-size: cover;
+        font-family: "Material Icons Outlined";
+        content: "search";
+        font-feature-settings: "liga";
+        font-size: rem-calc(18);
+        color: $color-primary;
+      }
+
+      &:hover,
+      &.is-active {
+      }
+    }
+
+    &__search-icon {
+      display: none;
+    }
+  }
+
 }

--- a/app/inc/layout/_header.pug
+++ b/app/inc/layout/_header.pug
@@ -40,17 +40,8 @@ header(class=className)
                   +a("/blocks/").l-header__submenu__block
                     .l-header__submenu__image: +img("img-sample-sm.jpg", "ブロック編集ページ")
                     span ブロック編集ページ
-    button.l-header__search.js-header-form.u-hidden-md キーワードから検索
-    button.l-header__search-icon.js-header-form.u-visible-md <span class="material-icons-outlined">search</span>
+    button.l-header__search.js-header-searchform-open.u-hidden-md キーワードから検索
+    button.l-header__search-icon.js-header-searchform-open.u-visible-md <span class="material-icons-outlined">search</span>
     +a("/contact/").l-header__button.c-button.is-sm <span class="material-icons-outlined">mail</span>お問い合わせ
 
-
-+c.block-modal-form
-  .l-container
-    +e.bg
-    +e.inner
-      +e("button").close
-      +e("form").form(action="/result/", method="get")
-        span.is-icon <span class="material-icons-outlined">search</span>
-        input(type="text", placeholder="キーワードから検索")
-        button 検索する
++l_searchform

--- a/app/inc/mixins/_mixins.pug
+++ b/app/inc/mixins/_mixins.pug
@@ -14,4 +14,5 @@ include /inc/mixins/_cssrules.pug
 include /inc/layout/_aside.pug
 include /inc/mixins/_loader.pug
 include /inc/mixins/_pagination.pug
+include /inc/mixins/_searchform.pug
 

--- a/app/inc/mixins/_searchform.pug
+++ b/app/inc/mixins/_searchform.pug
@@ -1,0 +1,13 @@
+//- ヘッダーのサイト内検索フォーム部分
+mixin l_searchform
+  .l-searchform
+    .l-searchform__overlay
+    .l-container
+      .l-searchform__inner
+        button.l-searchform__close.js-header-searchform-close
+          span.material-icons-outlined.l-searchform__close__icon close
+        form.l-searchform__form.js-header-searchform-content
+          label.l-searchform__form__label(for="searchform")
+            span.material-icons-outlined.l-searchform__form__icon(aria-label="キーワードから検索") search
+          input(type="text", placeholder="キーワードから検索")#searchform
+          button 検索する

--- a/app/inc/mixins/_slidebar.pug
+++ b/app/inc/mixins/_slidebar.pug
@@ -9,21 +9,83 @@ mixin c_slidebar
         span
       span.c-slidebar-button__text.is-open MENU
       span.c-slidebar-button__text.is-close CLOSE
+
+
   .c-slidebar-menu.js-slidebar-menu.is-top-to-bottom
     ul.c-slidebar-menu__list
-      li: +a("#") メニュー1
-      li: +a("#") メニュー2
       li.c-slidebar-menu__parent.js-accordion
-        span(data-accordion-title="menu-title") メニュー3
-        ul.c-slidebar-menu__children(data-accordion-content="menu-text")
-          li: +a("#") メニュー3-1
-          li: +a("#") メニュー3-2
-          li: +a("#") メニュー3-3
-      li: +a("#") メニュー4
-      li: +a("#") メニュー5
-      li: +a("#") メニュー6
+        span.c-slidebar-menu__parent-link(data-accordion-title='menu-title') メニュー レベル1
+        //子ページ
+        ul.c-slidebar-menu__children(data-accordion-content='menu-content')
+          li.c-slidebar-menu__child.js-accordion
+            span.c-slidebar-menu__child-link(data-accordion-title='menu-title') メニュー レベル2
+            //孫ページ
+            ul.c-slidebar-menu__grandchildren(data-accordion-content='menu-content')
+              li.c-slidebar-menu__grandchild
+                +a("#").c-slidebar-menu__grandchild-link メニュー レベル3
+              li.c-slidebar-menu__grandchild
+                +a("#").c-slidebar-menu__grandchild-link メニュー レベル3
+          li.c-slidebar-menu__child.js-accordion
+            span.c-slidebar-menu__child-link(data-accordion-title='menu-title') メニュー レベル2
+            //孫ページ
+            ul.c-slidebar-menu__grandchildren(data-accordion-content='menu-content')
+              li.c-slidebar-menu__grandchild
+                +a("#").c-slidebar-menu__grandchild-link メニュー レベル3
+              li.c-slidebar-menu__grandchild
+                +a("#").c-slidebar-menu__grandchild-link メニュー レベル3
+          li.c-slidebar-menu__child
+            +a("#").c-slidebar-menu__child-link メニュー レベル2
+          li.c-slidebar-menu__child
+            +a("#").c-slidebar-menu__child-link メニュー レベル2
+        //子ページ
+        ul.c-slidebar-menu__children(data-accordion-content='menu-content')
+          li.c-slidebar-menu__child.js-accordion
+            +a("#").c-slidebar-menu__child-link メニュー レベル2
+          li.c-slidebar-menu__child
+            +a("#").c-slidebar-menu__child-link メニュー レベル2
+          li.c-slidebar-menu__child
+            +a("#").c-slidebar-menu__child-link メニュー レベル2
+      li.c-slidebar-menu__parent.js-accordion
+        span.c-slidebar-menu__parent-link(data-accordion-title='menu-title') メニュー レベル1
+        ul.c-slidebar-menu__children(data-accordion-content='menu-content')
+          li.c-slidebar-menu__child.js-accordion
+            span.c-slidebar-menu__child-link(data-accordion-title='menu-title') メニュー レベル2
+            ul.c-slidebar-menu__grandchildren(data-accordion-content='menu-content')
+              li.c-slidebar-menu__grandchild
+                +a("#").c-slidebar-menu__grandchild-link メニュー レベル3
+              li.c-slidebar-menu__grandchild
+                +a("#").c-slidebar-menu__grandchild-link メニュー レベル3
+          li.c-slidebar-menu__child
+            +a("#").c-slidebar-menu__child-link メニュー レベル2
+          li.c-slidebar-menu__child
+            +a("#").c-slidebar-menu__child-link メニュー レベル2
+        ul.c-slidebar-menu__children(data-accordion-content='menu-content')
+          li.c-slidebar-menu__child.js-accordion
+            span.c-slidebar-menu__child-link(data-accordion-title='menu-title') メニュー レベル2
+            ul.c-slidebar-menu__grandchildren(data-accordion-content='menu-content')
+              li.c-slidebar-menu__grandchild
+                +a("#").c-slidebar-menu__grandchild-link メニュー レベル3
+              li.c-slidebar-menu__grandchild
+                +a("#").c-slidebar-menu__grandchild-link メニュー レベル3
+          li.c-slidebar-menu__child
+            +a("#").c-slidebar-menu__child-link メニュー レベル2
+          li.c-slidebar-menu__child
+            +a("#").c-slidebar-menu__child-link メニュー レベル2
+      li.c-slidebar-menu__parent
+        +a("#").c-slidebar-menu__parent-link メニュー レベル1
+      li.c-slidebar-menu__parent
+        +a("#").c-slidebar-menu__parent-link メニュー レベル1
+      li.c-slidebar-menu__parent
+        +a("#").c-slidebar-menu__parent-link メニュー レベル1
+
     .l-container
-      +a("#").c-slidebar-menu__button.c-button.is-contact お問い合わせ
+      .c-slidebar-menu__buttons
+        +a("#").c-slidebar-menu__button.c-button
+          span.material-icons-outlined.c-slidebar-menu__button__icon(aria-hidden="true") mail_outline
+          |お問い合わせ
       .c-slidebar-menu__sns-btns
-        +a("#").c-slidebar-menu__sns-btn <i class="fa fa-twitter" aria-hidden="true"></i>
-        +a("#").c-slidebar-menu__sns-btn <i class="fa fa-facebook" aria-hidden="true"></i>
+        //テンプレでは便宜上svgコードですが、実際にはimgタグ等での配置でOK
+        +a("#").c-slidebar-menu__sns-btn
+          |<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" fill="#65A04D" viewBox="0 0 256 256"><rect width="256" height="256" fill="none"></rect><path d="M245.7,77.7l-30.2,30.1C209.5,177.7,150.5,232,80,232c-14.5,0-26.5-2.3-35.6-6.8-7.3-3.7-10.3-7.6-11.1-8.8a8,8,0,0,1,3.9-11.9c.2-.1,23.8-9.1,39.1-26.4a108.6,108.6,0,0,1-24.7-24.4c-13.7-18.6-28.2-50.9-19.5-99.1a8.1,8.1,0,0,1,5.5-6.2,8,8,0,0,1,8.1,1.9c.3.4,33.6,33.2,74.3,43.8V88a48.3,48.3,0,0,1,48.6-48,48.2,48.2,0,0,1,41,24H240a8,8,0,0,1,7.4,4.9A8.4,8.4,0,0,1,245.7,77.7Z"></path></svg>
+        +a("#").c-slidebar-menu__sns-btn
+          |<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" fill="#65A04D" viewBox="0 0 256 256"><rect width="256" height="256" fill="none"></rect><circle cx="128" cy="128" r="32"></circle><path d="M172,28H84A56,56,0,0,0,28,84v88a56,56,0,0,0,56,56h88a56,56,0,0,0,56-56V84A56,56,0,0,0,172,28ZM128,176a48,48,0,1,1,48-48A48,48,0,0,1,128,176Zm52-88a12,12,0,1,1,12-12A12,12,0,0,1,180,88Z"></path></svg>


### PR DESCRIPTION
## サイト内検索フォームのコンポーネント全体的に変更
### l-searchformにしました
mixin化しています。（mixins/_searchform.pug）
<img width="1067" alt="image" src="https://user-images.githubusercontent.com/97862690/222343960-a6d6dd35-a849-4ef1-a293-67a6f4e8e736.png">

### formModal()関数
関数名を searchFormModal() 関数に変更して、
閉じる処理を「フォーム本体以外をクリックしたら閉じる」に変更しました。

### その他
HTMLやCSSの構成をちょっと変えています。

## slidebarの孫階層追加とCSS整理
### 概要
- アコーディオン in アコーディオンの実装例として孫階層まで追加しました
- 2階層目のデザインをデザインフォーマットXDに似せました
<img width="507" alt="image" src="https://user-images.githubusercontent.com/97862690/222344435-077f8ec5-6d99-4bf6-81f0-0e968852a7e5.png">

### コード上の調整
- CSSのスタイリングを（個人的に）やりやすいようにクラス命名を調整しました。
   - 使いにくそうでしたら直しますのでご指摘ください！
- もういらなそうな-webkitベンダープレフィックスを消しました
- ヘッダーの高さにまつわる数値を `$slidebar-header-height` に設定して一括変更できるようにしました

![image](https://user-images.githubusercontent.com/97862690/222344847-2d9679e6-705e-434a-9036-67e4baa770a3.png)


