### PR TITLE
[update] normalize.scss : 3.0.3ベースのものを8.0.1ベースに調整 + IE用の記述を除去

### DIFF
--- a/app/assets/scss/foundation/_normalize.scss
+++ b/app/assets/scss/foundation/_normalize.scss
@@ -10,11 +10,14 @@
 }
 
 /**
+ * 1. Correct the line height in all browsers.
  * 2. Prevent adjustments of font size after orientation changes in iOS.
  */
+
 html {
   font-size: $font-base-size;
   font-family: $font-base-family;
+  line-height: 1.15; /* 1 */
   -webkit-text-size-adjust: 100%; /* 2 */
 }
 

--- a/app/assets/scss/foundation/_normalize.scss
+++ b/app/assets/scss/foundation/_normalize.scss
@@ -1,33 +1,28 @@
-/*! normalize.css v3.0.3 | MIT License | github.com/necolas/normalize.css */
-
-/**
- * 1. Set default font family to sans-serif.
- * 2. Prevent iOS and IE text size adjust after device orientation change,
- *    without disabling user zoom.
- */
+/*! normalize.css v8.0.1 | MIT License | github.com/necolas/normalize.css */
 
 // # CSS 変数の定義
-:root{
-  --letter-spacing:#{$font-base-letter-spacing};
+:root {
+  --letter-spacing: #{$font-base-letter-spacing};
 
   //スマホのとき値を変更したい場合は以下に
-  @include breakpoint(small down){
+  @include breakpoint(small down) {
   }
 }
 
-
+/**
+ * 2. Prevent adjustments of font size after orientation changes in iOS.
+ */
 html {
   font-size: $font-base-size;
   font-family: $font-base-family;
-  -ms-text-size-adjust: 100%;
-  -webkit-text-size-adjust: 100%;
+  -webkit-text-size-adjust: 100%; /* 2 */
 }
 
 * {
   -webkit-box-sizing: border-box;
   -moz-box-sizing: border-box;
   box-sizing: border-box;
-  letter-spacing: var(--letter-spacing);//全要素へ基準のletter-spacingを当てる
+  letter-spacing: var(--letter-spacing); //全要素へ基準のletter-spacingを当てる
 }
 
 /**
@@ -56,7 +51,7 @@ body {
   }
 
   @include breakpoint(small only) {
-    font-size:  $font-base-size*0.875;
+    font-size: $font-base-size*0.875;
   }
 
   //&.home {
@@ -74,6 +69,7 @@ body {
     }
   }
 }
+
 /* chrome opera /
 /! autoprefixer: ignore next */
 @media screen and (-webkit-min-device-pixel-ratio: 0) and (min-resolution: .001dpcm) {
@@ -81,74 +77,12 @@ body {
     image-rendering: -webkit-optimize-contrast;
   }
 }
-/* HTML5 display definitions
-   ========================================================================== */
 
-/**
- * Correct `block` display not defined for any HTML5 element in IE 8/9.
- * Correct `block` display not defined for `details` or `summary` in IE 10/11
- * and Firefox.
- * Correct `block` display not defined for `main` in IE 11.
- */
-
-article,
-aside,
-details,
-figcaption,
-figure,
-footer,
-header,
-hgroup,
-main,
-menu,
-nav,
-section,
-summary {
-  display: block;
-}
-
-/**
- * 1. Correct `inline-block` display not defined in IE 8/9.
- * 2. Normalize vertical alignment of `progress` in Chrome, Firefox, and Opera.
- */
-
-audio,
-canvas,
-progress,
-video {
-  display: inline-block; /* 1 */
-  vertical-align: baseline; /* 2 */
-}
-
-/**
- * Prevent modern browsers from displaying `audio` without controls.
- * Remove excess height in iOS 5 devices.
- */
-
-audio:not([controls]) {
-  display: none;
-  height: 0;
-}
-
-/**
- * Address `[hidden]` styling not present in IE 8/9/10.
- * Hide the `template` element in IE 8/9/10/11, Safari, and Firefox < 22.
- */
-
-[hidden],
-template {
-  display: none;
-}
 
 /* Links
    ========================================================================== */
 
-/**
- * Remove the gray background color from active links in IE 10.
- */
-
 a {
-  background-color: transparent;
   text-decoration: none;
 }
 
@@ -231,13 +165,6 @@ h6 {
   margin-bottom: 0.5rem;
 }
 
-/**
- * Address styling not present in IE 8/9.
- */
-mark {
-  background: #ff0;
-  color: #000;
-}
 
 /**
  * Address inconsistent and variable font size in all browsers.
@@ -270,35 +197,15 @@ sub {
 /* Embedded content
    ========================================================================== */
 
-/**
- * Remove border when inside `a` element in IE 8/9/10.
- */
-
 img {
-  border: 0;
   max-width: 100%;
   height: auto;
   vertical-align: top;
 }
 
-/**
- * Correct overflow not hidden in IE 9/10/11.
- */
-
-svg:not(:root) {
-  overflow: hidden;
-}
-
 /* Grouping content
    ========================================================================== */
 
-/**
- * Address margin not present in IE 8/9 and Safari.
- */
-
-figure {
-  margin: 0;
-}
 
 /**
  * Address differences between Firefox and other browsers.
@@ -354,143 +261,108 @@ textarea {
   margin: 0; /* 3 */
 }
 
-/**
- * Address `overflow` set to `hidden` in IE 8/9/10/11.
- */
-
-button {
-  overflow: visible;
-}
 
 /**
- * Address inconsistent `text-transform` inheritance for `button` and `select`.
- * All other form control elements do not inherit `text-transform` values.
- * Correct `button` style inheritance in Firefox, IE 8/9/10/11, and Opera.
- * Correct `select` style inheritance in Firefox.
+ * Remove the inheritance of text transform in Edge, Firefox, and IE.
+ * 1. Remove the inheritance of text transform in Firefox.
  */
-
 button,
-select {
+select { /* 1 */
   text-transform: none;
 }
 
+
 /**
- * 1. Avoid the WebKit bug in Android 4.0.* where (2) destroys native `audio`
- *    and `video` controls.
- * 2. Correct inability to style clickable `input` types in iOS.
- * 3. Improve usability and consistency of cursor style between image-type
- *    `input` and others.
+ * Correct the inability to style clickable types in iOS and Safari.
  */
 
 button,
-input[type="button"], /* 1 */
-input[type="reset"],
-input[type="submit"] {
-  -webkit-appearance: button; /* 2 */
-  cursor: pointer; /* 3 */
+[type="button"],
+[type="reset"],
+[type="submit"] {
+  -webkit-appearance: button;
+  cursor: pointer;
 }
 
-/**
- * Re-set default cursor for disabled elements.
- */
-
-button[disabled],
-input[disabled] {
-  cursor: default;
-}
 
 /**
- * Remove inner padding and border in Firefox 4+.
+ * Remove the inner border and padding in Firefox.
  */
 
 button::-moz-focus-inner,
-input::-moz-focus-inner {
-  border: 0;
+[type="button"]::-moz-focus-inner,
+[type="reset"]::-moz-focus-inner,
+[type="submit"]::-moz-focus-inner {
+  border-style: none;
   padding: 0;
 }
 
 /**
- * Address Firefox 4+ setting `line-height` on `input` using `!important` in
- * the UA stylesheet.
+ * Restore the focus styles unset by the previous rule.
  */
 
-input {
-  line-height: normal;
+button:-moz-focusring,
+[type="button"]:-moz-focusring,
+[type="reset"]:-moz-focusring,
+[type="submit"]:-moz-focusring {
+  outline: 1px dotted ButtonText;
 }
 
 /**
- * It's recommended that you don't attempt to style these elements.
- * Firefox's implementation doesn't respect box-sizing, padding, or width.
- *
- * 1. Address box sizing set to `content-box` in IE 8/9/10.
- * 2. Remove excess padding in IE 8/9/10.
+ * Correct the padding in Firefox.
  */
 
-input[type="checkbox"],
-input[type="radio"] {
-  box-sizing: border-box; /* 1 */
-  padding: 0; /* 2 */
+fieldset {
+  padding: 0.35em 0.75em 0.625em;
 }
 
 /**
- * Fix the cursor style for Chrome's increment/decrement buttons. For certain
- * `font-size` values of the `input`, it causes the cursor style of the
- * decrement button to change from `default` to `text`.
+ * Correct the cursor style of increment and decrement buttons in Chrome.
  */
 
-input[type="number"]::-webkit-inner-spin-button,
-input[type="number"]::-webkit-outer-spin-button {
+[type="number"]::-webkit-inner-spin-button,
+[type="number"]::-webkit-outer-spin-button {
   height: auto;
 }
 
 /**
- * 1. Address `appearance` set to `searchfield` in Safari and Chrome.
- * 2. Address `box-sizing` set to `border-box` in Safari and Chrome.
+ * 1. Correct the odd appearance in Chrome and Safari.
+ * 2. Correct the outline style in Safari.
  */
 
-input[type="search"] {
+[type="search"] {
   -webkit-appearance: textfield; /* 1 */
-  box-sizing: content-box; /* 2 */
+  outline-offset: -2px; /* 2 */
 }
 
 /**
- * Remove inner padding and search cancel button in Safari and Chrome on OS X.
- * Safari (but not Chrome) clips the cancel button when the search input has
- * padding (and `textfield` appearance).
+ * Remove the inner padding in Chrome and Safari on macOS.
  */
 
-input[type="search"]::-webkit-search-cancel-button,
-input[type="search"]::-webkit-search-decoration {
+[type="search"]::-webkit-search-decoration {
   -webkit-appearance: none;
 }
 
+
 /**
- * Define consistent border, margin, and padding.
+ * 1. Correct the inability to style clickable types in iOS and Safari.
+ * 2. Change font properties to `inherit` in Safari.
  */
 
-fieldset {
-  border: 1px solid #c0c0c0;
-  margin: 0 2px;
-  padding: 0.35em 0.625em 0.75em;
+::-webkit-file-upload-button {
+  -webkit-appearance: button; /* 1 */
+  font: inherit; /* 2 */
 }
 
 /**
- * 1. Correct `color` not being inherited in IE 8/9/10/11.
- * 2. Remove padding so people aren't caught out if they zero out fieldsets.
+ * 3. Remove the padding so developers are not caught out when they zero out
+ *    `fieldset` elements in all browsers.
  */
 
 legend {
-  border: 0; /* 1 */
-  padding: 0; /* 2 */
+  padding: 0; /* 3 */
 }
 
-/**
- * Remove default vertical scrollbar in IE 8/9/10/11.
- */
-
-textarea {
-  overflow: auto;
-}
 
 /**
  * Don't inherit the `font-weight` (applied by a rule above).
@@ -547,9 +419,10 @@ li {
 }
 
 
-a{
+a {
   @include transition();
-  &:hover{
+
+  &:hover {
     @include transition()
   }
 }


### PR DESCRIPTION
▼関連改善事項
https://www.notion.so/growgroup/normalize-css-beb73ea1e88f42d28166a1ac268fa579

## 確認してほしいこと
normalize.scssが nomalize.cssに追記しまくったものになっておりそのまま置き換えができないため、
歴史的背景として消してはダメなものが消えていたら教えてください。

## 対応したこと
### 1. normalize.cssのベースのバージョンを上げる

元：8年くらい前のもの
https://github.com/necolas/normalize.css/blob/3.0.3/normalize.css
↓
最新：5年くらい前のもの
https://github.com/necolas/normalize.css/blob/8.0.1/normalize.css

### 2. IE10・IE11用の記述はなるべくけす
例えば以下のような部分
```

/**
 * Render the `main` element consistently in IE.
 */

main {
  display: block;
}
```

### ついでに：セレクタと { の間に半角スペース入れるなどの部分の調整

## 結果得られるもの
WordPress実装時に以下のようなCSSがブロックエディタ内のCSSを打ち消しすぎることを防ぐ

```
#growp-editor-wrapper article,#growp-editor-wrapper aside,#growp-editor-wrapper details,#growp-editor-wrapper figcaption,#growp-editor-wrapper figure,#growp-editor-wrapper footer,#growp-editor-wrapper header,#growp-editor-wrapper hgroup,#growp-editor-wrapper main,#growp-editor-wrapper menu,#growp-editor-wrapper nav,#growp-editor-wrapper section,#growp-editor-wrapper summary{display:block}
```