### PR TITLE
[update] app.js : material-iconsの各種読み込みアップデート

### DIFF
--- a/app/assets/js/app.js
+++ b/app/assets/js/app.js
@@ -1,5 +1,5 @@
 //import "@fontsource/material-icons";
-//import "@fontsource/material-icons-rounded";
+// import "@fontsource/material-icons-round";
 import "@fontsource/material-icons-outlined";
 //import "@fontsource/material-icons-sharp";
 //import "@fontsource/material-icons-two-tone";

--- a/app/assets/scss/foundation/_webfont.scss
+++ b/app/assets/scss/foundation/_webfont.scss
@@ -3,3 +3,43 @@
   font-family: 'Roboto', sans-serif;
 }
 
+@mixin material-icon-default() {
+  font-weight: normal;
+  font-style: normal;
+  font-size: 24px;
+  line-height: 1;
+  letter-spacing: normal;
+  text-transform: none;
+  display: inline-block;
+  white-space: nowrap;
+  word-wrap: normal;
+  direction: ltr;
+  -webkit-font-feature-settings: 'liga';
+  -webkit-font-smoothing: antialiased;
+}
+
+.material-icons-round {
+  font-family: 'Material Icons Round';
+  @include material-icon-default();
+}
+
+.material-icons-outlined {
+  font-family: 'Material Icons Outlined';
+  @include material-icon-default();
+}
+
+.material-icons {
+  font-family: 'Material Icons';
+  @include material-icon-default();
+}
+
+.material-icons-sharp {
+  font-family: 'Material Icons Sharp';
+  @include material-icon-default();
+}
+
+.material-icons-two-tone {
+  font-family: 'Material Icons Two Tone';
+  @include material-icon-default();
+}
+

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,11 +9,11 @@
       "version": "2.0.0",
       "license": "ISC",
       "dependencies": {
-        "@fontsource/material-icons": "^4.5.4",
-        "@fontsource/material-icons-outlined": "^4.5.4",
-        "@fontsource/material-icons-rounded": "^4.5.4",
-        "@fontsource/material-icons-sharp": "^4.5.4",
-        "@fontsource/material-icons-two-tone": "^4.5.4",
+        "@fontsource/material-icons": "^5.0.5",
+        "@fontsource/material-icons-outlined": "^5.0.5",
+        "@fontsource/material-icons-round": "^5.0.5",
+        "@fontsource/material-icons-sharp": "^5.0.5",
+        "@fontsource/material-icons-two-tone": "^5.0.5",
         "@fontsource/noto-sans-jp": "^4.5.12",
         "@fontsource/roboto": "^4.5.8",
         "animejs": "^3.2.1",
@@ -1688,29 +1688,29 @@
       }
     },
     "node_modules/@fontsource/material-icons": {
-      "version": "4.5.4",
-      "resolved": "https://registry.npmjs.org/@fontsource/material-icons/-/material-icons-4.5.4.tgz",
-      "integrity": "sha512-YGmXkkEdu6EIgpFKNmB/nIXzZocwSmbI01Ninpmml8x8BT0M6RR++V1KqOfpzZ6Cw/FQ2/KYonQ3x4IY/4VRRA=="
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/@fontsource/material-icons/-/material-icons-5.0.5.tgz",
+      "integrity": "sha512-QXAKK1KSztfrGL/8yft2jd8OyZyiFywRHJHI8bLUy3NVPEgwW3O3/Lsr5kqhB+qRywNw8tjf3lr0qg9/g6UvGw=="
     },
     "node_modules/@fontsource/material-icons-outlined": {
-      "version": "4.5.4",
-      "resolved": "https://registry.npmjs.org/@fontsource/material-icons-outlined/-/material-icons-outlined-4.5.4.tgz",
-      "integrity": "sha512-2SLQe/pAlOzoE2Kd5cBxqTgI9U63hf3a7RrCF8GFvgPkYhF6WOcIzFzsLc1Fdf+UhcYS+Hgpp6o8peguwZGK9Q=="
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/@fontsource/material-icons-outlined/-/material-icons-outlined-5.0.5.tgz",
+      "integrity": "sha512-lrDrisQiLR1P+2Xc+QZtncX9ibzHTUoivwbd8eDsU/uPD01qV+Y7sqOiZWw4Ye6aJw9Tzi1vFgE8P318RbVFDA=="
     },
