### PR TITLE
[add] css-mqpacker-webpack-plugin : webpackでCSSのメディアクエリ出力をまとめる

### DIFF
--- a/app/assets/scss/foundation/_mqpacker.scss
+++ b/app/assets/scss/foundation/_mqpacker.scss
@@ -1,0 +1,38 @@
+/*
+メディアクエリ圧縮時に並べたいメディアクエリの順
+*/
+@include breakpoint(xxlarge up) {
+  /**/
+}
+
+@include breakpoint(xlarge down) {
+  /**/
+}
+
+@include breakpoint(xlarge up) {
+  /**/
+}
+
+@include breakpoint(large down) {
+  /**/
+}
+
+@include breakpoint(large up) {
+  /**/
+}
+
+@include breakpoint(medium down) {
+  /**/
+}
+
+@include breakpoint(medium up) {
+  /**/
+}
+
+@include breakpoint(small down) {
+  /**/
+}
+
+@include breakpoint(small only) {
+  /**/
+}

--- a/app/assets/scss/style.scss
+++ b/app/assets/scss/style.scss
@@ -21,6 +21,7 @@
 @import "foundation/_webfont";
 @import "foundation/_settings";
 @import "foundation/_mixin";
+@import "foundation/_mqpacker";
 @import "foundation/_normalize";
 @import "foundation/_forms";
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -42,6 +42,7 @@
         "core-js": "^3.21.1",
         "cpx": "^1.5.0",
         "css-loader": "^6.5.1",
+        "css-mqpacker-webpack-plugin": "^0.12.9",
         "fast-sass-loader": "^2.0.1",
         "fibers": "^5.0.0",
         "file-loader": "^6.2.0",
@@ -2833,6 +2834,24 @@
         "node": ">=8"
       }
     },
+    "node_modules/babel-loader/node_modules/schema-utils": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-2.7.1.tgz",
+      "integrity": "sha512-SHiNtMOUGWBQJwzISiVYKu82GiV4QYGePp3odlY1tuKO7gPtphAT5R/py0fA6xtbgLL/RvtJZnU9b8s0F1q0Xg==",
+      "dev": true,
+      "dependencies": {
+        "@types/json-schema": "^7.0.5",
+        "ajv": "^6.12.4",
+        "ajv-keywords": "^3.5.2"
+      },
+      "engines": {
+        "node": ">= 8.9.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      }
+    },
     "node_modules/babel-messages": {
       "version": "6.23.0",
       "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz",
@@ -4067,32 +4086,6 @@
         "webpack": "^5.1.0"
       }
     },
-    "node_modules/copy-webpack-plugin/node_modules/ajv": {
-      "version": "8.11.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.11.0.tgz",
-      "integrity": "sha512-wGgprdCvMalC0BztXvitD2hC04YffAvtsUn93JbGXYLAtCUO4xd17mCCZQxUOItiBwZvJScWo8NIvQMQ71rdpg==",
-      "dependencies": {
-        "fast-deep-equal": "^3.1.1",
-        "json-schema-traverse": "^1.0.0",
-        "require-from-string": "^2.0.2",
-        "uri-js": "^4.2.2"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/epoberezkin"
-      }
-    },
-    "node_modules/copy-webpack-plugin/node_modules/ajv-keywords": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-5.1.0.tgz",
-      "integrity": "sha512-YCS/JNFAUyr5vAuhk1DWm1CBxRHW9LbJ2ozWeemrIqpbsqKjHVxYPyi5GC0rjZIT5JxJ3virVTS8wk4i/Z+krw==",
-      "dependencies": {
-        "fast-deep-equal": "^3.1.3"
-      },
-      "peerDependencies": {
-        "ajv": "^8.8.2"
-      }
-    },
     "node_modules/copy-webpack-plugin/node_modules/glob-parent": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
