### PR TITLE
selectタグのアイコンを右から16pxずらして欲しいという要望

### DIFF
--- a/app/assets/scss/foundation/_forms.scss
+++ b/app/assets/scss/foundation/_forms.scss
@@ -107,6 +107,12 @@ select {
   border-radius: 0!important;
   box-shadow: inset 0 1px 1px rgba(0,0,0,.075);
   transition: border-color ease-in-out .15s,box-shadow ease-in-out .15s;
+  appearance: none;
+  background-image: url('data:image/svg+xml;utf8,<svg width="9" height="6" viewBox="0 0 9 6" fill="none" xmlns="http://www.w3.org/2000/svg"> <path d="M7.945 2.38419e-05L9 1.05402L4.5 5.55402L0 1.05402L1.055 -0.000976562L4.5 3.44502L7.945 2.38419e-05Z" fill="%23222222"/></svg>');
+  background-repeat: no-repeat;
+  background-position: calc(100% - 15px) center;
+  background-size: 9px 5px;
+
   @include breakpoint(small only) {
     width: 100%;
   }

--- a/app/assets/scss/object/components/_forms.scss
+++ b/app/assets/scss/object/components/_forms.scss
@@ -124,7 +124,7 @@
     width: 100%;
     input {
       border-radius: 4px;
-      background: #F9F9F9;
+      background-color: #F9F9F9;
       padding: rem-calc(16) rem-calc(16) rem-calc(16) rem-calc(24);
       @include breakpoint(small only) {
         padding: rem-calc(12) rem-calc(16);
@@ -147,7 +147,7 @@
     input {
 
       &::file-selector-button{
-        background: #F9F9F9;
+        background-color: #F9F9F9;
         border: solid 1px $border-base-color;
         border-radius: 4px;
         padding: rem-calc(8) rem-calc(16);
@@ -160,7 +160,7 @@
     select {
       outline: none;
       border-radius: 4px !important;
-      background: #F9F9F9;
+      background-color: #F9F9F9;
 
       &:focus{
         border-color: $color-primary;
@@ -174,7 +174,7 @@
   &__textarea {
     textarea {
       border-radius: 4px;
-      background: #F9F9F9;
+      background-color: #F9F9F9;
       padding: rem-calc(16) rem-calc(16) rem-calc(16) rem-calc(24);
       @include breakpoint(small only) {
         padding: rem-calc(12) rem-calc(16);


### PR DESCRIPTION
# What
selectタグのアイコンを右から16pxずらして欲しいという要望。

# Why
擬似要素では実現不可能かつselectのappearanceはブラウザによって見た目が異なるため、
極力触らない方が良かったが、上記の要望がちらほら見かけるのでbackgroundで無理やり対応。
ブラウザ間でのデバッグは未検証。