### PR TITLE
[update] material-icons : font-displayの値を変更できるように

### DIFF
--- a/app/assets/js/app.js
+++ b/app/assets/js/app.js
@@ -1,8 +1,5 @@
-//import "@fontsource/material-icons";
-// import "@fontsource/material-icons-round";
-import "@fontsource/material-icons-outlined";
-//import "@fontsource/material-icons-sharp";
-//import "@fontsource/material-icons-two-tone";
+//Material Icons
+import "../scss/font.scss";
 // 英語版作成時に本文書体で利用するためrobotoの400と700はコメントアウトしないでください
 import "@fontsource/roboto/400.css"
 import "@fontsource/roboto/700.css"

--- a/app/assets/scss/font.scss
+++ b/app/assets/scss/font.scss
@@ -1,0 +1,10 @@
+//@use "@fontsource/material-icons/scss/mixins" as material-icons;
+//@use "@fontsource/material-icons-round/scss/mixins" as material-icons;
+@use "@fontsource/material-icons-outlined/scss/mixins" as material-icons;
+//@use "@fontsource/material-icons-sharp/scss/mixins" as material-icons;
+//@use "@fontsource/material-icons-two-tone/scss/mixins" as material-icons;
+
+//font-displayの値を変更
+@include material-icons.faces(
+  $display: block,
+);

--- a/webpack.config.babel.js
+++ b/webpack.config.babel.js
@@ -54,7 +54,8 @@ module.exports = (env, argv) => {
                 {
                     test: /\.(scss|css|sass)$/,
                     include: [
-                        path.resolve(__dirname, 'node_modules'),
+                      path.resolve(__dirname, 'app/assets/scss/font.scss'),
+                      path.resolve(__dirname, 'node_modules'),
                     ],
                     use: [
                         {


### PR DESCRIPTION
▼改善事項
https://www.notion.so/growgroup/Material-icon-f926f64b2e8a456fa4636663ac337309

---

▼マニュアル更新済み
https://www.notion.so/growgroup/Web-90cc36baf41b4ba18b9d04dc1a2311c5?pvs=4#3a4483f8b6fd44d0b0759a88d92b7571

---

## 行ったこと
fontsourceの[Faces Mixin](https://fontsource.org/docs/getting-started/faces-mixin)を利用して、Material Iconsのfont-displayの値を変更できるようにしました。

出力例
```
/* material-icons-outlined-latin-400-normal */
@font-face {
  font-family: "Material Icons Outlined";
  font-style: normal;
  font-display: block;
  font-weight: 400;
  src: url(../../assets/fonts/material-icons-outlined-latin-400-normal.woff2) format("woff2"), url(../../assets/fonts/material-icons-outlined-latin-400-normal.woff) format("woff");
}
```

## もう少し詳しく
- Material Iconsの読み込みはfont.scssで行うようにしました（app.jsでの読み込みではFaces Mixinが使えないため）
- それに伴いapp.jsからMaterial Iconsの読み込みを消し、上記のfont.scssをインポートしました
- fontファイルのパスの解決のために、webpack.config.babel.jsも調整しました。

font.scssはこんな感じ。
@use ~~ as ~~ を使っているため、フォントを複数使用する場合は
コメントアウトを外すだけでは動きませんので注意。

```
//@use "@fontsource/material-icons/scss/mixins" as material-icons;
//@use "@fontsource/material-icons-round/scss/mixins" as material-icons;
@use "@fontsource/material-icons-outlined/scss/mixins" as material-icons;
//@use "@fontsource/material-icons-sharp/scss/mixins" as material-icons;
//@use "@fontsource/material-icons-two-tone/scss/mixins" as material-icons;

@include material-icons.faces(
  $display: block,
);
```