@@ -4120,29 +4113,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/copy-webpack-plugin/node_modules/json-schema-traverse": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
-    },
-    "node_modules/copy-webpack-plugin/node_modules/schema-utils": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-4.0.0.tgz",
-      "integrity": "sha512-1edyXKgh6XnJsJSQ8mKWXnN/BVaIbFMLpouRUrXgVq7WYne5kw3MW7UPhO44uRXQSIpTSXoJbmrR2X0w9kUTyg==",
-      "dependencies": {
-        "@types/json-schema": "^7.0.9",
-        "ajv": "^8.8.0",
-        "ajv-formats": "^2.1.1",
-        "ajv-keywords": "^5.0.0"
-      },
-      "engines": {
-        "node": ">= 12.13.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/webpack"
       }
     },
     "node_modules/copy-webpack-plugin/node_modules/slash": {
@@ -4781,6 +4751,17 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/css-mqpacker-webpack-plugin": {
+      "version": "0.12.9",
+      "resolved": "https://registry.npmjs.org/css-mqpacker-webpack-plugin/-/css-mqpacker-webpack-plugin-0.12.9.tgz",
+      "integrity": "sha512-TPsp1skvtmpnLsMC2QwRPhogcc1kCpWEDp43L3pngXuybRUfH+Kmjo6NnSMYhKEFAF/RSh8TqiBZIUtV0liULQ==",
+      "dev": true,
+      "peerDependencies": {
+        "postcss": "^8.0.0",
+        "schema-utils": "^3.0.0 || ^4.0.0",
+        "webpack": "^4.0.0 || ^5.0.0"
       }
     },
     "node_modules/css-node-extract": {
@@ -8722,59 +8703,6 @@
         "webpack": "^5.0.0"
       }
     },
-    "node_modules/mini-css-extract-plugin/node_modules/ajv": {
-      "version": "8.8.2",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.8.2.tgz",
-      "integrity": "sha512-x9VuX+R/jcFj1DHo/fCp99esgGDWiHENrKxaCENuCxpoMCmAt/COCGVDwA7kleEpEzJjDnvh3yGoOuLu0Dtllw==",
-      "dev": true,
-      "dependencies": {
-        "fast-deep-equal": "^3.1.1",
-        "json-schema-traverse": "^1.0.0",
-        "require-from-string": "^2.0.2",
-        "uri-js": "^4.2.2"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/epoberezkin"
-      }
-    },
-    "node_modules/mini-css-extract-plugin/node_modules/ajv-keywords": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-5.1.0.tgz",
-      "integrity": "sha512-YCS/JNFAUyr5vAuhk1DWm1CBxRHW9LbJ2ozWeemrIqpbsqKjHVxYPyi5GC0rjZIT5JxJ3virVTS8wk4i/Z+krw==",
-      "dev": true,
-      "dependencies": {
-        "fast-deep-equal": "^3.1.3"
-      },
-      "peerDependencies": {
-        "ajv": "^8.8.2"
-      }
-    },
-    "node_modules/mini-css-extract-plugin/node_modules/json-schema-traverse": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-      "dev": true
-    },
-    "node_modules/mini-css-extract-plugin/node_modules/schema-utils": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-4.0.0.tgz",
-      "integrity": "sha512-1edyXKgh6XnJsJSQ8mKWXnN/BVaIbFMLpouRUrXgVq7WYne5kw3MW7UPhO44uRXQSIpTSXoJbmrR2X0w9kUTyg==",
-      "dev": true,
-      "dependencies": {
-        "@types/json-schema": "^7.0.9",
-        "ajv": "^8.8.0",
-        "ajv-formats": "^2.1.1",
-        "ajv-keywords": "^5.0.0"
-      },
-      "engines": {
-        "node": ">= 12.13.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/webpack"
-      }
-    },
     "node_modules/minimatch": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
@@ -11470,22 +11398,53 @@
       "dev": true
     },
     "node_modules/schema-utils": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-2.7.1.tgz",
-      "integrity": "sha512-SHiNtMOUGWBQJwzISiVYKu82GiV4QYGePp3odlY1tuKO7gPtphAT5R/py0fA6xtbgLL/RvtJZnU9b8s0F1q0Xg==",
-      "dev": true,
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-4.2.0.tgz",
+      "integrity": "sha512-L0jRsrPpjdckP3oPug3/VxNKt2trR8TcabrM6FOAAlvC/9Phcmm+cuAgTlxBqdBR1WJx7Naj9WHw+aOmheSVbw==",
       "dependencies": {
-        "@types/json-schema": "^7.0.5",
-        "ajv": "^6.12.4",
-        "ajv-keywords": "^3.5.2"
+        "@types/json-schema": "^7.0.9",
+        "ajv": "^8.9.0",
+        "ajv-formats": "^2.1.1",
+        "ajv-keywords": "^5.1.0"
       },
       "engines": {
-        "node": ">= 8.9.0"
+        "node": ">= 12.13.0"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/webpack"
       }
