### PR TITLE
[update] font-format & font-format-light : CSSスキップをnullではなく"" で可能に

### DIFF
--- a/app/assets/scss/foundation/_mixin.scss
+++ b/app/assets/scss/foundation/_mixin.scss
@@ -490,20 +490,28 @@
   align-items: $align-items;
 }
 
-@mixin font-format($size : $font-base-size,$letter:null,$height: 24,$weight:null){
+@mixin font-format($size : $font-base-size,$letter:null,$height: 24,$weight:null) {
+  //letter と weight が "" で送られてきてもnull扱いにする
+  @if ($letter == "") {
+    $letter: null;
+  }
+  @if ($weight == "") {
+    $weight: null;
+  }
+
   font-size: rem-calc($size);
-  line-height: math.div($height, $size) * 1;
-  @if ($letter){//line-heightはnullにするとCSS出力をスキップします
+  line-height: calc($height / $size);
+  @if ($letter) { //nullにするとCSS出力をスキップします
     --letter-spacing: #{$letter + em};
   }
-  @if ($weight){//font-weightはnullもしくは記載しないとCSS出力をスキップします
+  @if ($weight) { //nullもしくは記載しないとCSS出力をスキップします
     font-weight: $weight;
   }
 }
 
-@mixin font-format-light($size : $font-base-size,$height: 24){
+@mixin font-format-light($size : $font-base-size,$height: 24) {
   font-size: rem-calc($size);
-  line-height: math.div($height, $size) * 1;
+  line-height: calc($height / $size);
 }
 
 @mixin flex-wrapper() {

--- a/app/assets/scss/object/components/_heading.scss
+++ b/app/assets/scss/object/components/_heading.scss
@@ -66,7 +66,7 @@ category: Heading
     &.is-ja {
       display: block;
       @include webfont();
-      @include font-format(14,null,20,normal);//line-heightはnullにするとCSS出力をスキップします
+      @include font-format(14, "", 20, normal); //2番目を""にするとletter-spacingのCSS出力をスキップします
       margin-top: rem-calc(6);
       @include breakpoint(small only) {
         font-size: rem-calc(14)*0.8;

--- a/app/assets/scss/object/components/_pagination.scss
+++ b/app/assets/scss/object/components/_pagination.scss
@@ -29,7 +29,7 @@ category: Navigation
   ul li > span,
   ul li > a {
     @include webfont();
-    @include font-format(16,null,13,bold);
+    @include font-format(16, "", 13, bold);
     display: flex;
     justify-content: center;
     align-items: center;


### PR DESCRIPTION
## letter-spacing不要の時、"" でCSS出力をスキップできるように
元の記述のままでも動きますが、
呼び出すときに""での出力スキップが可能になりました。

### 元
```
@include font-format(14,null,20,normal);
```

### 変更後
```
@include font-format(14, "", 20, normal);
```


## math.div→calcへ変更
出力されるCSSは一緒です。

### 元
```
line-height: math.div($height, $size) * 1;
```

### 変更後
```
line-height: calc($height / $size);
```

## そのほか
コメントアウトの記述を間違えていたので直しました。