### PR TITLE
[update] slidebar : メニューが閉じた状態でもtabでの操作やvoiceoverでのフォーカスが当たる問題の改善

### DIFF
--- a/app/assets/js/app/slidebar.js
+++ b/app/assets/js/app/slidebar.js
@@ -97,11 +97,49 @@ export default class Slidebar {
   open() {
     $("body").addClass('is-slidebar-active');
     this.isActive = true;
+    this.menu.removeAttr("inert");
+
+    this.focusToMenu();
   }
 
   close() {
     $("body").removeClass('is-slidebar-active');
     this.isActive = false;
+    this.menu.attr("inert", "true");
+
+    this.focusToOuterMenu();
+  }
+
+  focusToMenu() {
+    // フォーカスを移動する
+    if (document.activeElement !== this.menu) {
+      let anchorTabindex = this.menu.attr('tabindex');
+      if (typeof anchorTabindex === 'undefined') {
+        this.menu.attr('tabindex', '-1');
+        this.menu.css('outline', 'none');
+      }
+      this.menu.focus().promise().done(function () {
+        // フォーカスが完了した後に tabIndex を削除
+        if (typeof anchorTabindex === 'undefined') {
+          $(this).removeAttr('tabindex');
+        }
+      });
+    }
+  }
+
+  focusToOuterMenu() {
+    // フォーカスを移動する
+    let anchorTabindex = $("body").attr('tabindex');
+    if (typeof anchorTabindex === 'undefined') {
+      $("body").attr('tabindex', '-1');
+      $("body").css('outline', 'none');
+    }
+    $("body").focus().promise().done(function () {
+      // フォーカスが完了した後に tabIndex を削除
+      if (typeof anchorTabindex === 'undefined') {
+        $(this).removeAttr('tabindex');
+      }
+    });
   }
 
 }

--- a/app/inc/mixins/_slidebar.pug
+++ b/app/inc/mixins/_slidebar.pug
@@ -11,7 +11,7 @@ mixin c_slidebar
       span.c-slidebar-button__text.is-close CLOSE
 
 
-  .c-slidebar-menu.js-slidebar-menu.is-top-to-bottom
+  .c-slidebar-menu.js-slidebar-menu.is-top-to-bottom(inert="true")
     ul.c-slidebar-menu__list
       li.c-slidebar-menu__parent.js-accordion
         span.c-slidebar-menu__parent-link(data-accordion-title='menu-title') メニュー レベル1


### PR DESCRIPTION
▼関連改善事項
https://www.notion.so/growgroup/voice-over-slidebar-53fc0d8e25254637aca07b7d2694b899

## 対応したこと
slidebarが閉じた状態でも、
（スマホ幅のときに）tabキーでの操作またはiOSのVoiceOverでメニューにフォーカスが当たる問題の改善。

1. slidebarの初期状態にinert属性を付与
2. slidebarの開閉操作でinert属性をつけ外し
3. iOSのVoiceOverだとフォーカス中の要素の直前・直後の要素のinert属性の有無の変更を検知できていない気がするので
フォーカス位置を開閉操作に合わせて移動

## 気になること
`inert` は本来 `<div inert>` という形で付与するのが通例のはずだが、
pugやjQueryで値無しの指定方法が分からなかった。

### 対応ブラウザ
iOS 15.5以上。