### PR TITLE
[update] autoprefixser 

### DIFF
--- a/app/assets/scss/foundation/_forms.scss
+++ b/app/assets/scss/foundation/_forms.scss
@@ -105,10 +105,7 @@ select {
   color: rgba($font-base-color,1);
   border: 1px solid $border-base-color;
   border-radius: 0!important;
-  -webkit-box-shadow: inset 0 1px 1px rgba(0,0,0,.075);
   box-shadow: inset 0 1px 1px rgba(0,0,0,.075);
-  -webkit-transition: border-color ease-in-out .15s,-webkit-box-shadow ease-in-out .15s;
-  -o-transition: border-color ease-in-out .15s,box-shadow ease-in-out .15s;
   transition: border-color ease-in-out .15s,box-shadow ease-in-out .15s;
   @include breakpoint(small only) {
     width: 100%;
@@ -116,26 +113,6 @@ select {
 }
 
 /*  プレイスホルダーの色変更 */
-:placeholder-shown {
+::placeholder{
   color: rgba($font-base-color,0.3);
-}
-
-/* Google Chrome, Safari, Opera 15+, Android, iOS */
-::-webkit-input-placeholder {
-  color: rgba($font-base-color,0.3);
-}
-
-/* Firefox 18- */
-:-moz-placeholder {
-  color: rgba($font-base-color,0.3);
-}
-
-/* Firefox 19+ */
-::-moz-placeholder {
-  color: rgba($font-base-color,0.3);
-}
-
-/* IE 10+ */
-:-ms-input-placeholder {
-  color: #9FA0A0;
 }

--- a/app/assets/scss/foundation/_mixin.scss
+++ b/app/assets/scss/foundation/_mixin.scss
@@ -188,7 +188,6 @@
 // フォームの有効化時のスタイル
 @mixin input-active(){
   outline: none;
-  -webkit-box-shadow: none;
   box-shadow: none;
 }
 
@@ -213,8 +212,6 @@
 
 // box sizing
 @mixin box-sizing($type) {
-  -webkit-box-sizing:$type;
-  -moz-box-sizing:$type;
   box-sizing:$type;
 }
 
@@ -223,8 +220,6 @@
   position: absolute;
   top: 50%;
   left: 50%;
-  -webkit-transform: translate(-50%,-50%);
-  -ms-transform: translate(-50%,-50%);
   transform: translate(-50%,-50%);
 }
 

--- a/app/assets/scss/object/components/_accordion-list.scss
+++ b/app/assets/scss/object/components/_accordion-list.scss
@@ -6,7 +6,6 @@ category: Components
 */
 
 .c-accordion-list {
-  backdrop-filter: blur(10px);
   &__block {
     margin-bottom: rem-calc(20);
     @include breakpoint(small only) {

--- a/app/assets/scss/object/components/_accordion-list.scss
+++ b/app/assets/scss/object/components/_accordion-list.scss
@@ -6,6 +6,7 @@ category: Components
 */
 
 .c-accordion-list {
+  backdrop-filter: blur(10px);
   &__block {
     margin-bottom: rem-calc(20);
     @include breakpoint(small only) {

--- a/app/assets/scss/object/components/_grid.scss
+++ b/app/assets/scss/object/components/_grid.scss
@@ -57,8 +57,6 @@
   margin-right: -(map.get($grid-column-responsive-gutter, medium) * 0.5);
   // @include susy-clearfix();
   display: flex;
-  -webkit-flex-wrap: wrap;
-  -ms-flex-wrap: wrap;
   flex-wrap: wrap;
   @include breakpoint(small only) {
     margin-left: -(map.get($grid-column-responsive-gutter, small) * 0.5);

--- a/app/assets/scss/object/project/_owl-carousel.scss
+++ b/app/assets/scss/object/project/_owl-carousel.scss
@@ -118,15 +118,6 @@
   }
 }
 
-@-webkit-keyframes fadeOut {
-  from {
-    opacity: 1;
-  }
-
-  to {
-    opacity: 0;
-  }
-}
 
 @keyframes fadeOut {
   from {
@@ -139,7 +130,6 @@
 }
 
 .fadeOut {
-  -webkit-animation-name: fadeOut;
   animation-name: fadeOut;
 }
 

--- a/app/assets/scss/object/utility/_animate.scss
+++ b/app/assets/scss/object/utility/_animate.scss
@@ -16,76 +16,51 @@
 
 @-webkit-keyframes bounce {
   from, 20%, 53%, 80%, to {
-    -webkit-animation-timing-function: cubic-bezier(0.215, 0.610, 0.355, 1.000);
     animation-timing-function: cubic-bezier(0.215, 0.610, 0.355, 1.000);
-    -webkit-transform: translate3d(0,0,0);
     transform: translate3d(0,0,0);
   }
 
   40%, 43% {
-    -webkit-animation-timing-function: cubic-bezier(0.755, 0.050, 0.855, 0.060);
     animation-timing-function: cubic-bezier(0.755, 0.050, 0.855, 0.060);
-    -webkit-transform: translate3d(0, -30px, 0);
     transform: translate3d(0, -30px, 0);
   }
 
   70% {
-    -webkit-animation-timing-function: cubic-bezier(0.755, 0.050, 0.855, 0.060);
     animation-timing-function: cubic-bezier(0.755, 0.050, 0.855, 0.060);
-    -webkit-transform: translate3d(0, -15px, 0);
     transform: translate3d(0, -15px, 0);
   }
 
   90% {
-    -webkit-transform: translate3d(0,-4px,0);
     transform: translate3d(0,-4px,0);
   }
 }
 
 @keyframes bounce {
   from, 20%, 53%, 80%, to {
-    -webkit-animation-timing-function: cubic-bezier(0.215, 0.610, 0.355, 1.000);
     animation-timing-function: cubic-bezier(0.215, 0.610, 0.355, 1.000);
-    -webkit-transform: translate3d(0,0,0);
     transform: translate3d(0,0,0);
   }
 
   40%, 43% {
-    -webkit-animation-timing-function: cubic-bezier(0.755, 0.050, 0.855, 0.060);
     animation-timing-function: cubic-bezier(0.755, 0.050, 0.855, 0.060);
-    -webkit-transform: translate3d(0, -30px, 0);
     transform: translate3d(0, -30px, 0);
   }
 
   70% {
-    -webkit-animation-timing-function: cubic-bezier(0.755, 0.050, 0.855, 0.060);
     animation-timing-function: cubic-bezier(0.755, 0.050, 0.855, 0.060);
-    -webkit-transform: translate3d(0, -15px, 0);
     transform: translate3d(0, -15px, 0);
   }
 
   90% {
-    -webkit-transform: translate3d(0,-4px,0);
     transform: translate3d(0,-4px,0);
   }
 }
 
 .bounce {
-  -webkit-animation-name: bounce;
   animation-name: bounce;
-  -webkit-transform-origin: center bottom;
   transform-origin: center bottom;
 }
 
-@-webkit-keyframes fadeIn {
-  from {
-    opacity: 0;
-  }
-
-  to {
-    opacity: 1;
-  }
-}
 
 @keyframes fadeIn {
   from {
@@ -98,35 +73,19 @@
 }
 
 .fadeIn {
-  -webkit-animation-name: fadeIn;
   animation-name: fadeIn;
 }
 
 
-@-webkit-keyframes fadeInDown {
-  from {
-    opacity: 0;
-    -webkit-transform: translate3d(0, -100%, 0);
-    transform: translate3d(0, -100%, 0);
-  }
-
-  to {
-    opacity: 1;
-    -webkit-transform: none;
-    transform: none;
-  }
-}
 
 @keyframes fadeInDown {
   from {
     opacity: 0;
-    -webkit-transform: translate3d(0, -100%, 0);
     transform: translate3d(0, -100%, 0);
   }
 
   to {
     opacity: 1;
-    -webkit-transform: none;
     transform: none;
   }
 }
@@ -137,49 +96,22 @@
 }
 
 
-@-webkit-keyframes fadeInUp {
-  from {
-    opacity: 0;
-    -webkit-transform: translate3d(0, 100%, 0);
-    transform: translate3d(0, 100%, 0);
-  }
-
-  to {
-    opacity: 1;
-    -webkit-transform: none;
-    transform: none;
-  }
-}
-
 @keyframes fadeInUp {
   from {
     opacity: 0;
-    -webkit-transform: translate3d(0, 100%, 0);
     transform: translate3d(0, 100%, 0);
   }
 
   to {
     opacity: 1;
-    -webkit-transform: none;
     transform: none;
   }
 }
 
 .fadeInUp {
-  -webkit-animation-name: fadeInUp;
   animation-name: fadeInUp;
 }
 
-
-@-webkit-keyframes fadeOut {
-  from {
-    opacity: 1;
-  }
-
-  to {
-    opacity: 0;
-  }
-}
 
 @keyframes fadeOut {
   from {
@@ -192,7 +124,6 @@
 }
 
 .fadeOut {
-  -webkit-animation-name: fadeOut;
   animation-name: fadeOut;
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -3419,13 +3419,23 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001292",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001292.tgz",
-      "integrity": "sha512-jnT4Tq0Q4ma+6nncYQVe7d73kmDmE9C3OGTx3MvW7lBM/eY1S1DZTMBON7dqV481RhNiS5OxD7k9JQvmDOTirw==",
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/browserslist"
-      }
+      "version": "1.0.30001503",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001503.tgz",
+      "integrity": "sha512-Sf9NiF+wZxPfzv8Z3iS0rXM1Do+iOy2Lxvib38glFX+08TCYYYGR5fRJXk4d77C4AYwhUjgYgMsMudbh2TqCKw==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ]
     },
     "node_modules/center-align": {
       "version": "0.1.3",
@@ -16696,9 +16706,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001292",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001292.tgz",
-      "integrity": "sha512-jnT4Tq0Q4ma+6nncYQVe7d73kmDmE9C3OGTx3MvW7lBM/eY1S1DZTMBON7dqV481RhNiS5OxD7k9JQvmDOTirw=="
+      "version": "1.0.30001503",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001503.tgz",
+      "integrity": "sha512-Sf9NiF+wZxPfzv8Z3iS0rXM1Do+iOy2Lxvib38glFX+08TCYYYGR5fRJXk4d77C4AYwhUjgYgMsMudbh2TqCKw=="
     },
     "center-align": {
       "version": "0.1.3",

--- a/package.json
+++ b/package.json
@@ -89,6 +89,12 @@
     "node_modules"
   ],
   "main": "postcss.config.js",
+  "browserslist": [
+    "last 3 versions",
+    "not dead",
+    "iOS >= 14",
+    "Safari >= 14"
+  ],
   "repository": {
     "type": "git",
     "url": "git+https://github.com/growgroup/gg-styleguide.git"

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,6 +1,6 @@
 module.exports = (ctx) => ({
   plugins: {
-    "autoprefixer":{ grid: true },
+    "autoprefixer":{},
     "prepend-selector-postcss":ctx.file.basename === 'admin-style.css' ? {
       selector: '#growp-editor-wrapper ',
       appendTo:['html','body'],


### PR DESCRIPTION
Autoprefixerの設定を調整し、ビルド時に表示されていた各種警告が出ないようにしました。
また、Autoprefixerがあれば不要になる、手書きベンダープレフィックスをある程度除去しました。

▼該当改善事項
https://www.notion.so/growgroup/autoprefixer-IE11-389247dce3a74b2eaf158755b8f7aa95

# 詳細
### browserlist設定
```
  "browserslist": [
    "last 3 versions",
    "not dead",
    "iOS >= 14",
    "Safari >= 14"
  ],
```
※ブラウザ設定が正しく効いているか若干不安だが、
`backdrop-filter` に必要なベンダープレフィックスがつくのは確認済み
![スクリーンショット 2023-06-15 11 59 27](https://github.com/growgroup/gg-styleguide/assets/97862690/30de8ab7-552a-424b-94db-ebdfd42f3d8f)


### caniuse更新
`caniuse-lite is outdated` の出力を消すため。
build時に `caniuse-lite is outdated` がでなければ成功。


### IE11サポート削除
中央寄せ手法として以下を使っても、警告が出ないことを確認済み。

```
  display: grid;
  place-items: center;
```


### 手書きベンダープレフィックス削除 ・ ::placeholder記述調整
_normalize.scss と _owl-carousel.scss以外のscssについて、
手書きのベンダープレフィックスを除去して見通しをよく。

foundation/_forms.scss の ::placeholder について、
なぜかベンダープレフィックス系ではないものについては
 :placeholder_shownの色を変えていたので
::placeholder に統一。