-    "node_modules/@fontsource/material-icons-rounded": {
-      "version": "4.5.4",
-      "resolved": "https://registry.npmjs.org/@fontsource/material-icons-rounded/-/material-icons-rounded-4.5.4.tgz",
-      "integrity": "sha512-zBrzaDzj//EJiuz9+yaL3uvYhqGcGXxewrwWy0fqHibOivNE9mlYtIjgibNRjEmS0eRXUu9h3TNmahlLwj3JvQ=="
+    "node_modules/@fontsource/material-icons-round": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/@fontsource/material-icons-round/-/material-icons-round-5.0.5.tgz",
+      "integrity": "sha512-H8HF4tO3xjJ9Z4vyBVn+RpG7lOtwyS1IGQ3t+OqyekuQ9jbuO7flb8WRDgPj4VUl8/oL04HNCTQfXmii1iGo2w=="
     },
     "node_modules/@fontsource/material-icons-sharp": {
-      "version": "4.5.4",
-      "resolved": "https://registry.npmjs.org/@fontsource/material-icons-sharp/-/material-icons-sharp-4.5.4.tgz",
-      "integrity": "sha512-bQX2ZQ9jjQXRggj412I0VZ2EE0NN3cABIEW3fNvhq6joWXz9aticIWjt6eKymyuz+X3NCinxaq40+xw9FpC0GA=="
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/@fontsource/material-icons-sharp/-/material-icons-sharp-5.0.5.tgz",
+      "integrity": "sha512-t4Y0RfIMNL1GA+64tE0Pj5dKlI7+fGqU2L2gdrf99kZBZ+3xbR/P7b+I8RkHca4JEBJ/i3pBIkOX4Tf8oYverw=="
     },
     "node_modules/@fontsource/material-icons-two-tone": {
-      "version": "4.5.4",
-      "resolved": "https://registry.npmjs.org/@fontsource/material-icons-two-tone/-/material-icons-two-tone-4.5.4.tgz",
-      "integrity": "sha512-w0/v62w5GIUe9xrpiF+7uR84K2NExE9f9Z/8gluCWtFT8pbSYoiilvqCd/kAe89pQj+2I4cxsKrRMkkZrYkz7w=="
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/@fontsource/material-icons-two-tone/-/material-icons-two-tone-5.0.5.tgz",
+      "integrity": "sha512-EUi70bNBtsu0BLFkV0JjOpvrkKOQMYzxmMRBAQA2tYig51ebmnbc6E6K0VpCvJNMUHSd9JxdjA0YhSdgMtN4+g=="
     },
     "node_modules/@fontsource/noto-sans-jp": {
       "version": "4.5.12",
@@ -15238,29 +15238,29 @@
       "dev": true
     },
     "@fontsource/material-icons": {
-      "version": "4.5.4",
-      "resolved": "https://registry.npmjs.org/@fontsource/material-icons/-/material-icons-4.5.4.tgz",
-      "integrity": "sha512-YGmXkkEdu6EIgpFKNmB/nIXzZocwSmbI01Ninpmml8x8BT0M6RR++V1KqOfpzZ6Cw/FQ2/KYonQ3x4IY/4VRRA=="
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/@fontsource/material-icons/-/material-icons-5.0.5.tgz",
+      "integrity": "sha512-QXAKK1KSztfrGL/8yft2jd8OyZyiFywRHJHI8bLUy3NVPEgwW3O3/Lsr5kqhB+qRywNw8tjf3lr0qg9/g6UvGw=="
     },
     "@fontsource/material-icons-outlined": {
-      "version": "4.5.4",
-      "resolved": "https://registry.npmjs.org/@fontsource/material-icons-outlined/-/material-icons-outlined-4.5.4.tgz",
-      "integrity": "sha512-2SLQe/pAlOzoE2Kd5cBxqTgI9U63hf3a7RrCF8GFvgPkYhF6WOcIzFzsLc1Fdf+UhcYS+Hgpp6o8peguwZGK9Q=="
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/@fontsource/material-icons-outlined/-/material-icons-outlined-5.0.5.tgz",
+      "integrity": "sha512-lrDrisQiLR1P+2Xc+QZtncX9ibzHTUoivwbd8eDsU/uPD01qV+Y7sqOiZWw4Ye6aJw9Tzi1vFgE8P318RbVFDA=="
     },
