### PR TITLE
[update] block append config : 各ページでid、titleと同じ文字列を入れる箇所に自動で文字が入るように

### DIFF
--- a/app/archive-twocolumns/index.pug
+++ b/app/archive-twocolumns/index.pug
@@ -2,9 +2,9 @@ extends /inc/foundation/_base-twocolumn.pug
 block append config
   - current.id = "archive-twocolumns" // ページのID
   - current.title = "アーカイブ_2カラム" // タイトル
-  - current.description = "これはアーカイブ_2カラムの説明文です" // 説明文
-  - current.bodyClass = "archive-twocolumns" // body に付与するクラス
-  - current.path = "/archive-twocolumns/" // ページのpath
+  - current.description = `これは${current.title}についての説明文です` // 説明文
+  - current.bodyClass = `${current.id}` // body に付与するクラス
+  - current.path = `/${current.id}/` // ページのpath
   - current.depth = 2 // ページの階層
 
 block page_header

--- a/app/archive-twocolumns/page/index.pug
+++ b/app/archive-twocolumns/page/index.pug
@@ -2,9 +2,9 @@ extends /inc/foundation/_base-twocolumn.pug
 block append config
   - current.id = "post-twocolumns" // ページのID
   - current.title = "ポスト_2カラム" // タイトル
-  - current.description = "これはポスト_2カラムの説明文です" // 説明文
-  - current.bodyClass = "post-twocolumns" // body に付与するクラス
-  - current.path = "/post-twocolumns/" // ページのpath
+  - current.description = `これは${current.title}についての説明文です` // 説明文
+  - current.bodyClass = `${current.id}` // body に付与するクラス
+  - current.path = "/archive-twocolumns/page/" // ページのpath
   - current.depth = 3 // ページの階層
 
 block page_header

--- a/app/contact/complete/index.pug
+++ b/app/contact/complete/index.pug
@@ -2,9 +2,9 @@ extends /inc/foundation/_base.pug
 block append config
   - current.id = "complete" // ページのID
   - current.title = "お問い合わせ - 送信完了ページ" // タイトル
-  - current.description = "これはお問い合わせ - 送信完了ページの説明文です" // 説明文
-  - current.bodyClass = "complete" // body に付与するクラス
-  - current.path = "/contact/complete/" // ページのpath
+  - current.description = `これは${current.title}についての説明文です` // 説明文
+  - current.bodyClass = `${current.id}` // body に付与するクラス
+  - current.path = `/contact/${current.id}/` // ページのpath
   - current.depth = 3 // ページの階層
 
 block page_header

--- a/app/contact/confirm/index.pug
+++ b/app/contact/confirm/index.pug
@@ -2,9 +2,9 @@ extends /inc/foundation/_base.pug
 block append config
   - current.id = "confirm" // ページのID
   - current.title = "お問い合わせ - 確認ページ" // タイトル
-  - current.description = "これはお問い合わせ - 確認ページの説明文です" // 説明文
-  - current.bodyClass = "confirm" // body に付与するクラス
-  - current.path = "/contact/confirm/" // ページのpath
+  - current.description = `これは${current.title}についての説明文です` // 説明文
+  - current.bodyClass = `${current.id}` // body に付与するクラス
+  - current.path = `/contact/${current.id}/` // ページのpath
   - current.depth = 3 // ページの階層
 
 block page_header

--- a/app/contact/index.pug
+++ b/app/contact/index.pug
@@ -2,9 +2,9 @@ extends /inc/foundation/_base.pug
 block append config
   - current.id = "contact" // ページのID
   - current.title = "お問い合わせフォーム" // タイトル
-  - current.description = "これはお問い合わせフォームの説明文です" // 説明文
-  - current.bodyClass = "contact" // body に付与するクラス
-  - current.path = "/contact/" // ページのpath
+  - current.description = `これは${current.title}についての説明文です` // 説明文
+  - current.bodyClass = `${current.id}` // body に付与するクラス
+  - current.path = `/${current.id}/` // ページのpath
   - current.depth = 2 // ページの階層
 
 block page_header

--- a/app/format/index.pug
+++ b/app/format/index.pug
@@ -2,9 +2,9 @@ extends /inc/foundation/_base.pug
 block append config
   - current.id = "format" // ページのID
   - current.title = "フォーマット" // タイトル
-  - current.description = "これはフォーマットページの説明文です" // 説明文
-  - current.bodyClass = "format" // body に付与するクラス
-  - current.path = "/format/" // ページのpath
+  - current.description = `これは${current.title}についての説明文です` // 説明文
+  - current.bodyClass = `${current.id}` // body に付与するクラス
+  - current.path = `/${current.id}/` // ページのpath
   - current.depth = 2 // ページの階層
 
 block body

--- a/app/news/category/index.pug
+++ b/app/news/category/index.pug
@@ -2,9 +2,9 @@ extends /inc/foundation/_base.pug
 block append config
   - current.id = "category" // ページのID
   - current.title = "カテゴリ" // タイトル
-  - current.description = "これはカテゴリの説明文です" // 説明文
-  - current.bodyClass = "category" // body に付与するクラス
-  - current.path = "/news/category/" // ページのpath
+  - current.description = `これは${current.title}についての説明文です` // 説明文
+  - current.bodyClass = `${current.id}` // body に付与するクラス
+  - current.path = `/news/${current.id}/` // ページのpath
   - current.depth = 3 // ページの階層
 
 block page_header

