### PR TITLE
[update] anchor.js Safariでのフォーカス修正

### DIFF
--- a/app/assets/js/app/anchor.js
+++ b/app/assets/js/app/anchor.js
@@ -98,10 +98,9 @@ export default class Anchor {
           anchorTarget.css('outline', 'none');
         }
         anchorTarget.focus().promise().done(function () {
-          // フォーカスが完了した後に tabindex と スタイルを削除
+          // フォーカスが完了した後に tabindex を削除
           if (typeof anchorTabindex === 'undefined') {
             $(this).removeAttr('tabindex');
-            $(this).css('outline', '');
           }
         });
       }


### PR DESCRIPTION
▼対象改善事項
https://www.notion.so/growgroup/anchor-js-outline-css-Safari-outline-smooth-scroll-js-431fef62b50f4f84a3680556593315b2

▼関連プルリクエスト
https://github.com/growgroup/gg-styleguide/pull/97

## 対応したこと
https://github.com/growgroup/gg-styleguide/pull/97 で対応した anchor.jsのフォーカス位置調整で
Safari（Mac OS）の場合にフォーカスインジケーターが表示されてしまっていた問題の修正。

[smooth-scroll.js](https://github.com/cferdinandi/smooth-scroll/blob/master/src/core.js#L318-L325) を参考に
スクロール位置移動後も `outline:none` のスタイルを削除しないようにしました。
