### PR TITLE
/app/robots.txt を /dist/ にコピーする設定の追加

### DIFF
--- a/webpack.config.babel.js
+++ b/webpack.config.babel.js
@@ -103,8 +103,8 @@ module.exports = (env, argv) => {
             ]
         },
         plugins: [
-            //画像とscripts.jsは、そのままコピーする
             new CopyPlugin({
+                //画像とscripts.jsは、そのままコピーする
                 patterns: [
                     {
                         from: path.resolve(__dirname, 'app/assets/images'),
@@ -117,6 +117,11 @@ module.exports = (env, argv) => {
                     {
                         from: path.resolve(__dirname, 'app/assets/fonts'),
                         to: path.resolve(__dirname, 'dist/assets/fonts'),
+                    },
+                    //robots.txtは、そのままコピーする
+                    {
+                        from: path.resolve(__dirname, 'app/robots.txt'),
+                        to: path.resolve(__dirname, 'dist/'),
                     },
                     //その他設定追加したい場合は以下を参考に
                     // {


### PR DESCRIPTION
## webpack.config.babel.js 
CopyPluginの設定に、以下の記述を追加しました。

```
                    //robots.txtは、そのままコピーする
                    {
                        from: path.resolve(__dirname, 'app/robots.txt'),
                        to: path.resolve(__dirname, 'dist/'),
                    },
```

dist 直下に、robots.txt が生成されるようになります。
<img width="155" alt="image" src="https://user-images.githubusercontent.com/97862690/235043937-3a1282cd-6fd9-4388-837a-8318c55a829d.png">
