### PR TITLE
[update] jQuery : 3.6.3 → 3.7.1

### DIFF
--- a/app/inc/foundation/_head.pug
+++ b/app/inc/foundation/_head.pug
@@ -52,7 +52,7 @@ html(lang="ja")
     //- ヘッダーに組み込むスクリプト
     block head_script
       | <script src="https://cdn.polyfill.io/v2/polyfill.min.js"></script>
-      | <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.6.3/jquery.min.js"></script>
+      | <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.7.1/jquery.min.js"></script>
 
   body(class!=current.bodyClass)
     //- スマホメニュー


### PR DESCRIPTION
WordPress 6.4でjQueryが3.7.1になる件の反映
https://core.trac.wordpress.org/ticket/59227

▼関連改善事項
https://www.notion.so/growgroup/WordPress6-3-jQuery-3-7-7378b5133dc1478fb7b8fc755653a359