+    },
+    "node_modules/schema-utils/node_modules/ajv": {
+      "version": "8.12.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
+      "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/schema-utils/node_modules/ajv-keywords": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-5.1.0.tgz",
+      "integrity": "sha512-YCS/JNFAUyr5vAuhk1DWm1CBxRHW9LbJ2ozWeemrIqpbsqKjHVxYPyi5GC0rjZIT5JxJ3virVTS8wk4i/Z+krw==",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3"
+      },
+      "peerDependencies": {
+        "ajv": "^8.8.2"
+      }
+    },
+    "node_modules/schema-utils/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
     },
     "node_modules/scroll-hint": {
       "version": "1.2.5",
@@ -16197,6 +16156,17 @@
           "requires": {
             "find-up": "^4.0.0"
           }
+        },
+        "schema-utils": {
+          "version": "2.7.1",
+          "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-2.7.1.tgz",
+          "integrity": "sha512-SHiNtMOUGWBQJwzISiVYKu82GiV4QYGePp3odlY1tuKO7gPtphAT5R/py0fA6xtbgLL/RvtJZnU9b8s0F1q0Xg==",
+          "dev": true,
+          "requires": {
+            "@types/json-schema": "^7.0.5",
+            "ajv": "^6.12.4",
+            "ajv-keywords": "^3.5.2"
+          }
         }
       }
     },
@@ -17222,25 +17192,6 @@
         "serialize-javascript": "^6.0.0"
       },
       "dependencies": {
-        "ajv": {
-          "version": "8.11.0",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.11.0.tgz",
-          "integrity": "sha512-wGgprdCvMalC0BztXvitD2hC04YffAvtsUn93JbGXYLAtCUO4xd17mCCZQxUOItiBwZvJScWo8NIvQMQ71rdpg==",
-          "requires": {
-            "fast-deep-equal": "^3.1.1",
-            "json-schema-traverse": "^1.0.0",
-            "require-from-string": "^2.0.2",
-            "uri-js": "^4.2.2"
-          }
-        },
-        "ajv-keywords": {
-          "version": "5.1.0",
-          "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-5.1.0.tgz",
-          "integrity": "sha512-YCS/JNFAUyr5vAuhk1DWm1CBxRHW9LbJ2ozWeemrIqpbsqKjHVxYPyi5GC0rjZIT5JxJ3virVTS8wk4i/Z+krw==",
-          "requires": {
-            "fast-deep-equal": "^3.1.3"
-          }
-        },
         "glob-parent": {
           "version": "6.0.2",
           "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
@@ -17259,22 +17210,6 @@
             "ignore": "^5.2.0",
             "merge2": "^1.4.1",
             "slash": "^4.0.0"
-          }
-        },
-        "json-schema-traverse": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-          "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
-        },
-        "schema-utils": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-4.0.0.tgz",
-          "integrity": "sha512-1edyXKgh6XnJsJSQ8mKWXnN/BVaIbFMLpouRUrXgVq7WYne5kw3MW7UPhO44uRXQSIpTSXoJbmrR2X0w9kUTyg==",
-          "requires": {
-            "@types/json-schema": "^7.0.9",
-            "ajv": "^8.8.0",
-            "ajv-formats": "^2.1.1",
-            "ajv-keywords": "^5.0.0"
           }
         },
         "slash": {
@@ -17790,6 +17725,13 @@
           }
         }
       }