-    "@fontsource/material-icons-rounded": {
-      "version": "4.5.4",
-      "resolved": "https://registry.npmjs.org/@fontsource/material-icons-rounded/-/material-icons-rounded-4.5.4.tgz",
-      "integrity": "sha512-zBrzaDzj//EJiuz9+yaL3uvYhqGcGXxewrwWy0fqHibOivNE9mlYtIjgibNRjEmS0eRXUu9h3TNmahlLwj3JvQ=="
+    "@fontsource/material-icons-round": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/@fontsource/material-icons-round/-/material-icons-round-5.0.5.tgz",
+      "integrity": "sha512-H8HF4tO3xjJ9Z4vyBVn+RpG7lOtwyS1IGQ3t+OqyekuQ9jbuO7flb8WRDgPj4VUl8/oL04HNCTQfXmii1iGo2w=="
     },
     "@fontsource/material-icons-sharp": {
-      "version": "4.5.4",
-      "resolved": "https://registry.npmjs.org/@fontsource/material-icons-sharp/-/material-icons-sharp-4.5.4.tgz",
-      "integrity": "sha512-bQX2ZQ9jjQXRggj412I0VZ2EE0NN3cABIEW3fNvhq6joWXz9aticIWjt6eKymyuz+X3NCinxaq40+xw9FpC0GA=="
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/@fontsource/material-icons-sharp/-/material-icons-sharp-5.0.5.tgz",
+      "integrity": "sha512-t4Y0RfIMNL1GA+64tE0Pj5dKlI7+fGqU2L2gdrf99kZBZ+3xbR/P7b+I8RkHca4JEBJ/i3pBIkOX4Tf8oYverw=="
     },
     "@fontsource/material-icons-two-tone": {
-      "version": "4.5.4",
-      "resolved": "https://registry.npmjs.org/@fontsource/material-icons-two-tone/-/material-icons-two-tone-4.5.4.tgz",
-      "integrity": "sha512-w0/v62w5GIUe9xrpiF+7uR84K2NExE9f9Z/8gluCWtFT8pbSYoiilvqCd/kAe89pQj+2I4cxsKrRMkkZrYkz7w=="
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/@fontsource/material-icons-two-tone/-/material-icons-two-tone-5.0.5.tgz",
+      "integrity": "sha512-EUi70bNBtsu0BLFkV0JjOpvrkKOQMYzxmMRBAQA2tYig51ebmnbc6E6K0VpCvJNMUHSd9JxdjA0YhSdgMtN4+g=="
     },
     "@fontsource/noto-sans-jp": {
       "version": "4.5.12",

--- a/package.json
+++ b/package.json
@@ -64,11 +64,11 @@
     "webpack-cli": "^4.9.1"
   },
   "dependencies": {
-    "@fontsource/material-icons": "^4.5.4",
-    "@fontsource/material-icons-outlined": "^4.5.4",
-    "@fontsource/material-icons-rounded": "^4.5.4",
-    "@fontsource/material-icons-sharp": "^4.5.4",
-    "@fontsource/material-icons-two-tone": "^4.5.4",
+    "@fontsource/material-icons": "^5.0.5",
+    "@fontsource/material-icons-outlined": "^5.0.5",
+    "@fontsource/material-icons-round": "^5.0.5",
+    "@fontsource/material-icons-sharp": "^5.0.5",
+    "@fontsource/material-icons-two-tone": "^5.0.5",
     "@fontsource/noto-sans-jp": "^4.5.12",
     "@fontsource/roboto": "^4.5.8",
     "animejs": "^3.2.1",


### PR DESCRIPTION
▼該当改善事項
https://www.notion.so/growgroup/fontsource-material-icons-rounded-fontsource-material-icons-round-b47b94494c2b4262abf50f5c4f032db4

最新のMaterial Icons では Rounded は material-icons-round だが、
gg-styleguideはmaterial-icons-rounded だったので

- Fontsourceの最新版に差し替え v4 → v5
- Fontsourceの最新版 v5 だと .material-icons のようなclass名がCSSから消えるため、
webfont.scssにいったん記載して元通りの動作になるように調整

を行いました。

## 大きな変更点
フォントファミリーの呼び出し名が変わって最新のCDNと同じになります
https://fonts.googleapis.com/css2?family=Material+Icons+Round

### 元
```
font-family: 'Material Icons Rounded'
```


### 新
```
font-family: 'Material Icons Round';
```