### PR TITLE
[update] postcss : admin-style.cssの処理変更

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -54,7 +54,7 @@
         "postcss": "^8.4.5",
         "postcss-cli": "^9.1.0",
         "postcss-import": "^14.0.2",
-        "prepend-selector-postcss": "^0.4.7",
+        "postcss-prefix-selector": "^1.16.0",
         "pug": "^3.0.2",
         "pug-cli": "git+https://github.com/pugjs/pug-cli.git",
         "rimraf": "^3.0.2",
@@ -8878,10 +8878,16 @@
       "optional": true
     },
     "node_modules/nanoid": {
-      "version": "3.3.4",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.4.tgz",
-      "integrity": "sha512-MqBkQh/OHTS2egovRtLk45wEyNXwF+cokD+1YPf9u5VfJiRdAiRwB2froX5Co9Rh20xs4siNPm8naNotSD6RBw==",
+      "version": "3.3.6",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.6.tgz",
+      "integrity": "sha512-BGcqMMJuToF7i1rt+2PWSNVnWIkGCU78jBG3RxO/bZlnZPK2Cmi2QaffxGO/2RvWi9sL+FAiRiXMgsyxQ1DIDA==",
       "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
       "bin": {
         "nanoid": "bin/nanoid.cjs"
       },
@@ -9744,9 +9750,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.4.20",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.20.tgz",
-      "integrity": "sha512-6Q04AXR1212bXr5fh03u8aAwbLxAQNGQ/Q1LNa0VfOI06ZAlhPHtQvE4OIdpj4kLThXilalPnmDSOD65DcHt+g==",
+      "version": "8.4.25",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.25.tgz",
+      "integrity": "sha512-7taJ/8t2av0Z+sQEvNzCkpDynl0tX3uJMCODi6nT3PfASC7dYCWV9aQ+uiCf+KBD4SEFcu+GvJdGdwzQ6OSjCw==",
       "dev": true,
       "funding": [
         {
@@ -9756,10 +9762,14 @@
         {
           "type": "tidelift",
           "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
         }
       ],
       "dependencies": {
-        "nanoid": "^3.3.4",
+        "nanoid": "^3.3.6",
         "picocolors": "^1.0.0",
         "source-map-js": "^1.0.2"
       },
@@ -10042,6 +10052,15 @@
         "postcss": "^8.1.0"
       }
     },
+    "node_modules/postcss-prefix-selector": {
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/postcss-prefix-selector/-/postcss-prefix-selector-1.16.0.tgz",
+      "integrity": "sha512-rdVMIi7Q4B0XbXqNUEI+Z4E+pueiu/CS5E6vRCQommzdQ/sgsS4dK42U7GX8oJR+TJOtT+Qv3GkNo6iijUMp3Q==",
+      "dev": true,
+      "peerDependencies": {
+        "postcss": ">4 <9"
+      }
+    },
     "node_modules/postcss-reporter": {
       "version": "7.0.4",
       "resolved": "https://registry.npmjs.org/postcss-reporter/-/postcss-reporter-7.0.4.tgz",
@@ -10128,15 +10147,6 @@
       "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
       "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
       "dev": true
-    },
-    "node_modules/prepend-selector-postcss": {
-      "version": "0.4.7",
-      "resolved": "https://registry.npmjs.org/prepend-selector-postcss/-/prepend-selector-postcss-0.4.7.tgz",
-      "integrity": "sha512-EVt1u0fkefsmO8zZM8FfNpFQLYJEyQQ3+8SvoQIfQ1P/eQHgzWXGpomWqzyomdzScWoztya59P0x2mSruMxXVg==",
-      "dev": true,
-      "dependencies": {
-        "postcss": "^8.4.5"
-      }
     },
     "node_modules/preserve": {
       "version": "0.2.0",
@@ -20941,9 +20951,9 @@
       "optional": true
     },
     "nanoid": {
-      "version": "3.3.4",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.4.tgz",
-      "integrity": "sha512-MqBkQh/OHTS2egovRtLk45wEyNXwF+cokD+1YPf9u5VfJiRdAiRwB2froX5Co9Rh20xs4siNPm8naNotSD6RBw==",
+      "version": "3.3.6",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.6.tgz",
+      "integrity": "sha512-BGcqMMJuToF7i1rt+2PWSNVnWIkGCU78jBG3RxO/bZlnZPK2Cmi2QaffxGO/2RvWi9sL+FAiRiXMgsyxQ1DIDA==",
       "dev": true
     },
     "nanomatch": {
@@ -21592,12 +21602,12 @@
       "integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs="
     },
     "postcss": {
-      "version": "8.4.20",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.20.tgz",
-      "integrity": "sha512-6Q04AXR1212bXr5fh03u8aAwbLxAQNGQ/Q1LNa0VfOI06ZAlhPHtQvE4OIdpj4kLThXilalPnmDSOD65DcHt+g==",
+      "version": "8.4.25",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.25.tgz",
+      "integrity": "sha512-7taJ/8t2av0Z+sQEvNzCkpDynl0tX3uJMCODi6nT3PfASC7dYCWV9aQ+uiCf+KBD4SEFcu+GvJdGdwzQ6OSjCw==",
       "dev": true,
       "requires": {
-        "nanoid": "^3.3.4",
+        "nanoid": "^3.3.6",
         "picocolors": "^1.0.0",
         "source-map-js": "^1.0.2"
       }
@@ -21788,6 +21798,13 @@
         "icss-utils": "^5.0.0"
       }
     },