+    },
+    "css-mqpacker-webpack-plugin": {
+      "version": "0.12.9",
+      "resolved": "https://registry.npmjs.org/css-mqpacker-webpack-plugin/-/css-mqpacker-webpack-plugin-0.12.9.tgz",
+      "integrity": "sha512-TPsp1skvtmpnLsMC2QwRPhogcc1kCpWEDp43L3pngXuybRUfH+Kmjo6NnSMYhKEFAF/RSh8TqiBZIUtV0liULQ==",
+      "dev": true,
+      "requires": {}
     },
     "css-node-extract": {
       "version": "2.1.3",
@@ -20814,47 +20756,6 @@
       "dev": true,
       "requires": {
         "schema-utils": "^4.0.0"
-      },
-      "dependencies": {
-        "ajv": {
-          "version": "8.8.2",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.8.2.tgz",
-          "integrity": "sha512-x9VuX+R/jcFj1DHo/fCp99esgGDWiHENrKxaCENuCxpoMCmAt/COCGVDwA7kleEpEzJjDnvh3yGoOuLu0Dtllw==",
-          "dev": true,
-          "requires": {
-            "fast-deep-equal": "^3.1.1",
-            "json-schema-traverse": "^1.0.0",
-            "require-from-string": "^2.0.2",
-            "uri-js": "^4.2.2"
-          }
-        },
-        "ajv-keywords": {
-          "version": "5.1.0",
-          "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-5.1.0.tgz",
-          "integrity": "sha512-YCS/JNFAUyr5vAuhk1DWm1CBxRHW9LbJ2ozWeemrIqpbsqKjHVxYPyi5GC0rjZIT5JxJ3virVTS8wk4i/Z+krw==",
-          "dev": true,
-          "requires": {
-            "fast-deep-equal": "^3.1.3"
-          }
-        },
-        "json-schema-traverse": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-          "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-          "dev": true
-        },
-        "schema-utils": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-4.0.0.tgz",
-          "integrity": "sha512-1edyXKgh6XnJsJSQ8mKWXnN/BVaIbFMLpouRUrXgVq7WYne5kw3MW7UPhO44uRXQSIpTSXoJbmrR2X0w9kUTyg==",
-          "dev": true,
-          "requires": {
-            "@types/json-schema": "^7.0.9",
-            "ajv": "^8.8.0",
-            "ajv-formats": "^2.1.1",
-            "ajv-keywords": "^5.0.0"
-          }
-        }
       }
     },
     "minimatch": {
@@ -22921,14 +22822,40 @@
       }
     },
     "schema-utils": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-2.7.1.tgz",
