### PR TITLE
slidebarリサイズ時にスクロールできない原因を解決

### DIFF
--- a/app/assets/js/app/slidebar.js
+++ b/app/assets/js/app/slidebar.js
@@ -151,7 +151,7 @@ export default class Slidebar {
   setupResizeObserver() {
     const resizeObserver = new ResizeObserver(entries => {
       for (const entry of entries) {
-        if (entry.contentRect.width >= 750) {
+        if (entry.contentRect.width >= 9g50) {
           document.body.classList.remove("is-slidebar-active");
           this.isActive = false;
           this.menu.attr("inert", "true");

--- a/app/assets/js/app/slidebar.js
+++ b/app/assets/js/app/slidebar.js
@@ -45,6 +45,7 @@ export default class Slidebar {
     this.isActive = false;
 
     this.init();
+    this.setupResizeObserver(); // ResizeObserverをセットアップ
   }
 
   /**
@@ -72,6 +73,11 @@ export default class Slidebar {
       e.preventDefault();
       self.toggle();
     });
+
+    // ページ内リンク時の挙動
+    // $(".c-slidebar-menu a[href*=\"#\"]").on('click', function (e) {
+    //   self.close();
+    // });
   }
 
   /**
@@ -140,6 +146,21 @@ export default class Slidebar {
         $(this).removeAttr('tabindex');
       }
     });
+  }
+
+  setupResizeObserver() {
+    const resizeObserver = new ResizeObserver(entries => {
+      for (const entry of entries) {
+        if (entry.contentRect.width >= 750) {
+          document.body.classList.remove("is-slidebar-active");
+          this.isActive = false;
+          this.menu.attr("inert", "true");
+        }
+      }
+    });
+
+    // 監視対象となる要素を設定
+    resizeObserver.observe(document.body);
   }
 
 }

--- a/app/assets/js/scripts.js
+++ b/app/assets/js/scripts.js
@@ -61,6 +61,7 @@
     }
   };
 
+  //　キャッシュ対策
   growApp.prototype.backCache = function () {
     window.onpageshow = function(event) {
       if (event.persisted) {
@@ -69,6 +70,7 @@
     }
   }
 
+  // Cookie
   growApp.prototype.showCookie = function () {
     const cookie = $(".js-cookie");
     const cookieId = $("#cookie");
@@ -99,11 +101,13 @@
     }
   }
 
+
   $(function () {
     var app = new growApp();
     app.myCode();
     app.modalContents();
     app.enterAnimation();
     app.showCookie();
+    app.backCache();
   });
 })(jQuery);


### PR DESCRIPTION
https://www.notion.so/growgroup/PC-b40130adbaf14fecb93acf551b0e0499

スマホメニューを開いた後、PC表示に戻すとスクロールできない