+    "postcss-prefix-selector": {
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/postcss-prefix-selector/-/postcss-prefix-selector-1.16.0.tgz",
+      "integrity": "sha512-rdVMIi7Q4B0XbXqNUEI+Z4E+pueiu/CS5E6vRCQommzdQ/sgsS4dK42U7GX8oJR+TJOtT+Qv3GkNo6iijUMp3Q==",
+      "dev": true,
+      "requires": {}
+    },
     "postcss-reporter": {
       "version": "7.0.4",
       "resolved": "https://registry.npmjs.org/postcss-reporter/-/postcss-reporter-7.0.4.tgz",
@@ -21850,15 +21867,6 @@
       "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
       "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
       "dev": true
-    },
-    "prepend-selector-postcss": {
-      "version": "0.4.7",
-      "resolved": "https://registry.npmjs.org/prepend-selector-postcss/-/prepend-selector-postcss-0.4.7.tgz",
-      "integrity": "sha512-EVt1u0fkefsmO8zZM8FfNpFQLYJEyQQ3+8SvoQIfQ1P/eQHgzWXGpomWqzyomdzScWoztya59P0x2mSruMxXVg==",
-      "dev": true,
-      "requires": {
-        "postcss": "^8.4.5"
-      }
     },
     "preserve": {
       "version": "0.2.0",

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "postcss": "^8.4.5",
     "postcss-cli": "^9.1.0",
     "postcss-import": "^14.0.2",
-    "prepend-selector-postcss": "^0.4.7",
+    "postcss-prefix-selector": "^1.16.0",
     "pug": "^3.0.2",
     "pug-cli": "git+https://github.com/pugjs/pug-cli.git",
     "rimraf": "^3.0.2",

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -5,7 +5,9 @@ module.exports = (ctx) => ({
       prefix: '#growp-editor-wrapper ',
       exclude: [':root'],
       transform: function (prefix, selector, prefixedSelector) {
-        if (selector === 'body') {
+        if (selector.includes('#growp-editor-wrapper')) {
+          return selector;
+        } else if (selector === 'body') {
           return prefix;
         } else if (selector === 'html') {
           return prefix;

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,9 +1,19 @@
 module.exports = (ctx) => ({
   plugins: {
-    "autoprefixer":{},
-    "prepend-selector-postcss":ctx.file.basename === 'admin-style.css' ? {
-      selector: '#growp-editor-wrapper ',
-      appendTo:['html','body'],
+    "autoprefixer": {},
+    "postcss-prefix-selector": ctx.file.basename === 'admin-style.css' ? {
+      prefix: '#growp-editor-wrapper ',
+      exclude: [':root'],
+      transform: function (prefix, selector, prefixedSelector) {
+        if (selector.includes('body')) {
+          return prefix;
+        } else if (selector.includes('html')) {
+          return prefix;
+        } else {
+          return prefixedSelector;
+        }
+      }
     } : false,
+
   },
 })

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -5,9 +5,9 @@ module.exports = (ctx) => ({
       prefix: '#growp-editor-wrapper ',
       exclude: [':root'],
       transform: function (prefix, selector, prefixedSelector) {
-        if (selector.includes('body')) {
+        if (selector === 'body') {
           return prefix;
-        } else if (selector.includes('html')) {
+        } else if (selector === 'html') {
           return prefix;
         } else {
           return prefixedSelector;


### PR DESCRIPTION
2を解決しようとしたら、1も直さざるを得なかったので同時に直しました。

# 1. postcss.plugin was deprecated.  が出ている問題の解決

▼該当改善事項
https://www.notion.so/growgroup/prepend-selector-postcss-postcss-plugin-was-deprecated-22a309c47e5941069a36e7ae0413db60

> prepend-selector-postcss: postcss.plugin was deprecated. Migration guide:
> https://evilmartians.com/chronicles/postcss-8-plugin-migration

### 実施したこと
プラグインを少し新しいpostcss-prefix-selectorに変更する。

# 2. `:root` が `#growp-editor-wrapper :root` に変換される問題の解決

▼該当改善事項
https://www.notion.so/growgroup/admin-style-css-letter-spacing-body-line-height-dcb831fe106d48afbce9405e6fd278b7

### 実施したこと
`:root` を変換対象から省きました。
ついでに bodyとhtmlの変換はともに #growp-editor-wrapper にしました
（元は　body #growp-editor-wrapper のように出ていたと思う）

修正後
![image](https://github.com/growgroup/gg-styleguide/assets/97862690/39052a32-6f07-42af-bd81-8b7785ab2d4a)

修正前
![image](https://github.com/growgroup/gg-styleguide/assets/97862690/a25e9b1f-616b-4c48-b162-272eb519a1de)