-      "integrity": "sha512-SHiNtMOUGWBQJwzISiVYKu82GiV4QYGePp3odlY1tuKO7gPtphAT5R/py0fA6xtbgLL/RvtJZnU9b8s0F1q0Xg==",
-      "dev": true,
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-4.2.0.tgz",
+      "integrity": "sha512-L0jRsrPpjdckP3oPug3/VxNKt2trR8TcabrM6FOAAlvC/9Phcmm+cuAgTlxBqdBR1WJx7Naj9WHw+aOmheSVbw==",
       "requires": {
-        "@types/json-schema": "^7.0.5",
-        "ajv": "^6.12.4",
-        "ajv-keywords": "^3.5.2"
+        "@types/json-schema": "^7.0.9",
+        "ajv": "^8.9.0",
+        "ajv-formats": "^2.1.1",
+        "ajv-keywords": "^5.1.0"
+      },
+      "dependencies": {
+        "ajv": {
+          "version": "8.12.0",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
+          "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
+          "requires": {
+            "fast-deep-equal": "^3.1.1",
+            "json-schema-traverse": "^1.0.0",
+            "require-from-string": "^2.0.2",
+            "uri-js": "^4.2.2"
+          }
+        },
+        "ajv-keywords": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-5.1.0.tgz",
+          "integrity": "sha512-YCS/JNFAUyr5vAuhk1DWm1CBxRHW9LbJ2ozWeemrIqpbsqKjHVxYPyi5GC0rjZIT5JxJ3virVTS8wk4i/Z+krw==",
+          "requires": {
+            "fast-deep-equal": "^3.1.3"
+          }
+        },
+        "json-schema-traverse": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+          "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
+        }
       }
     },
     "scroll-hint": {

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "core-js": "^3.21.1",
     "cpx": "^1.5.0",
     "css-loader": "^6.5.1",
+    "css-mqpacker-webpack-plugin": "^0.12.9",
     "fast-sass-loader": "^2.0.1",
     "fibers": "^5.0.0",
     "file-loader": "^6.2.0",

--- a/webpack.style.config.babel.js
+++ b/webpack.style.config.babel.js
@@ -2,6 +2,7 @@ import webpack from 'webpack'
 import MiniCssExtractPlugin from 'mini-css-extract-plugin'
 import globImporter from 'node-sass-glob-importer';
 import path from 'path'
+const CssMqpackerPlugin = require('css-mqpacker-webpack-plugin');
 
 const BASE_DIR = "../../"
 
@@ -11,68 +12,75 @@ module.exports = (env, argv) => {
     const IS_DEVELOPMENT = argv.mode === 'development';
 
     const configs = {
-        mode: argv.mode,
-        context: __dirname + '/app/',
-        // cache: {
-        //     type: 'filesystem',
-        //     buildDependencies: {
-        //         config: [__filename]
-        //     }
-        // },
-        entry: {
-            style: __dirname + '/app/assets/js/style.js',
-        },
-        output: {
-            path: path.join(__dirname, 'dist/'),
-            filename: 'assets/js/[name].js',
-            publicPath: BASE_DIR,
-        },
-        watch: false,
-        module: {
-            rules: [
-                {
-                    test: /\.(scss|css)/,
-                    enforce: 'pre',
-                    loader: 'import-glob-loader'
-                },
-                {
-                    test: /\.(scss|css|sass)$/,
-                    include: [
-                        path.resolve(__dirname, 'app/assets/scss'),
-                    ],
-                    use: [
-                        {
-                            loader: MiniCssExtractPlugin.loader,
-                        },
-                        {
-                            loader: 'css-loader',
-                            options: {
-                                url: false
-                            }
-                        },
-                        {
-                            loader: 'sass-loader',
-                            options: {
-                                sassOptions: {
-                                    importer: globImporter()
-                                },
-                            }
-                        }
-                    ],
-                },
+      mode: argv.mode,
+      context: __dirname + '/app/',
+      // cache: {
+      //     type: 'filesystem',
+      //     buildDependencies: {
+      //         config: [__filename]
+      //     }
+      // },
+      entry: {
+        style: __dirname + '/app/assets/js/style.js',
+      },
+      output: {
+        path: path.join(__dirname, 'dist/'),
+        filename: 'assets/js/[name].js',
+        publicPath: BASE_DIR,
+      },
+      watch: false,
+      module: {
+        rules: [
+          {
+            test: /\.(scss|css)/,
+            enforce: 'pre',
+            loader: 'import-glob-loader'
+          },
+          {
+            test: /\.(scss|css|sass)$/,
+            include: [
+              path.resolve(__dirname, 'app/assets/scss'),
+            ],
+            use: [
+              {
+                loader: MiniCssExtractPlugin.loader,
+              },
+              {
+                loader: 'css-loader',
+                options: {
+                  url: false
+                }
+              },
+              {
+                loader: 'sass-loader',
+                options: {
+                  sassOptions: {
+                    importer: globImporter()
+                  },
+                }
+              }
+            ],
+          },
 
-            ]
-        },
-        plugins: [
-            new MiniCssExtractPlugin({
-                filename: "assets/css/[name].css",
-                chunkFilename: "[id].css"
-            })
+        ]
+      },
+      plugins: [
+        new MiniCssExtractPlugin({
+          filename: "assets/css/[name].css",
+          chunkFilename: "[id].css"
+        })
+      ],
+      optimization: {
+        //CSSのメディアクエリ部分を圧縮
+        minimize: true,
+        minimizer: [
+          new CssMqpackerPlugin(),
         ],
+      },
     }
     if (IS_DEVELOPMENT) {
-        // development であれば、devtool を追加
-        configs.devtool = 'cheap-module-source-map';
+      // development であれば、devtool を追加
+      configs.devtool = 'cheap-module-source-map';
     }
     return configs;
 }


### PR DESCRIPTION
▼改善事項
https://www.notion.so/growgroup/https-github-com-shoonia-css-mqpacker-webpack-plugin-CSS-c692ed1c5591474485bb2d848b2baf9d

▼導入したもの
https://github.com/shoonia/css-mqpacker-webpack-plugin

---


## 概要
https://github.com/shoonia/css-mqpacker-webpack-plugin を使ってメディアクエリの最終出力をまとめます。
CSSの行数が減る＝ファイルサイズが減ります。

![image](https://github.com/growgroup/gg-styleguide/assets/97862690/8066c00b-b977-4565-9ef2-42b8fdcc1743)

## くわしく
- webpack.style.config.babel.jsにて、css-mqpacker-webpack-plugin を実行しています
- 出力されるメディアクエリの順番は、CSS全体の中での出現順になります
- CSS出現順序を制御するため、foundation/_mqpacke.scss に主要なメディアクエリを記載してあります（PC→TB→SPの順で）

## 出力順序を調整したいときは？
### foundation/_mqpacke.scss
こちらの追加・順番変更で対応できます。
「ここだけまとめないでほしい」みたいなのはできないので、
まとまると困るようだったら以下の方法で処理を切りましょう。

## 処理を切りたいときは？
### webpack.style.config.babel.js

optimization の部分を全体的にコメントアウト
または、optimization内 minimize をfalseにしてください。

### style.scss
 `@import "foundation/_mqpacker";` をコメントアウトすると、無駄なゴミが出なくてよいです。