### PR TITLE
[update] c-breadcrumb : if分岐を調整してコードの重複を減らす

### DIFF
--- a/app/inc/mixins/_breadcrumb.pug
+++ b/app/inc/mixins/_breadcrumb.pug
@@ -1,38 +1,26 @@
 //- パンくずリスト
 mixin c_breadcrumb(parent,parentURL,parent2,parentURL2)
-  if parent2
-    +c.breadcrumb
-      .l-container
-        +e.inner
+  +c.breadcrumb
+    .l-container
+      +e.inner
+        span
           span
-            span
-              +a("/") ホーム
-              span.is-arrow <span class="material-icons-outlined">chevron_right</span>
-              span
-                +a('/'+parentURL+'/')=parent
-                span.is-arrow <span class="material-icons-outlined">chevron_right</span>
-                span
-                  +a('/' + parentURL +'/' + parentURL2 + '/')=parent2
-                  span.is-arrow <span class="material-icons-outlined">chevron_right</span>
-                  span !{current.title}
-  else if parent
-    +c.breadcrumb
-      .l-container
-        +e.inner
-          span
-            span
-              +a("/") ホーム
-              span.is-arrow <span class="material-icons-outlined">chevron_right</span>
-              span
-                +a('/'+parentURL+'/')=parent
-                span.is-arrow <span class="material-icons-outlined">chevron_right</span>
-                span !{current.title}
-  else
-    +c.breadcrumb
-      .l-container
-        +e.inner
-          span
-            span
-              +a("/") ホーム
-              span.is-arrow <span class="material-icons-outlined">chevron_right</span>
+            +a("/") TOP
+            span.is-arrow <span class="material-icons-outlined">chevron_right</span>
+            if !parent
+              //- parent設定がないとき
               span !{current.title}
+            else
+              //- parent設定があるとき
+              span
+                +a('/' + parentURL + '/')=parent
+                span.is-arrow <span class="material-icons-outlined">chevron_right</span>
+                if !parent2
+                  //- parent2設定がないとき
+                  span !{current.title}
+                else
+                  //- parent2設定があるとき
+                  span
+                    +a('/' + parentURL + '/' + parentURL2 + '/')=parent2
+                    span.is-arrow <span class="material-icons-outlined">chevron_right</span>
+                    span !{current.title}


### PR DESCRIPTION
▼改善事項
https://www.notion.so/growgroup/mixin-c_breadcrumb-if-b3f4b15385354a588038168bb54f6653

改善事項で提案した再帰的な処理だと、各ページ側の記述方法も変更しないといけなくて大がかりなので、
いったん現状の引数のままでコードの重複だけ減らしました。

▼呼び出し（変更なし）
```
  +c_breadcrumb("2階層目","2","3階層目","3")
  +c_breadcrumb("2階層目","2")
  +c_breadcrumb()
```

▼出力（変更なし）
<img width="270" alt="image" src="https://github.com/growgroup/gg-styleguide/assets/97862690/d901375f-b66b-433e-8fa7-276174b5d172">
