### PR TITLE
[update] cssrules, pug.js:  `+l.hoge`したときのscssファイル生成の修正

### DIFF
--- a/app/inc/mixins/_cssrules.pug
+++ b/app/inc/mixins/_cssrules.pug
@@ -135,7 +135,7 @@ mixin l(el)
       attributes.class =  classlist.join(" ")
       cssrules.addComponent(temp_class)
       cssrules.layer = "l"
-      locals.locals.addComponentFile(temp_class)
+      locals.locals.addLayoutFile(temp_class)
     }
   #{el}(class!="l-" + temp_class )&attributes(attributes)
     block

--- a/build/pug.js
+++ b/build/pug.js
@@ -16,7 +16,17 @@ var pugconfig = {
         await fs.writeFileSync(componentPath, '.c-' + componentName + ' {\n\n}', {flag: "a"});
         return false;
       }
-    }
+    },
+    addLayoutFile: async function (componentName) {
+      var componentPath = __dirname + '/../app/assets/scss/layout/_' + componentName + '.scss';
+      try {
+        fs.statSync(componentPath);
+        return true;
+      } catch (err) {
+        await fs.writeFileSync(componentPath, '.l-' + componentName + ' {\n\n}', {flag: "a"});
+        return false;
+      }
+    },
   },
   filters: {
     // 改行をbrに置換


### PR DESCRIPTION
▼対象改善事項
https://www.notion.so/growgroup/l-pug-js-addComponentFile-ee9f7c88672046519de91b5eb5785e69

## やったこと
`+l.hoge`したときのscssファイル生成の修正。

- pug.js に記載のscssファイル生成処理が.c-hoge 専用だったため、.l-hoge の場合に期待される動作を追加
- `+l`のmixin側で呼び出している関数を↑↑で追加したものに変更

## テストしたこと
- `+l.hoge` で /layout/にscssファイルが生成されるか
- `+l.offer` 等、すでにscssがあるときは新規のファイル生成が起こらないか
- `+c.hoge` で/component/にscssファイルが生成されるか