### PR TITLE
font-format() : letter-spacingの出力を --letter-spacingに変更

### DIFF
--- a/app/assets/scss/foundation/_mixin.scss
+++ b/app/assets/scss/foundation/_mixin.scss
@@ -499,7 +499,7 @@
   font-size: rem-calc($size);
   line-height: math.div($height, $size) * 1;
   @if ($letter){//line-heightはnullにするとCSS出力をスキップします
-    letter-spacing: $letter + em;
+    --letter-spacing: #{$letter + em};
   }
   @if ($weight){//font-weightはnullもしくは記載しないとCSS出力をスキップします
     font-weight: $weight;


### PR DESCRIPTION
WP工程時にHTML構造が変わったときに困る認識でしたが、

よく見たら

.c-buttonは全部 letter-spacing:0.1em にしたいが、
.c-button span の方はletter-spacing:var(--letter-spacing)なので、実際表示は0.06em

というような事故も発生していたので修正プルリクです…！
CSS変数導入時にこちら直していなくてすみません…！

<img width="429" alt="image" src="https://github.com/growgroup/gg-styleguide/assets/97862690/e2dbaedb-84fa-41a4-8305-b12f1c2e8002">

<img width="386" alt="image" src="https://github.com/growgroup/gg-styleguide/assets/97862690/fb0e39a9-0660-4be3-9363-cb3002e84a40">