### PR TITLE
$font-html-size の追加＋関連mixinの整理

### DIFF
--- a/app/assets/scss/foundation/_mixin.scss
+++ b/app/assets/scss/foundation/_mixin.scss
@@ -36,7 +36,7 @@
   $count: length($values);
 
   @if $base == null {
-    $base: $font-base-size;
+    $base: $font-html-size;
   }
 
   @if unit($base) == '%' {

--- a/app/assets/scss/foundation/_mixin.scss
+++ b/app/assets/scss/foundation/_mixin.scss
@@ -408,41 +408,6 @@
   -webkit-line-clamp: $clamp;
 }
 
-// 行数制限
-@mixin row-limit($font-size-base: $font-base-size, $font-size-base-sp: $font-base-size*0.875, $line-height-computed: 1.7, $lines-to-show: 2) {
-  overflow: hidden;
-  width: 100%;
-  span {
-    display: block;
-    font-size: $font-size-base;
-    height: $font-size-base * $line-height-computed * $lines-to-show;
-    line-height: $line-height-computed;
-    position: relative;
-    @include breakpoint(small only) {
-      font-size: $font-size-base-sp;
-      height: $font-size-base-sp * $line-height-computed * $lines-to-show;
-    }
-    &::before,
-    &::after {
-      background: $color-white;
-      position: absolute;
-    }
-    &::before {
-      content: "...";
-      top: $font-size-base * $line-height-computed * ($lines-to-show - 1);
-      right: 0;
-      bottom: 0;
-      @include breakpoint(small only) {
-        top: $font-size-base-sp * $line-height-computed * ($lines-to-show - 1);
-      }
-    }
-    &::after {
-      content: "";
-      height: 100%;
-      width: 100%;
-    }
-  }
-}
 
 @mixin bg-img(){
   position: absolute;

--- a/app/assets/scss/foundation/_normalize.scss
+++ b/app/assets/scss/foundation/_normalize.scss
@@ -15,7 +15,7 @@
  */
 
 html {
-  font-size: $font-base-size;
+  font-size: $font-html-size;
   font-family: $font-base-family;
   line-height: 1.15; /* 1 */
   -webkit-text-size-adjust: 100%; /* 2 */

--- a/app/assets/scss/foundation/_settings.scss
+++ b/app/assets/scss/foundation/_settings.scss
@@ -42,9 +42,11 @@ $grid-column-responsive-gutter: (// カラムとカラムの間隔
 );
 
 // # 3. font
-$font-base-size: 16px !default; // body のフォントサイズ
-$font-base-line-height: 1.75 !default; // body のフォントサイズ
-$font-base-letter-spacing: 0.1em !default; // body のフォントサイズ
+$font-html-size: 16px !default; // （変更しない）html のフォントサイズ
+
+$font-base-size: 15px !default; // body のフォントサイズ（本文のフォントサイズ）
+$font-base-line-height: 1.75 !default; // body の行間（本文の行間）
+$font-base-letter-spacing: 0.05em !default; // 基本の文字間隔
 $font-base-color: #333 !default; // body のフォントカラー
 $font-base-family: 'Noto Sans JP', sans-serif !default; // フォントファミリー
 $font-base-weight: normal !default; // フォント幅


### PR DESCRIPTION
▼関連改善事項
https://www.notion.so/growgroup/HTML-e6286b77fb4f424e85c0296f9a885457

# 発生していた問題
本文フォントサイズが16px以外の案件で、以下を変更すると`<html>`タグのfont-sizeが変更になるが
`$font-base-size: 16px !default; // body のフォントサイズ`

WordPress組み込み後にブロックエディタ（非iframe）の管理画面上では
`<html>`タグのfont-sizeが16pxのままとなり、サイズの計算がおかしくなる問題

# 対応
以下の部分を変更しても、`<html>`タグのfont-sizeが変更にならないようにする
`$font-base-size: 16px !default; // body のフォントサイズ`

# 補足
## 追加した変数について
追加した `$font-html-size` については値を変更しないでください。
この変数は `rem-calc()` のmixinでの計算式にも利用しています。

## 関連のmixinの整理について
`$font-base-size` を利用しているmixinに `row-limit()` がありましたが、
`line-clamp()`の登場で`row-limit`の利用は非推奨になっていましたので削除しました。