--- a/app/news/category/page/index.pug
+++ b/app/news/category/page/index.pug
@@ -2,8 +2,8 @@ extends /inc/foundation/_base.pug
 block append config
   - current.id = "post" // ページのID
   - current.title = "ここに記事のタイトルが入ります。" // タイトル
-  - current.description = "ここに記事のタイトルが入ります。" // 説明文
-  - current.bodyClass = "single-" + current.id // body に付与するクラス
+  - current.description = `これは${current.title}についての説明文です` // 説明文
+  - current.bodyClass = `single-${current.id}` // body に付与するクラス
   - current.path = "/news/category/page/" // ページのpath
   - current.depth = 4 // ページの階層
 

--- a/app/news/index.pug
+++ b/app/news/index.pug
@@ -2,9 +2,9 @@ extends /inc/foundation/_base.pug
 block append config
   - current.id = "news" // ページのID
   - current.title = "お知らせ" // タイトル
-  - current.description = "これはお知らせの説明文です" // 説明文
-  - current.bodyClass = "news" // body に付与するクラス
-  - current.path = "/news/" // ページのpath
+  - current.description = `これは${current.title}についての説明文です` // 説明文
+  - current.bodyClass = `${current.id}` // body に付与するクラス
+  - current.path = `/${current.id}/` // ページのpath
   - current.depth = 2 // ページの階層
 
 block page_header

--- a/app/page/index.pug
+++ b/app/page/index.pug
@@ -2,9 +2,9 @@ extends /inc/foundation/_base.pug
 block append config
   - current.id = "format" // ページのID
   - current.title = "量産ページ" // タイトル
-  - current.description = "これは量産ページについての説明文です" // 説明文
-  - current.bodyClass = "format" // body に付与するクラス
-  - current.path = "/format/" // ページのpath
+  - current.description = `これは${current.title}についての説明文です` // 説明文
+  - current.bodyClass = `${current.id}` // body に付与するクラス
+  - current.path = `/${current.id}/` // ページのpath
   - current.depth = 2 // ページの階層
 
 block page_header

--- a/app/result/index.pug
+++ b/app/result/index.pug
@@ -2,9 +2,9 @@ extends /inc/foundation/_base.pug
 block append config
   - current.id = "result" // ページのID
   - current.title = "サイト内検索" // タイトル
-  - current.description = "これはサイト内検索についての説明文です" // 説明文
-  - current.bodyClass = "result" // body に付与するクラス
-  - current.path = "/result/" // ページのpath
+  - current.description = `これは${current.title}についての説明文です` // 説明文
+  - current.bodyClass = `${current.id}` // body に付与するクラス
+  - current.path = `/${current.id}/` // ページのpath
   - current.depth = 2 // ページの階層
 
 block page_header

--- a/app/sitemap/index.pug
+++ b/app/sitemap/index.pug
@@ -2,9 +2,9 @@ extends /inc/foundation/_base.pug
 block append config
   - current.id = "format" // ページのID
   - current.title = "量産ページ" // タイトル
-  - current.description = "これは量産ページについての説明文です" // 説明文
-  - current.bodyClass = "format" // body に付与するクラス
-  - current.path = "/sitemap/" // ページのpath
+  - current.description = `これは${current.title}についての説明文です` // 説明文
+  - current.bodyClass = `${current.id}` // body に付与するクラス
+  - current.path = `/${current.id}/` // ページのpath
   - current.depth = 2 // ページの階層
 
 block page_header

--- a/app/twocolumns/index.pug
+++ b/app/twocolumns/index.pug
@@ -2,9 +2,9 @@ extends /inc/foundation/_base-twocolumn.pug
 block append config
   - current.id = "twocolumns" // ページのID
   - current.title = "ページ_2カラム" // タイトル
-  - current.description = "これはPAGE 2COLUMNの説明文です" // 説明文
-  - current.bodyClass = "twocolumns" // body に付与するクラス
-  - current.path = "/twocolumns/" // ページのpath
+  - current.description = `これは${current.title}についての説明文です` // 説明文
+  - current.bodyClass = `${current.id}` // body に付与するクラス
+  - current.path = `/${current.id}/` // ページのpath
   - current.depth = 2 // ページの階層
 
 block page_header


### PR DESCRIPTION
ページ内で定義したconfig.idやconfig.titleと同じ文字列を使う箇所は
あらかじめ同じ文字列が自動で入るように変更しました。

**違う文字列を入れたいページでは、${current.id}等の記述を消して普通に文字を入れて使えます。**

### 元
```
 block append config
   - current.id = "format" // ページのID
   - current.title = "フォーマット" // タイトル
   - current.description = "これはフォーマットページの説明文です" // 説明文
   - current.bodyClass = "format" // body に付与するクラス
   - current.path = "/format/" // ページのpath
   - current.depth = 2 // ページの階層
```

### 変更後
```
block append config
  - current.id = "format" // ページのID
  - current.title = "フォーマット" // タイトル
  - current.description = `これは${current.title}についての説明文です` // 説明文
  - current.bodyClass = `${current.id}` // body に付与するクラス
  - current.path = `/${current.id}/` // ページのpath
  - current.depth = 2 // ページの階層
```

## path部分の調整方法がわかりやすいように、階層が深いページも調整済み

### 例：contact/confirm/

```
  - current.path = `/contact/${current.id}/` // ページのpath
```
