### PR TITLE
[update] _base.pug : main.l-mainを各ページではなく base.pug 側で書くように変更

### DIFF
--- a/app/blocks/index.pug
+++ b/app/blocks/index.pug
@@ -7,680 +7,680 @@ block append config
   - current.path = "/blocks/" // ページのpath
   - current.depth = 2 // ページの階層
 
+
+block page_header
+  +l_page_header({
+    image: "img-page-header-format.jpg",
+    title: "ブロック編集ページ",
+    subtitle: "BLOCK"
+  })
+  +c_breadcrumb()
+
 block body
-  // メインビジュアル
-  +l_page_header("img-page-header-format.jpg","ブロック編集ページ","BLOCK")
-  +c.breadcrumb
-    .l-container
-      +e.inner
-        span: +a("/") ホーム
-        span >
-        span ブロック編集ページ
-  main.l-main
-    section.l-section.is-lg
-      .l-post-content
-        section.l-block.l-block__margin-large
-          .l-container
-            div.u-mbs.is-bottom
-              h1 見出しレベル1
+  section.l-section.is-lg
+    .l-post-content
+      section.l-block.l-block__margin-large
+        .l-container
+          div.u-mbs.is-bottom
+            h1 見出しレベル1
 
-            div.u-mbs.is-bottom
-              h2 見出しレベル2見出しレベル2
+          div.u-mbs.is-bottom
+            h2 見出しレベル2見出しレベル2
 
-            // -> h2見出し
-            div.u-mbs.is-bottom
-              h3 見出しレベル3見出しレベル3見出しレベル3
+          // -> h2見出し
+          div.u-mbs.is-bottom
+            h3 見出しレベル3見出しレベル3見出しレベル3
 
-            // -> h3見出し
-            div.u-mbs.is-bottom
-              h4 見出しレベル4見出しレベル4見出しレベル4見出しレベ
+          // -> h3見出し
+          div.u-mbs.is-bottom
+            h4 見出しレベル4見出しレベル4見出しレベル4見出しレベ
 
 
-            // -> h4見出し
-            div.u-mbs.is-bottom
-              h5 見出しレベル5見出しレベル5見出しレベル5見出しレベ
+          // -> h4見出し
+          div.u-mbs.is-bottom
+            h5 見出しレベル5見出しレベル5見出しレベル5見出しレベ
 
-            // -> h5見出し
-            div.u-mbs.is-bottom
-              h6 見出しレベル6見出しレベル6見出しレベル6見出しレベ
+          // -> h5見出し
+          div.u-mbs.is-bottom
+            h6 見出しレベル6見出しレベル6見出しレベル6見出しレベ
 
-            // 基本テキストのスタイル
-            div.u-mbs.is-bottom
-              +a("#") リンクテキスト
+          // 基本テキストのスタイル
+          div.u-mbs.is-bottom
+            +a("#") リンクテキスト
 
-            div.u-mbs.is-bottom
-              strong 強調テキスト
+          div.u-mbs.is-bottom
+            strong 強調テキスト
 
-            div.u-mbs.is-bottom
-              small 縮小テキスト縮小テキスト縮小テキスト縮小テキスト縮小テキスト縮小テキスト縮小テキスト
+          div.u-mbs.is-bottom
+            small 縮小テキスト縮小テキスト縮小テキスト縮小テキスト縮小テキスト縮小テキスト縮小テキスト
 
-            // 引用テキスト
-            div.u-mbs.is-bottom
-              blockquote.c-blockquote これは引用テキストです。これは引用テキストです。これは引用テキストです。<br>これは引用テキストです。これは引用テキストです。これは引用テキストです。
+          // 引用テキスト
+          div.u-mbs.is-bottom
+            blockquote.c-blockquote これは引用テキストです。これは引用テキストです。これは引用テキストです。<br>これは引用テキストです。これは引用テキストです。これは引用テキストです。
 
-            // リスト
-            div.u-mbs.is-bottom
-              ul
-                li 箇条書きリスト1
-                li 箇条書きリスト2
-                  ul
-                    li 箇条書きリスト2の子要素
-                    li 箇条書きリスト2の子要素
-                li 箇条書きリスト3
+          // リスト
+          div.u-mbs.is-bottom
+            ul
+              li 箇条書きリスト1
+              li 箇条書きリスト2
+                ul
+                  li 箇条書きリスト2の子要素
+                  li 箇条書きリスト2の子要素
+              li 箇条書きリスト3
 
-            // 数字付きリスト
-            div.u-mbs.is-bottom
-              ol
-                li 数字付きリスト1
-                li 数字付きリスト2
-                  ol
-                    li 数字付きリスト2の子要素
-                    li 数字付きリスト2の子要素
-                li 数字付きリスト3
+          // 数字付きリスト
+          div.u-mbs.is-bottom
+            ol
+              li 数字付きリスト1
+              li 数字付きリスト2
+                ol
+                  li 数字付きリスト2の子要素
+                  li 数字付きリスト2の子要素
+              li 数字付きリスト3
 
-            // テーブル
-            div.u-mbs.is-bottom
-              table
-                tbody
-                  tr
-                    th thテキスト
-                    td tdテキストテキストテキストテキストテキスト
-                  tr
-                    th thテキスト
-                    td tdテキストテキストテキストテキストテキスト
-                  tr
-                    th thテキスト
-                    td tdテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキスト
-
-
-        section#block-2.l-block.l-block-capsul-nav.l-block__margin-normal(style="")
-          .l-container
-            .c-capsul-nav
-              a.c-capsul-nav__block.c-button(target="_self" href=".") ページリンク
-              a.c-capsul-nav__block.c-button(target="_blank" href="https://yahoo.co.jp") YAHOO
-              a.c-capsul-nav__block.c-button.is-pagelink.js-anchor(target="_self" href="#flow") ページ内リンク
+          // テーブル
+          div.u-mbs.is-bottom
+            table
+              tbody
+                tr
+                  th thテキスト
+                  td tdテキストテキストテキストテキストテキスト
+                tr
+                  th thテキスト
+                  td tdテキストテキストテキストテキストテキスト
+                tr
+                  th thテキスト
+                  td tdテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキスト
 
 
-        section#flow.l-block.l-block-box-number.l-block__margin-normal(style="")
-          .l-container
-            .c-box-number
-              .c-box-number__block
-                .c-box-number__head
-                  .c-box-number__number
-                    small STEP
-                    span 01
-                .c-box-number__content
-                  .c-box-number__title
-                    | 手順
-                  .c-box-number__text
-                    | テキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキスト
-                    br
-                    | テキストテキストテキストテキストテキストテキスト
-              .c-box-number__block
-                .c-box-number__head
-                  .c-box-number__number
-                    small STEP
-                    span 02
-                .c-box-number__content
-                  .c-box-number__title
-                    | 手順
-                  .c-box-number__text
-                    | テキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキスト
-                    br
-                    | テキストテキストテキストテキストテキストテキスト
-              .c-box-number__block
-                .c-box-number__head
-                  .c-box-number__number
-                    small STEP
-                    span 03
-                .c-box-number__content
-                  .c-box-number__title
-                    | 手順
-                  .c-box-number__text
-                    | テキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキスト
-                    br
-                    | テキストテキストテキストテキストテキストテキスト
-              .c-box-number__block
-                .c-box-number__head
-                  .c-box-number__number
-                    small STEP
-                    span 04
-                .c-box-number__content
-                  .c-box-number__title
-                    | 手順
-                  .c-box-number__text
-                    | テキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキスト
-                    br
-                    | テキストテキストテキストテキストテキストテキスト
-              .c-box-number__block
-                .c-box-number__head
-                  .c-box-number__number
-                    small STEP
-                    span 05
-                .c-box-number__content
-                  .c-box-number__title
-                    | 手順
-                  .c-box-number__text
-                    | テキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキスト
-                    br
-                    | テキストテキストテキストテキストテキストテキスト
+      section#block-2.l-block.l-block-capsul-nav.l-block__margin-normal(style="")
+        .l-container
+          .c-capsul-nav
+            a.c-capsul-nav__block.c-button(target="_self" href=".") ページリンク
+            a.c-capsul-nav__block.c-button(target="_blank" href="https://yahoo.co.jp") YAHOO
+            a.c-capsul-nav__block.c-button.is-pagelink.js-anchor(target="_self" href="#flow") ページ内リンク
 
 
-        section#block-4.l-block.l-block-hero-block.l-block__margin-normal(style="")
-          .c-hero-block
-            .c-hero-block__block
-              .c-hero-block__image
-                img(src="http://growp.grgr.red/wp-content/uploads/2020/07/img-number-cards-01.jpg" alt="")
-              .l-container
-                .c-hero-block__content
-                  .c-hero-block__title.c-heading.is-sm.is-bottom
-                    | タイトルテキストがここに入ります。
-                  p
-                    | テキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキスト
-                  .c-hero-block__button
-                    a.c-button.is-sm(href="#" target="_self")
-                      | リンクテキスト
-            .c-hero-block__block
-              .c-hero-block__image
-                img(src="http://growp.grgr.red/wp-content/uploads/2020/07/img-number-cards-01.jpg" alt="")
-              .l-container
-                .c-hero-block__content
-                  .c-hero-block__title.c-heading.is-sm.is-bottom
-                    | タイトルテキストがここに入ります。
-                  p
-                    | テキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキスト
-                  .c-hero-block__button
-                    a.c-button.is-sm(href="#" target="_self")
-                      | リンクテキスト
-            .c-hero-block__block
-              .c-hero-block__image
-                img(src="http://growp.grgr.red/wp-content/uploads/2020/07/img-number-cards-01.jpg" alt="")
-              .l-container
-                .c-hero-block__content
-                  .c-hero-block__title.c-heading.is-sm.is-bottom
-                    | タイトルテキストがここに入ります。
-                  p
-                    | テキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキスト
-                  .c-hero-block__button
-                    a.c-button.is-sm(href="http://yahoo.co.jp" target="_blank")
-                      | 外部サイト
-
-
-        section#block-5.l-block.l-block-block.l-block__margin-normal(style="")
-          .l-container
-            .c-block
-              .c-block__blocks
-                .c-block__block
-                  .row
-                    .large-4.small-12
-                      .c-block__image
-                        img(src="http://growp.grgr.red/wp-content/uploads/2020/07/img-number-cards-01.jpg" alt="")
-                    .large-8.small-12
-                      .c-block__content
-                        h3.c-block__title
-                          | タイトルテキストがここに入ります。
-                        .c-block__text
-                          p
-                            | テキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキスト
-                .c-block__block
-                  .row
-                    .large-4.small-12
-                      .c-block__image
-                        img(src="http://growp.grgr.red/wp-content/uploads/2020/07/img-number-cards-01.jpg" alt="")
-                    .large-8.small-12
-                      .c-block__content
-                        h3.c-block__title
-                          | タイトルテキストがここに入ります。
-                        .c-block__text
-                          p
-                            | テキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキスト
-                .c-block__block
-                  .row
-                    .large-4.small-12
-                      .c-block__image
-                        img(src="http://growp.grgr.red/wp-content/uploads/2020/07/img-number-cards-01.jpg" alt="")
-                    .large-8.small-12
-                      .c-block__content
-                        h3.c-block__title
-                          | タイトルテキストがここに入ります。
-                        .c-block__text
-                          p
-                            | テキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキスト
-                .c-block__block
-                  .row
-                    .large-4.small-12
-                      .c-block__image
-                        img(src="http://growp.grgr.red/wp-content/uploads/2020/07/img-number-cards-01.jpg" alt="")
-                    .large-8.small-12
-                      .c-block__content
-                        h3.c-block__title
-                          | タイトルテキストがここに入ります。
-                        .c-block__text
-                          p
-                            | テキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキスト
-
-
-        section#block-6.l-block.l-block-number-cards.l-block__margin-normal(style="")
-          .l-container
-            .row
-              .large-6.small-12
-                .c-card
-                  .c-card__block
-                    .c-card__image
-                      img(src="http://growp.grgr.red/wp-content/uploads/2020/07/img-number-cards-01.jpg" alt="")
-                    .c-card__content
-                      .c-card__title
-                        | 見出しがここに入ります。
-                      .c-card__text
-                        | テキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキスト
-              .large-6.small-12
-                .c-card
-                  .c-card__block
-                    .c-card__image
-                      img(src="http://growp.grgr.red/wp-content/uploads/2020/07/img-number-cards-01.jpg" alt="")
-                    .c-card__content
-                      .c-card__title
-                        | 見出しがここに入ります。
-                      .c-card__text
-                        | テキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキスト
-              .large-6.small-12
-                .c-card
-                  .c-card__block
-                    .c-card__image
-                      img(src="http://growp.grgr.red/wp-content/uploads/2020/07/img-number-cards-01.jpg" alt="")
-                    .c-card__content
-                      .c-card__title
-                        | 見出しがここに入ります。
-                      .c-card__text
-                        | テキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキスト
-              .large-6.small-12
-                .c-card
-                  .c-card__block
-                    .c-card__image
-                      img(src="http://growp.grgr.red/wp-content/uploads/2020/07/img-number-cards-01.jpg" alt="")
-                    .c-card__content
-                      .c-card__title
-                        | 見出しがここに入ります。
-                      .c-card__text
-                        | テキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキスト
-              .large-6.small-12
-                .c-card
-                  .c-card__block
-                    .c-card__image
-                      img(src="http://growp.grgr.red/wp-content/uploads/2020/07/img-number-cards-01.jpg" alt="")
-                    .c-card__content
-                      .c-card__title
-                        | 見出しがここに入ります。
-                      .c-card__text
-                        | テキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキスト
-
-
-        section#block-7.l-block.l-block-number-cards.l-block__margin-normal(style="")
-          .l-container
-            .row
-              .large-3.small-12
-                .c-card
-                  .c-card__block
-                    .c-card__image
-                      img(src="http://growp.grgr.red/wp-content/uploads/2020/07/img-number-cards-01.jpg" alt="")
-                    .c-card__content
-                      .c-card__title
-                        | 見出しがここに入ります。
-                      .c-card__text
-                        | テキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキスト
-              .large-3.small-12
-                .c-card
-                  .c-card__block
-                    .c-card__image
-                      img(src="http://growp.grgr.red/wp-content/uploads/2020/07/img-number-cards-01.jpg" alt="")
-                    .c-card__content
-                      .c-card__title
-                        | 見出しがここに入ります。
-                      .c-card__text
-                        | テキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキスト
-              .large-3.small-12
-                .c-card
-                  .c-card__block
-                    .c-card__image
-                      img(src="http://growp.grgr.red/wp-content/uploads/2020/07/img-number-cards-01.jpg" alt="")
-                    .c-card__content
-                      .c-card__title
-                        | 見出しがここに入ります。
-                      .c-card__text
-                        | テキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキスト
-              .large-3.small-12
-                .c-card
-                  .c-card__block
-                    .c-card__image
-                      img(src="http://growp.grgr.red/wp-content/uploads/2020/07/img-number-cards-01.jpg" alt="")
-                    .c-card__content
-                      .c-card__title
-                        | 見出しがここに入ります。
-                      .c-card__text
-                        | テキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキスト
-              .large-3.small-12
-                .c-card
-                  .c-card__block
-                    .c-card__image
-                      img(src="http://growp.grgr.red/wp-content/uploads/2020/07/img-number-cards-01.jpg" alt="")
-                    .c-card__content
-                      .c-card__title
-                        | 見出しがここに入ります。
-                      .c-card__text
-                        | テキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキスト
-              .large-3.small-12
-                .c-card
-                  .c-card__block
-                    .c-card__image
-                      img(src="http://growp.grgr.red/wp-content/uploads/2020/07/img-number-cards-01.jpg" alt="")
-                    .c-card__content
-                      .c-card__title
-                        | 見出しがここに入ります。
-                      .c-card__text
-                        | テキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキスト
-
-
-        section#block-8.l-block.l-block-number-cards.l-block__margin-normal(style="")
-          .l-container
-            .row
-              .large-4.small-12
-                .c-card
-                  .c-card__block
-                    .c-card__image
-                      img(src="http://growp.grgr.red/wp-content/uploads/2020/07/img-number-cards-01.jpg" alt="")
-                    .c-card__content
-                      .c-card__title
-                        | 見出しがここに入ります。
-                      .c-card__text
-                        | テキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキスト
-              .large-4.small-12
-                .c-card
-                  .c-card__block
-                    .c-card__image
-                      img(src="http://growp.grgr.red/wp-content/uploads/2020/07/img-number-cards-01.jpg" alt="")
-                    .c-card__content
-                      .c-card__title
-                        | 見出しがここに入ります。
-                      .c-card__text
-                        | テキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキスト
-              .large-4.small-12
-                .c-card
-                  .c-card__block
-                    .c-card__image
-                      img(src="http://growp.grgr.red/wp-content/uploads/2020/07/img-number-cards-01.jpg" alt="")
-                    .c-card__content
-                      .c-card__title
-                        | 見出しがここに入ります。
-                      .c-card__text
-                        | テキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキスト
-              .large-4.small-12
-                .c-card
-                  .c-card__block
-                    .c-card__image
-                      img(src="http://growp.grgr.red/wp-content/uploads/2020/07/img-number-cards-01.jpg" alt="")
-                    .c-card__content
-                      .c-card__title
-                        | 見出しがここに入ります。
-                      .c-card__text
-                        | テキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキスト
-              .large-4.small-12
-                .c-card
-                  .c-card__block
-                    .c-card__image
-                      img(src="http://growp.grgr.red/wp-content/uploads/2020/07/img-number-cards-01.jpg" alt="")
-                    .c-card__content
-                      .c-card__title
-                        | 見出しがここに入ります。
-                      .c-card__text
-                        | テキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキスト
-              .large-4.small-12
-                .c-card
-                  .c-card__block
-                    .c-card__image
-                      img(src="http://growp.grgr.red/wp-content/uploads/2020/07/img-number-cards-01.jpg" alt="")
-                    .c-card__content
-                      .c-card__title
-                        | 見出しがここに入ります。
-                      .c-card__text
-                        | テキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキスト
-
-
-        section#block-9.l-block.l-block-accordion.l-block__margin-normal(style="")
-          .l-container
-            .c-accordion
-              .c-accordion__block.js-accordion
-                .c-accordion__head(data-accordion-title="accordion-title")
-                  .c-accordion__icon
-                    | Q
-                  .c-accordion__title
-                    | テキストテキスト
-                .c-accordion__content(data-accordion-content="accordion--text")
-                  .c-accordion__icon.is-color-accent
-                    | A
-                  .c-accordion__text
-                    | テキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキスト
-                    br
-                    | テキストテキストテキストテキストテキストテキストテキストテキスト
-                    br
-                    | テキストテキストテキストテキストテキストテキスト
-              .c-accordion__block.js-accordion
-                .c-accordion__head(data-accordion-title="accordion-title")
-                  .c-accordion__icon
-                    | Q
-                  .c-accordion__title
-                    | テキストテキスト
-                .c-accordion__content(data-accordion-content="accordion--text")
-                  .c-accordion__icon.is-color-accent
-                    | A
-                  .c-accordion__text
-                    | テキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキスト
-                    br
-                    | テキストテキストテキストテキストテキストテキストテキストテキスト
-                    br
-                    | テキストテキストテキストテキストテキストテキスト
-              .c-accordion__block.js-accordion
-                .c-accordion__head(data-accordion-title="accordion-title")
-                  .c-accordion__icon
-                    | Q
-                  .c-accordion__title
-                    | テキストテキスト
-                .c-accordion__content(data-accordion-content="accordion--text")
-                  .c-accordion__icon.is-color-accent
-                    | A
-                  .c-accordion__text
-                    | テキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキスト
-                    br
-                    | テキストテキストテキストテキストテキストテキストテキストテキスト
-                    br
-                    | テキストテキストテキストテキストテキストテキスト
-              .c-accordion__block.js-accordion
-                .c-accordion__head(data-accordion-title="accordion-title")
-                  .c-accordion__icon
-                    | Q
-                  .c-accordion__title
-                    | テキストテキスト
-                .c-accordion__content(data-accordion-content="accordion--text")
-                  .c-accordion__icon.is-color-accent
-                    | A
-                  .c-accordion__text
-                    | テキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキスト
-                    br
-                    | テキストテキストテキストテキストテキストテキストテキストテキスト
-                    br
-                    | テキストテキストテキストテキストテキストテキスト
-              .c-accordion__block.js-accordion
-                .c-accordion__head(data-accordion-title="accordion-title")
-                  .c-accordion__icon
-                    | Q
-                  .c-accordion__title
-                    | テキストテキスト
-                .c-accordion__content(data-accordion-content="accordion--text")
-                  .c-accordion__icon.is-color-accent
-                    | A
-                  .c-accordion__text
-                    | テキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキスト
-                    br
-                    | テキストテキストテキストテキストテキストテキストテキストテキスト
-                    br
-                    | テキストテキストテキストテキストテキストテキスト
-
-
-        section#block-10.l-block.l-block-accordion.l-block__margin-normal(style="")
-          .l-container
-            .c-accordion
-              .c-accordion__block.js-accordion.is-open
-                .c-accordion__head(data-accordion-title="accordion-title")
-                  .c-accordion__icon
-                    | Q
-                  .c-accordion__title
-                    | テキストテキスト
-                .c-accordion__content(data-accordion-content="accordion--text" style="display: block;")
-                  .c-accordion__icon.is-color-accent
-                    | A
-                  .c-accordion__text
-                    | テキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキスト
-                    br
-                    | テキストテキストテキストテキストテキストテキストテキストテキスト
-                    br
-                    | テキストテキストテキストテキストテキストテキスト
-              .c-accordion__block.js-accordion.is-open
-                .c-accordion__head(data-accordion-title="accordion-title")
-                  .c-accordion__icon
-                    | Q
-                  .c-accordion__title
-                    | テキストテキスト
-                .c-accordion__content(data-accordion-content="accordion--text" style="display: block;")
-                  .c-accordion__icon.is-color-accent
-                    | A
-                  .c-accordion__text
-                    | テキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキスト
-                    br
-                    | テキストテキストテキストテキストテキストテキストテキストテキスト
-                    br
-                    | テキストテキストテキストテキストテキストテキスト
-              .c-accordion__block.js-accordion.is-open
-                .c-accordion__head(data-accordion-title="accordion-title")
-                  .c-accordion__icon
-                    | Q
-                  .c-accordion__title
-                    | テキストテキスト
-                .c-accordion__content(data-accordion-content="accordion--text" style="display: block;")
-                  .c-accordion__icon.is-color-accent
-                    | A
-                  .c-accordion__text
-                    | テキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキスト
-                    br
-                    | テキストテキストテキストテキストテキストテキストテキストテキスト
-                    br
-                    | テキストテキストテキストテキストテキストテキスト
-              .c-accordion__block.js-accordion.is-open
-                .c-accordion__head(data-accordion-title="accordion-title")
-                  .c-accordion__icon
-                    | Q
-                  .c-accordion__title
-                    | テキストテキスト
-                .c-accordion__content(data-accordion-content="accordion--text" style="display: block;")
-                  .c-accordion__icon.is-color-accent
-                    | A
-                  .c-accordion__text
-                    | テキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキスト
-                    br
-                    | テキストテキストテキストテキストテキストテキストテキストテキスト
-                    br
-                    | テキストテキストテキストテキストテキストテキスト
-              .c-accordion__block.js-accordion.is-open
-                .c-accordion__head(data-accordion-title="accordion-title")
-                  .c-accordion__icon
-                    | Q
-                  .c-accordion__title
-                    | テキストテキスト
-                .c-accordion__content(data-accordion-content="accordion--text" style="display: block;")
-                  .c-accordion__icon.is-color-accent
-                    | A
-                  .c-accordion__text
-                    | テキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキスト
-                    br
-                    | テキストテキストテキストテキストテキストテキストテキストテキスト
-                    br
-                    | テキストテキストテキストテキストテキストテキスト
-
-
-        section#block-11.l-block.l-block-accordion-list.l-block__margin-normal(style="")
-          .l-container
-            .c-accordion-list
-              .c-accordion-list__block.js-accordion
-                .c-accordion-list__head(data-accordion-title="accordion-title")
-                  | テキストテキスト
-                .c-accordion-list__content(data-accordion-content="accordion--text")
+      section#flow.l-block.l-block-box-number.l-block__margin-normal(style="")
+        .l-container
+          .c-box-number
+            .c-box-number__block
+              .c-box-number__head
+                .c-box-number__number
+                  small STEP
+                  span 01
+              .c-box-number__content
+                .c-box-number__title
+                  | 手順
+                .c-box-number__text
                   | テキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキスト
-                  br
-                  | テキストテキストテキストテキストテキストテキストテキストテキスト
                   br
                   | テキストテキストテキストテキストテキストテキスト
-              .c-accordion-list__block.js-accordion
-                .c-accordion-list__head(data-accordion-title="accordion-title")
-                  | テキストテキスト
-                .c-accordion-list__content(data-accordion-content="accordion--text")
+            .c-box-number__block
+              .c-box-number__head
+                .c-box-number__number
+                  small STEP
+                  span 02
+              .c-box-number__content
+                .c-box-number__title
+                  | 手順
+                .c-box-number__text
                   | テキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキスト
-                  br
-                  | テキストテキストテキストテキストテキストテキストテキストテキスト
                   br
                   | テキストテキストテキストテキストテキストテキスト
-              .c-accordion-list__block.js-accordion
-                .c-accordion-list__head(data-accordion-title="accordion-title")
-                  | テキストテキスト
-                .c-accordion-list__content(data-accordion-content="accordion--text")
+            .c-box-number__block
+              .c-box-number__head
+                .c-box-number__number
+                  small STEP
+                  span 03
+              .c-box-number__content
+                .c-box-number__title
+                  | 手順
+                .c-box-number__text
                   | テキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキスト
                   br
-                  | テキストテキストテキストテキストテキストテキストテキストテキスト
+                  | テキストテキストテキストテキストテキストテキスト
+            .c-box-number__block
+              .c-box-number__head
+                .c-box-number__number
+                  small STEP
+                  span 04
+              .c-box-number__content
+                .c-box-number__title
+                  | 手順
+                .c-box-number__text
+                  | テキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキスト
+                  br
+                  | テキストテキストテキストテキストテキストテキスト
+            .c-box-number__block
+              .c-box-number__head
+                .c-box-number__number
+                  small STEP
+                  span 05
+              .c-box-number__content
+                .c-box-number__title
+                  | 手順
+                .c-box-number__text
+                  | テキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキスト
                   br
                   | テキストテキストテキストテキストテキストテキスト
 
 
-        section#block-12.l-block.l-block-accordion-list.l-block__margin-normal(style="")
-          .l-container
-            .c-accordion-list
-              .c-accordion-list__block.js-accordion.is-open
-                .c-accordion-list__head(data-accordion-title="accordion-title")
-                  | テキストテキスト
-                .c-accordion-list__content(data-accordion-content="accordion--text" style="display: block;")
-                  | テキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキスト
-                  br
-                  | テキストテキストテキストテキストテキストテキストテキストテキスト
-                  br
-                  | テキストテキストテキストテキストテキストテキスト
-              .c-accordion-list__block.js-accordion.is-open
-                .c-accordion-list__head(data-accordion-title="accordion-title")
-                  | テキストテキスト
-                .c-accordion-list__content(data-accordion-content="accordion--text" style="display: block;")
-                  | テキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキスト
-                  br
-                  | テキストテキストテキストテキストテキストテキストテキストテキスト
-                  br
-                  | テキストテキストテキストテキストテキストテキスト
-              .c-accordion-list__block.js-accordion.is-open
-                .c-accordion-list__head(data-accordion-title="accordion-title")
-                  | テキストテキスト
-                .c-accordion-list__content(data-accordion-content="accordion--text" style="display: block;")
-                  | テキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキスト
-                  br
-                  | テキストテキストテキストテキストテキストテキストテキストテキスト
-                  br
-                  | テキストテキストテキストテキストテキストテキスト
-
-
-        section#block-13.l-block.l-block-offer.l-block__margin-normal(style="")
-          .l-offer
+      section#block-4.l-block.l-block-hero-block.l-block__margin-normal(style="")
+        .c-hero-block
+          .c-hero-block__block
+            .c-hero-block__image
+              img(src="http://growp.grgr.red/wp-content/uploads/2020/07/img-number-cards-01.jpg" alt="")
             .l-container
-              .l-offer__inner
-                h2.c-heading.is-md.is-bottom オファータイトルオファータイトル
-                .l-offer__text オファーテキストオファーテキストオファーテキストへのお問い合わせは下記からお願いします。
-                .l-offer__items
-                  .row(style="width:100%;")
-                    .large-6.small-12
-                      a.l-offer__button.is-tel(href="tel:00-000-0000")
-                        i.fa.fa-phone(aria-hidden="true")
-                        | 00-000-0000
-                      .l-offer__subtext 受付時間:平日 9:00〜18:00 （土日祝除く）
-                    .large-6.small-12
-                      a.l-offer__button(href="/contact/") メールで問い合わせ
+              .c-hero-block__content
+                .c-hero-block__title.c-heading.is-sm.is-bottom
+                  | タイトルテキストがここに入ります。
+                p
+                  | テキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキスト
+                .c-hero-block__button
+                  a.c-button.is-sm(href="#" target="_self")
+                    | リンクテキスト
+          .c-hero-block__block
+            .c-hero-block__image
+              img(src="http://growp.grgr.red/wp-content/uploads/2020/07/img-number-cards-01.jpg" alt="")
+            .l-container
+              .c-hero-block__content
+                .c-hero-block__title.c-heading.is-sm.is-bottom
+                  | タイトルテキストがここに入ります。
+                p
+                  | テキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキスト
+                .c-hero-block__button
+                  a.c-button.is-sm(href="#" target="_self")
+                    | リンクテキスト
+          .c-hero-block__block
+            .c-hero-block__image
+              img(src="http://growp.grgr.red/wp-content/uploads/2020/07/img-number-cards-01.jpg" alt="")
+            .l-container
+              .c-hero-block__content
+                .c-hero-block__title.c-heading.is-sm.is-bottom
+                  | タイトルテキストがここに入ります。
+                p
+                  | テキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキスト
+                .c-hero-block__button
+                  a.c-button.is-sm(href="http://yahoo.co.jp" target="_blank")
+                    | 外部サイト
+
+
+      section#block-5.l-block.l-block-block.l-block__margin-normal(style="")
+        .l-container
+          .c-block
+            .c-block__blocks
+              .c-block__block
+                .row
+                  .large-4.small-12
+                    .c-block__image
+                      img(src="http://growp.grgr.red/wp-content/uploads/2020/07/img-number-cards-01.jpg" alt="")
+                  .large-8.small-12
+                    .c-block__content
+                      h3.c-block__title
+                        | タイトルテキストがここに入ります。
+                      .c-block__text
+                        p
+                          | テキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキスト
+              .c-block__block
+                .row
+                  .large-4.small-12
+                    .c-block__image
+                      img(src="http://growp.grgr.red/wp-content/uploads/2020/07/img-number-cards-01.jpg" alt="")
+                  .large-8.small-12
+                    .c-block__content
+                      h3.c-block__title
+                        | タイトルテキストがここに入ります。
+                      .c-block__text
+                        p
+                          | テキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキスト
+              .c-block__block
+                .row
+                  .large-4.small-12
+                    .c-block__image
+                      img(src="http://growp.grgr.red/wp-content/uploads/2020/07/img-number-cards-01.jpg" alt="")
+                  .large-8.small-12
+                    .c-block__content
+                      h3.c-block__title
+                        | タイトルテキストがここに入ります。
+                      .c-block__text
+                        p
+                          | テキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキスト
+              .c-block__block
+                .row
+                  .large-4.small-12
+                    .c-block__image
+                      img(src="http://growp.grgr.red/wp-content/uploads/2020/07/img-number-cards-01.jpg" alt="")
+                  .large-8.small-12
+                    .c-block__content
+                      h3.c-block__title
+                        | タイトルテキストがここに入ります。
+                      .c-block__text
+                        p
+                          | テキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキスト
+
+
+      section#block-6.l-block.l-block-number-cards.l-block__margin-normal(style="")
+        .l-container
+          .row
+            .large-6.small-12
+              .c-card
+                .c-card__block
+                  .c-card__image
+                    img(src="http://growp.grgr.red/wp-content/uploads/2020/07/img-number-cards-01.jpg" alt="")
+                  .c-card__content
+                    .c-card__title
+                      | 見出しがここに入ります。
+                    .c-card__text
+                      | テキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキスト
+            .large-6.small-12
+              .c-card
+                .c-card__block
+                  .c-card__image
+                    img(src="http://growp.grgr.red/wp-content/uploads/2020/07/img-number-cards-01.jpg" alt="")
+                  .c-card__content
+                    .c-card__title
+                      | 見出しがここに入ります。
+                    .c-card__text
+                      | テキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキスト
+            .large-6.small-12
+              .c-card
+                .c-card__block
+                  .c-card__image
+                    img(src="http://growp.grgr.red/wp-content/uploads/2020/07/img-number-cards-01.jpg" alt="")
+                  .c-card__content
+                    .c-card__title
+                      | 見出しがここに入ります。
+                    .c-card__text
+                      | テキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキスト
+            .large-6.small-12
+              .c-card
+                .c-card__block
+                  .c-card__image
+                    img(src="http://growp.grgr.red/wp-content/uploads/2020/07/img-number-cards-01.jpg" alt="")
+                  .c-card__content
+                    .c-card__title
+                      | 見出しがここに入ります。
+                    .c-card__text
+                      | テキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキスト
+            .large-6.small-12
+              .c-card
+                .c-card__block
+                  .c-card__image
+                    img(src="http://growp.grgr.red/wp-content/uploads/2020/07/img-number-cards-01.jpg" alt="")
+                  .c-card__content
+                    .c-card__title
+                      | 見出しがここに入ります。
+                    .c-card__text
+                      | テキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキスト
+
+
+      section#block-7.l-block.l-block-number-cards.l-block__margin-normal(style="")
+        .l-container
+          .row
+            .large-3.small-12
+              .c-card
+                .c-card__block
+                  .c-card__image
+                    img(src="http://growp.grgr.red/wp-content/uploads/2020/07/img-number-cards-01.jpg" alt="")
+                  .c-card__content
+                    .c-card__title
+                      | 見出しがここに入ります。
+                    .c-card__text
+                      | テキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキスト
+            .large-3.small-12
+              .c-card
+                .c-card__block
+                  .c-card__image
+                    img(src="http://growp.grgr.red/wp-content/uploads/2020/07/img-number-cards-01.jpg" alt="")
+                  .c-card__content
+                    .c-card__title
+                      | 見出しがここに入ります。
+                    .c-card__text
+                      | テキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキスト
+            .large-3.small-12
+              .c-card
+                .c-card__block
+                  .c-card__image
+                    img(src="http://growp.grgr.red/wp-content/uploads/2020/07/img-number-cards-01.jpg" alt="")
+                  .c-card__content
+                    .c-card__title
+                      | 見出しがここに入ります。
+                    .c-card__text
+                      | テキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキスト
+            .large-3.small-12
+              .c-card
+                .c-card__block
+                  .c-card__image
+                    img(src="http://growp.grgr.red/wp-content/uploads/2020/07/img-number-cards-01.jpg" alt="")
+                  .c-card__content
+                    .c-card__title
+                      | 見出しがここに入ります。
+                    .c-card__text
+                      | テキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキスト
+            .large-3.small-12
+              .c-card
+                .c-card__block
+                  .c-card__image
+                    img(src="http://growp.grgr.red/wp-content/uploads/2020/07/img-number-cards-01.jpg" alt="")
+                  .c-card__content
+                    .c-card__title
+                      | 見出しがここに入ります。
+                    .c-card__text
+                      | テキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキスト
+            .large-3.small-12
+              .c-card
+                .c-card__block
+                  .c-card__image
+                    img(src="http://growp.grgr.red/wp-content/uploads/2020/07/img-number-cards-01.jpg" alt="")
+                  .c-card__content
+                    .c-card__title
+                      | 見出しがここに入ります。
+                    .c-card__text
+                      | テキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキスト
+
+
+      section#block-8.l-block.l-block-number-cards.l-block__margin-normal(style="")
+        .l-container
+          .row
+            .large-4.small-12
+              .c-card
+                .c-card__block
+                  .c-card__image
+                    img(src="http://growp.grgr.red/wp-content/uploads/2020/07/img-number-cards-01.jpg" alt="")
+                  .c-card__content
+                    .c-card__title
+                      | 見出しがここに入ります。
+                    .c-card__text
+                      | テキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキスト
+            .large-4.small-12
+              .c-card
+                .c-card__block
+                  .c-card__image
+                    img(src="http://growp.grgr.red/wp-content/uploads/2020/07/img-number-cards-01.jpg" alt="")
+                  .c-card__content
+                    .c-card__title
+                      | 見出しがここに入ります。
+                    .c-card__text
+                      | テキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキスト
+            .large-4.small-12
+              .c-card
+                .c-card__block
+                  .c-card__image
+                    img(src="http://growp.grgr.red/wp-content/uploads/2020/07/img-number-cards-01.jpg" alt="")
+                  .c-card__content
+                    .c-card__title
+                      | 見出しがここに入ります。
+                    .c-card__text
+                      | テキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキスト
+            .large-4.small-12
+              .c-card
+                .c-card__block
+                  .c-card__image
+                    img(src="http://growp.grgr.red/wp-content/uploads/2020/07/img-number-cards-01.jpg" alt="")
+                  .c-card__content
+                    .c-card__title
+                      | 見出しがここに入ります。
+                    .c-card__text
+                      | テキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキスト
+            .large-4.small-12
+              .c-card
+                .c-card__block
+                  .c-card__image
+                    img(src="http://growp.grgr.red/wp-content/uploads/2020/07/img-number-cards-01.jpg" alt="")
+                  .c-card__content
+                    .c-card__title
+                      | 見出しがここに入ります。
+                    .c-card__text
+                      | テキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキスト
+            .large-4.small-12
+              .c-card
+                .c-card__block
+                  .c-card__image
+                    img(src="http://growp.grgr.red/wp-content/uploads/2020/07/img-number-cards-01.jpg" alt="")
+                  .c-card__content
+                    .c-card__title
+                      | 見出しがここに入ります。
+                    .c-card__text
+                      | テキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキスト
+
+
+      section#block-9.l-block.l-block-accordion.l-block__margin-normal(style="")
+        .l-container
+          .c-accordion
+            .c-accordion__block.js-accordion
+              .c-accordion__head(data-accordion-title="accordion-title")
+                .c-accordion__icon
+                  | Q
+                .c-accordion__title
+                  | テキストテキスト
+              .c-accordion__content(data-accordion-content="accordion--text")
+                .c-accordion__icon.is-color-accent
+                  | A
+                .c-accordion__text
+                  | テキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキスト
+                  br
+                  | テキストテキストテキストテキストテキストテキストテキストテキスト
+                  br
+                  | テキストテキストテキストテキストテキストテキスト
+            .c-accordion__block.js-accordion
+              .c-accordion__head(data-accordion-title="accordion-title")
+                .c-accordion__icon
+                  | Q
+                .c-accordion__title
+                  | テキストテキスト
+              .c-accordion__content(data-accordion-content="accordion--text")
+                .c-accordion__icon.is-color-accent
+                  | A
+                .c-accordion__text
+                  | テキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキスト
+                  br
+                  | テキストテキストテキストテキストテキストテキストテキストテキスト
+                  br
+                  | テキストテキストテキストテキストテキストテキスト
+            .c-accordion__block.js-accordion
+              .c-accordion__head(data-accordion-title="accordion-title")
+                .c-accordion__icon
+                  | Q
+                .c-accordion__title
+                  | テキストテキスト
+              .c-accordion__content(data-accordion-content="accordion--text")
+                .c-accordion__icon.is-color-accent
+                  | A
+                .c-accordion__text
+                  | テキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキスト
+                  br
+                  | テキストテキストテキストテキストテキストテキストテキストテキスト
+                  br
+                  | テキストテキストテキストテキストテキストテキスト
+            .c-accordion__block.js-accordion
+              .c-accordion__head(data-accordion-title="accordion-title")
+                .c-accordion__icon
+                  | Q
+                .c-accordion__title
+                  | テキストテキスト
+              .c-accordion__content(data-accordion-content="accordion--text")
+                .c-accordion__icon.is-color-accent
+                  | A
+                .c-accordion__text
+                  | テキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキスト
+                  br
+                  | テキストテキストテキストテキストテキストテキストテキストテキスト
+                  br
+                  | テキストテキストテキストテキストテキストテキスト
+            .c-accordion__block.js-accordion
+              .c-accordion__head(data-accordion-title="accordion-title")
+                .c-accordion__icon
+                  | Q
+                .c-accordion__title
+                  | テキストテキスト
+              .c-accordion__content(data-accordion-content="accordion--text")
+                .c-accordion__icon.is-color-accent
+                  | A
+                .c-accordion__text
+                  | テキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキスト
+                  br
+                  | テキストテキストテキストテキストテキストテキストテキストテキスト
+                  br
+                  | テキストテキストテキストテキストテキストテキスト
+
+
+      section#block-10.l-block.l-block-accordion.l-block__margin-normal(style="")
+        .l-container
+          .c-accordion
+            .c-accordion__block.js-accordion.is-open
+              .c-accordion__head(data-accordion-title="accordion-title")
+                .c-accordion__icon
+                  | Q
+                .c-accordion__title
+                  | テキストテキスト
+              .c-accordion__content(data-accordion-content="accordion--text" style="display: block;")
+                .c-accordion__icon.is-color-accent
+                  | A
+                .c-accordion__text
+                  | テキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキスト
+                  br
+                  | テキストテキストテキストテキストテキストテキストテキストテキスト
+                  br
+                  | テキストテキストテキストテキストテキストテキスト
+            .c-accordion__block.js-accordion.is-open
+              .c-accordion__head(data-accordion-title="accordion-title")
+                .c-accordion__icon
+                  | Q
+                .c-accordion__title
+                  | テキストテキスト
+              .c-accordion__content(data-accordion-content="accordion--text" style="display: block;")
+                .c-accordion__icon.is-color-accent
+                  | A
+                .c-accordion__text
+                  | テキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキスト
+                  br
+                  | テキストテキストテキストテキストテキストテキストテキストテキスト
+                  br
+                  | テキストテキストテキストテキストテキストテキスト
+            .c-accordion__block.js-accordion.is-open
+              .c-accordion__head(data-accordion-title="accordion-title")
+                .c-accordion__icon
+                  | Q
+                .c-accordion__title
+                  | テキストテキスト
+              .c-accordion__content(data-accordion-content="accordion--text" style="display: block;")
+                .c-accordion__icon.is-color-accent
+                  | A
+                .c-accordion__text
+                  | テキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキスト
+                  br
+                  | テキストテキストテキストテキストテキストテキストテキストテキスト
+                  br
+                  | テキストテキストテキストテキストテキストテキスト
+            .c-accordion__block.js-accordion.is-open
+              .c-accordion__head(data-accordion-title="accordion-title")
+                .c-accordion__icon
+                  | Q
+                .c-accordion__title
+                  | テキストテキスト
+              .c-accordion__content(data-accordion-content="accordion--text" style="display: block;")
+                .c-accordion__icon.is-color-accent
+                  | A
+                .c-accordion__text
+                  | テキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキスト
+                  br
+                  | テキストテキストテキストテキストテキストテキストテキストテキスト
+                  br
+                  | テキストテキストテキストテキストテキストテキスト
+            .c-accordion__block.js-accordion.is-open
+              .c-accordion__head(data-accordion-title="accordion-title")
+                .c-accordion__icon
+                  | Q
+                .c-accordion__title
+                  | テキストテキスト
+              .c-accordion__content(data-accordion-content="accordion--text" style="display: block;")
+                .c-accordion__icon.is-color-accent
+                  | A
+                .c-accordion__text
+                  | テキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキスト
+                  br
+                  | テキストテキストテキストテキストテキストテキストテキストテキスト
+                  br
+                  | テキストテキストテキストテキストテキストテキスト
+
+
+      section#block-11.l-block.l-block-accordion-list.l-block__margin-normal(style="")
+        .l-container
+          .c-accordion-list
+            .c-accordion-list__block.js-accordion
+              .c-accordion-list__head(data-accordion-title="accordion-title")
+                | テキストテキスト
+              .c-accordion-list__content(data-accordion-content="accordion--text")
+                | テキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキスト
+                br
+                | テキストテキストテキストテキストテキストテキストテキストテキスト
+                br
+                | テキストテキストテキストテキストテキストテキスト
+            .c-accordion-list__block.js-accordion
+              .c-accordion-list__head(data-accordion-title="accordion-title")
+                | テキストテキスト
+              .c-accordion-list__content(data-accordion-content="accordion--text")
+                | テキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキスト
+                br
+                | テキストテキストテキストテキストテキストテキストテキストテキスト
+                br
+                | テキストテキストテキストテキストテキストテキスト
+            .c-accordion-list__block.js-accordion
+              .c-accordion-list__head(data-accordion-title="accordion-title")
+                | テキストテキスト
+              .c-accordion-list__content(data-accordion-content="accordion--text")
+                | テキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキスト
+                br
+                | テキストテキストテキストテキストテキストテキストテキストテキスト
+                br
+                | テキストテキストテキストテキストテキストテキスト
+
+
+      section#block-12.l-block.l-block-accordion-list.l-block__margin-normal(style="")
+        .l-container
+          .c-accordion-list
+            .c-accordion-list__block.js-accordion.is-open
+              .c-accordion-list__head(data-accordion-title="accordion-title")
+                | テキストテキスト
+              .c-accordion-list__content(data-accordion-content="accordion--text" style="display: block;")
+                | テキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキスト
+                br
+                | テキストテキストテキストテキストテキストテキストテキストテキスト
+                br
+                | テキストテキストテキストテキストテキストテキスト
+            .c-accordion-list__block.js-accordion.is-open
+              .c-accordion-list__head(data-accordion-title="accordion-title")
+                | テキストテキスト
+              .c-accordion-list__content(data-accordion-content="accordion--text" style="display: block;")
+                | テキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキスト
+                br
+                | テキストテキストテキストテキストテキストテキストテキストテキスト
+                br
+                | テキストテキストテキストテキストテキストテキスト
+            .c-accordion-list__block.js-accordion.is-open
+              .c-accordion-list__head(data-accordion-title="accordion-title")
+                | テキストテキスト
+              .c-accordion-list__content(data-accordion-content="accordion--text" style="display: block;")
+                | テキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキスト
+                br
+                | テキストテキストテキストテキストテキストテキストテキストテキスト
+                br
+                | テキストテキストテキストテキストテキストテキスト
+
+
+      section#block-13.l-block.l-block-offer.l-block__margin-normal(style="")
+        .l-offer
+          .l-container
+            .l-offer__inner
+              h2.c-heading.is-md.is-bottom オファータイトルオファータイトル
+              .l-offer__text オファーテキストオファーテキストオファーテキストへのお問い合わせは下記からお願いします。
+              .l-offer__items
+                .row(style="width:100%;")
+                  .large-6.small-12
+                    a.l-offer__button.is-tel(href="tel:00-000-0000")
+                      i.fa.fa-phone(aria-hidden="true")
+                      | 00-000-0000
+                    .l-offer__subtext 受付時間:平日 9:00〜18:00 （土日祝除く）
+                  .large-6.small-12
+                    a.l-offer__button(href="/contact/") メールで問い合わせ

--- a/app/contact/complete/index.pug
+++ b/app/contact/complete/index.pug
@@ -10,33 +10,32 @@ block append config
 block page_header
 
 block body
-  main.l-main
-    section.l-section.is-lg.is-color-secondary
-      .l-container
-        +c.form-head
-          +e.block
-            +h1.title お問い合わせ
-            +e.list
-              +e.item
-                +e.item-number 1
-                +e.item-text お客様情報入力
-              +e.item
-                +e.item-number 2
-                +e.item-text 入力内容の確認
-              +e.item.is-current
-                +e.item-number 3
-                +e.item-text 送信完了
-        +c.forms
-          +e.inner
-            +e.heading.c-heading.is-md.is-normal.u-text-center.is-bottom お問い合わせ<br class="u-hidden-lg">ありがとうございました。
-            +e.text.
-              この度はお問い合わせいただき、誠にありがとうございます。<br>
-              いただいた内容を確認後、担当者より再度ご連絡いたします。<br>
-              大変恐縮ですが、今しばらくお待ちくださいませ。<br><br>
+  section.l-section.is-lg.is-color-secondary
+    .l-container
+      +c.form-head
+        +e.block
+          +h1.title お問い合わせ
+          +e.list
+            +e.item
+              +e.item-number 1
+              +e.item-text お客様情報入力
+            +e.item
+              +e.item-number 2
+              +e.item-text 入力内容の確認
+            +e.item.is-current
+              +e.item-number 3
+              +e.item-text 送信完了
+      +c.forms
+        +e.inner
+          +e.heading.c-heading.is-md.is-normal.u-text-center.is-bottom お問い合わせ<br class="u-hidden-lg">ありがとうございました。
+          +e.text.
+            この度はお問い合わせいただき、誠にありがとうございます。<br>
+            いただいた内容を確認後、担当者より再度ご連絡いたします。<br>
+            大変恐縮ですが、今しばらくお待ちくださいませ。<br><br>
 
-              ※尚、ご入力いただいたメールアドレス宛に<br class="u-hidden-sm">お問い合わせ内容を記載した自動返信メールが配信されております。<br>
-              そちらも併せてご確認くださいませ。<br>
+            ※尚、ご入力いただいたメールアドレス宛に<br class="u-hidden-sm">お問い合わせ内容を記載した自動返信メールが配信されております。<br>
+            そちらも併せてご確認くださいませ。<br>
 
-          +e.pagetop.u-text-center
-            +a("/").c-button.is-xlg トップページに戻る
+        +e.pagetop.u-text-center
+          +a("/").c-button.is-xlg トップページに戻る
 

--- a/app/contact/confirm/index.pug
+++ b/app/contact/confirm/index.pug
@@ -10,71 +10,70 @@ block append config
 block page_header
 
 block body
-  main.l-main
-    section.l-section.is-lg.is-color-secondary
-      .l-container
-        +c.form-head
+  section.l-section.is-lg.is-color-secondary
+    .l-container
+      +c.form-head
+        +e.block
+          +h1.title お問い合わせ
+          +e.list
+            +e.item
+              +e.item-number 1
+              +e.item-text お客様情報入力
+            +e.item.is-current
+              +e.item-number 2
+              +e.item-text 入力内容の確認
+            +e.item
+              +e.item-number 3
+              +e.item-text 送信完了
+      +c.forms
+        +e.inner
+          +e.heading.c-heading.is-md.is-normal.u-text-center.is-bottom 入力内容確認
+          +e.text.
+            ご入力いただいた内容は下記の通りです。<br>
+            お間違いがなければ送信を、入力内容を変更する場合はお手数ですが、再入力をお願い致します。
           +e.block
-            +h1.title お問い合わせ
-            +e.list
-              +e.item
-                +e.item-number 1
-                +e.item-text お客様情報入力
-              +e.item.is-current
-                +e.item-number 2
-                +e.item-text 入力内容の確認
-              +e.item
-                +e.item-number 3
-                +e.item-text 送信完了
-        +c.forms
-          +e.inner
-            +e.heading.c-heading.is-md.is-normal.u-text-center.is-bottom 入力内容確認
-            +e.text.
-              ご入力いただいた内容は下記の通りです。<br>
-              お間違いがなければ送信を、入力内容を変更する場合はお手数ですが、再入力をお願い致します。
-            +e.block
-              +e.title
-                | 貴社名
-              +e.content
-                +e.input 株式会社 サンプル
-            +e.block
-              +e.title
-                | 部署
-              +e.content
-                +e.input 総務課
-            +e.block
-              +e.title
-                | ご担当者氏名
-                span.c-forms__label 必須
-              +e.content
-                +e.input 山田 太郎
-            +e.block
-              +e.title
-                | フリガナ
-                span.c-forms__label 必須
-              +e.content
-                +e.input ヤマダ タロウ
-            +e.block
-              +e.title
-                | TEL
-                span.c-forms__label 必須
-              +e.content
-                +e.input 123-456-789
-            +e.block
-              +e.title
-                | メールアドレス
-                span.c-forms__label 必須
-              +e.content
-                +e.input info@mail.com
-            +e.block
-              +e.title
-                | ファイル添付
-              +e.content
-                +e.input text.png
-            +e.block
-              +e.title.is-vertical-top お問い合わせ内容
-              +e.content
-                +e.textarea サービスについてご不明点のある方はこちらにご記載ください。
-          +e.submit
-            button.c-button.c-forms__submit__back.is-lg.is-secondary.is-arrow-left 戻る
-            button.c-button.c-forms__submit__submit.is-lg 送信する
+            +e.title
+              | 貴社名
+            +e.content
+              +e.input 株式会社 サンプル
+          +e.block
+            +e.title
+              | 部署
+            +e.content
+              +e.input 総務課
+          +e.block
+            +e.title
+              | ご担当者氏名
+              span.c-forms__label 必須
+            +e.content
+              +e.input 山田 太郎
+          +e.block
+            +e.title
+              | フリガナ
+              span.c-forms__label 必須
+            +e.content
+              +e.input ヤマダ タロウ
+          +e.block
+            +e.title
+              | TEL
+              span.c-forms__label 必須
+            +e.content
+              +e.input 123-456-789
+          +e.block
+            +e.title
+              | メールアドレス
+              span.c-forms__label 必須
+            +e.content
+              +e.input info@mail.com
+          +e.block
+            +e.title
+              | ファイル添付
+            +e.content
+              +e.input text.png
+          +e.block
+            +e.title.is-vertical-top お問い合わせ内容
+            +e.content
+              +e.textarea サービスについてご不明点のある方はこちらにご記載ください。
+        +e.submit
+          button.c-button.c-forms__submit__back.is-lg.is-secondary.is-arrow-left 戻る
+          button.c-button.c-forms__submit__submit.is-lg 送信する

--- a/app/contact/index.pug
+++ b/app/contact/index.pug
@@ -13,233 +13,232 @@ block page_header
   //- /confirm/ と /complete/ もCSS調整必須！
   //- ★★★★★★★★★★★★★★★★★★★★★★★★★★★★★★★★★★★
 block body
-  main.l-main
-    section.l-section.is-lg.is-color-secondary
-      .l-container
-        +c.form-head
-          +e.block
-            +h1.title お問い合わせ
-            +e.list
-              +e.item.is-current
-                +e.item-number 1
-                +e.item-text お客様情報入力
-              +e.item
-                +e.item-number 2
-                +e.item-text 入力内容の確認
-              +e.item
-                +e.item-number 3
-                +e.item-text 送信完了
-        <script src="https://ajaxzip3.github.io/ajaxzip3.js" charset="UTF-8"></script>
-        +c.forms
-          +e.inner
-            +e.text 下記のフォームに必須項目を入力して<br class="u-visible-sm">送信してください。
-            +e.blocks
-              +e.block.is-vertical
-                +e.title
-                  | 貴社名
-                  span.c-forms__label 必須
-                +e.content
-                  +e.input: input(type="text",name="貴社名",placeholder="（例）株式会社 サンプル")
-              +e.block
-                +e.title
-                  | 貴社名
-                  span.c-forms__label 必須
-                +e.content
-                  +e.input: input(type="text",name="貴社名",placeholder="（例）株式会社 サンプル")
-              +e.block
-                +e.title 部署・役職
-                +e.content
-                  +e.input: input(type="text",name="部署・役職",placeholder="（例）営業部")
+  section.l-section.is-lg.is-color-secondary
+    .l-container
+      +c.form-head
+        +e.block
+          +h1.title お問い合わせ
+          +e.list
+            +e.item.is-current
+              +e.item-number 1
+              +e.item-text お客様情報入力
+            +e.item
+              +e.item-number 2
+              +e.item-text 入力内容の確認
+            +e.item
+              +e.item-number 3
+              +e.item-text 送信完了
+      <script src="https://ajaxzip3.github.io/ajaxzip3.js" charset="UTF-8"></script>
+      +c.forms
+        +e.inner
+          +e.text 下記のフォームに必須項目を入力して<br class="u-visible-sm">送信してください。
+          +e.blocks
+            +e.block.is-vertical
+              +e.title
+                | 貴社名
+                span.c-forms__label 必須
+              +e.content
+                +e.input: input(type="text",name="貴社名",placeholder="（例）株式会社 サンプル")
+            +e.block
+              +e.title
+                | 貴社名
+                span.c-forms__label 必須
+              +e.content
+                +e.input: input(type="text",name="貴社名",placeholder="（例）株式会社 サンプル")
+            +e.block
+              +e.title 部署・役職
+              +e.content
+                +e.input: input(type="text",name="部署・役職",placeholder="（例）営業部")
 
-              +e.block
-                +e.title
-                  | お名前
-                  span.c-forms__label 必須
-                +e.content
-                  +e.input: input(type="text",name="お名前",placeholder="山田　太郎")
-              +e.block
-                +e.title
-                  | お名前フリガナ
-                  span.c-forms__label 必須
-                +e.content
-                  +e.input: input(type="text",name="お名前フリガナ",placeholder="ヤマダ　タロウ")
-              +e.block
-                +e.title
-                  | メールアドレス
-                  span.c-forms__label 必須
-                +e.content
-                  +e.input: input(type="text",name="メールアドレス",placeholder="（例）info@mail.jp")
-              +e.block
-                +e.title
-                  | TEL
-                  span.c-forms__label 必須
-                +e.content
-                  +e.input: input(type="text",name="TEL",placeholder="（例）000-0000-0000")
-              +e.block
-                +e.title
-                  | 履歴書（PDF）
-                +e.content
-                  +e.file: input(type="file",name="履歴書（PDF）")
-              +e.block
-                +e.title
-                  | 職務経歴書（PDF）
-                +e.content
-                  +e.file: input(type="file",name="職務経歴書（PDF）")
-              +e.block
-                +e.title.is-vertical-top 興味あるサービス
-                +e.content
-                  +e.checkbox.is-vertical
-                    span
-                      label
-                        input(type="checkbox",name="興味あるサービス",value="選択肢1")
-                        span テキスト
-                    span
-                      label
-                        input(type="checkbox",name="興味あるサービス",value="選択肢2")
-                        span テキストテキスト
-                    span
-                      label
-                        input(type="checkbox",name="興味あるサービス",value="選択肢3")
-                        span テキストテキストテキスト
-                    span
-                      label
-                        input(type="checkbox",name="興味あるサービス",value="選択肢4")
-                        span テキスト
-              +e.block
-                +e.title.is-vertical-top 興味あるサービス
-                +e.content
-                  +e.checkbox.is-design
-                    span
-                      label
-                        input(type="checkbox",name="興味あるサービス",value="選択肢1")
-                        span テキスト
-                    span
-                      label
-                        input(type="checkbox",name="興味あるサービス",value="選択肢2")
-                        span テキストテキスト
-                    span
-                      label
-                        input(type="checkbox",name="興味あるサービス",value="選択肢3")
-                        span テキストテキストテキスト
-                    span
-                      label
-                        input(type="checkbox",name="興味あるサービス",value="選択肢4")
-                        span テキスト
-              +e.block
-                +e.title
-                  | お問い合わせ種別
-                  span.c-forms__label 必須
-                +e.content
-                  +e.select
-                    select(name="お問い合わせ種別")
-                      option(disabled,selected) 選択してください
-                      option(value="選択肢A") 選択肢A
-                      option(value="選択肢B") 選択肢B
-                      option(value="選択肢C") 選択肢C
-              +e.block
-                +e.title.is-vertical-top
-                  | お問い合わせ種別
-                  span.c-forms__label 必須
-                +e.content
-                  +e.radio.is-vertical
-                    span
-                      label
-                        input(type="radio",name="お問い合わせ種別",value="選択肢1")
-                        span 選択肢1
-                    span
-                      label
-                        input(type="radio",name="お問い合わせ種別",value="選択肢2")
-                        span 選択肢2
-                    span
-                      label
-                        input(type="radio",name="お問い合わせ種別",value="選択肢3")
-                        span 選択肢3
-                    span
-                      label
-                        input(type="radio",name="お問い合わせ種別",value="選択肢4")
-                        span 選択肢4
-              +e.block
-                +e.title
-                  | お問い合わせ種別
-                  span.c-forms__label 必須
-                +e.content
-                  +e.radio.is-design.is-border
-                    span
-                      label
-                        input(type="radio",name="お問い合わせ種別",value="選択肢1")
-                        span 選択肢1
-                    span
-                      label
-                        input(type="radio",name="お問い合わせ種別",value="選択肢2")
-                        span 選択肢2
-                    span
-                      label
-                        input(type="radio",name="お問い合わせ種別",value="選択肢3")
-                        span 選択肢3
-                    span
-                      label
-                        input(type="radio",name="お問い合わせ種別",value="選択肢4")
-                        span 選択肢4
-              +e.block
-                +e.title.is-vertical-top お問い合わせ内容
-                +e.content
-                  +e.textarea
-                    textarea(name="テキストエリア",placeholder="お問い合わせ内容をご記入ください。")
-              +e.block
-                +e.title.is-vertical-top ご連絡方法
-                +e.content
-                  +e.checkbox
-                    span
-                      label
-                        input(type="checkbox",name="ご連絡方法",value="電話")
-                        span 電話
-                    span
-                      label
-                        input(type="checkbox",name="ご連絡方法",value="メール")
-                        span メール
-                    span
-                      label
-                        input(type="checkbox",name="ご連絡方法",value="いずれでも可")
-                        span いずれでも可
-              +e.block
-                +e.title.is-vertical-top.is-just
-                  | 住所
-                  span.c-forms__label 必須
-                +e.content
-                  +e.flexbox
-                    span 郵便番号
-                    +e.flex-al
-                      +e.input.is-sm: input(type="text",name="郵便番号",placeholder="（例）464-0850")
-                      button(onclick="AjaxZip3.zip2addr('郵便番号','','ご住所','ご住所');",type="button").c-forms__button#zipauto 住所を自動入力
-                  +e.flexbox
-                    span ご住所
-                    +e.input: input(type="text",name="ご住所",placeholder="（例）愛知県名古屋市千種区今池3丁目12-20 KAビル 6F")
-              +e.block
-                +e.title
-                  | 郵便番号
-                  span.c-forms__label 必須
-                +e.content
+            +e.block
+              +e.title
+                | お名前
+                span.c-forms__label 必須
+              +e.content
+                +e.input: input(type="text",name="お名前",placeholder="山田　太郎")
+            +e.block
+              +e.title
+                | お名前フリガナ
+                span.c-forms__label 必須
+              +e.content
+                +e.input: input(type="text",name="お名前フリガナ",placeholder="ヤマダ　タロウ")
+            +e.block
+              +e.title
+                | メールアドレス
+                span.c-forms__label 必須
+              +e.content
+                +e.input: input(type="text",name="メールアドレス",placeholder="（例）info@mail.jp")
+            +e.block
+              +e.title
+                | TEL
+                span.c-forms__label 必須
+              +e.content
+                +e.input: input(type="text",name="TEL",placeholder="（例）000-0000-0000")
+            +e.block
+              +e.title
+                | 履歴書（PDF）
+              +e.content
+                +e.file: input(type="file",name="履歴書（PDF）")
+            +e.block
+              +e.title
+                | 職務経歴書（PDF）
+              +e.content
+                +e.file: input(type="file",name="職務経歴書（PDF）")
+            +e.block
+              +e.title.is-vertical-top 興味あるサービス
+              +e.content
+                +e.checkbox.is-vertical
+                  span
+                    label
+                      input(type="checkbox",name="興味あるサービス",value="選択肢1")
+                      span テキスト
+                  span
+                    label
+                      input(type="checkbox",name="興味あるサービス",value="選択肢2")
+                      span テキストテキスト
+                  span
+                    label
+                      input(type="checkbox",name="興味あるサービス",value="選択肢3")
+                      span テキストテキストテキスト
+                  span
+                    label
+                      input(type="checkbox",name="興味あるサービス",value="選択肢4")
+                      span テキスト
+            +e.block
+              +e.title.is-vertical-top 興味あるサービス
+              +e.content
+                +e.checkbox.is-design
+                  span
+                    label
+                      input(type="checkbox",name="興味あるサービス",value="選択肢1")
+                      span テキスト
+                  span
+                    label
+                      input(type="checkbox",name="興味あるサービス",value="選択肢2")
+                      span テキストテキスト
+                  span
+                    label
+                      input(type="checkbox",name="興味あるサービス",value="選択肢3")
+                      span テキストテキストテキスト
+                  span
+                    label
+                      input(type="checkbox",name="興味あるサービス",value="選択肢4")
+                      span テキスト
+            +e.block
+              +e.title
+                | お問い合わせ種別
+                span.c-forms__label 必須
+              +e.content
+                +e.select
+                  select(name="お問い合わせ種別")
+                    option(disabled,selected) 選択してください
+                    option(value="選択肢A") 選択肢A
+                    option(value="選択肢B") 選択肢B
+                    option(value="選択肢C") 選択肢C
+            +e.block
+              +e.title.is-vertical-top
+                | お問い合わせ種別
+                span.c-forms__label 必須
+              +e.content
+                +e.radio.is-vertical
+                  span
+                    label
+                      input(type="radio",name="お問い合わせ種別",value="選択肢1")
+                      span 選択肢1
+                  span
+                    label
+                      input(type="radio",name="お問い合わせ種別",value="選択肢2")
+                      span 選択肢2
+                  span
+                    label
+                      input(type="radio",name="お問い合わせ種別",value="選択肢3")
+                      span 選択肢3
+                  span
+                    label
+                      input(type="radio",name="お問い合わせ種別",value="選択肢4")
+                      span 選択肢4
+            +e.block
+              +e.title
+                | お問い合わせ種別
+                span.c-forms__label 必須
+              +e.content
+                +e.radio.is-design.is-border
+                  span
+                    label
+                      input(type="radio",name="お問い合わせ種別",value="選択肢1")
+                      span 選択肢1
+                  span
+                    label
+                      input(type="radio",name="お問い合わせ種別",value="選択肢2")
+                      span 選択肢2
+                  span
+                    label
+                      input(type="radio",name="お問い合わせ種別",value="選択肢3")
+                      span 選択肢3
+                  span
+                    label
+                      input(type="radio",name="お問い合わせ種別",value="選択肢4")
+                      span 選択肢4
+            +e.block
+              +e.title.is-vertical-top お問い合わせ内容
+              +e.content
+                +e.textarea
+                  textarea(name="テキストエリア",placeholder="お問い合わせ内容をご記入ください。")
+            +e.block
+              +e.title.is-vertical-top ご連絡方法
+              +e.content
+                +e.checkbox
+                  span
+                    label
+                      input(type="checkbox",name="ご連絡方法",value="電話")
+                      span 電話
+                  span
+                    label
+                      input(type="checkbox",name="ご連絡方法",value="メール")
+                      span メール
+                  span
+                    label
+                      input(type="checkbox",name="ご連絡方法",value="いずれでも可")
+                      span いずれでも可
+            +e.block
+              +e.title.is-vertical-top.is-just
+                | 住所
+                span.c-forms__label 必須
+              +e.content
+                +e.flexbox
+                  span 郵便番号
                   +e.flex-al
                     +e.input.is-sm: input(type="text",name="郵便番号",placeholder="（例）464-0850")
-                    button(onclick="AjaxZip3.zip2addr('郵便番号','','住所','住所');",type="button").c-forms__button#zipauto 住所を自動入力
-              +e.block
-                +e.title
-                  | 住所
-                  span.c-forms__label 必須
-                +e.content
-                  +e.input: input(type="text",name="住所",placeholder="（例）愛知県名古屋市千種区今池3丁目12-20 KAビル 6F")
-              +e.block
-                +e.title.is-vertical-top お問い合わせ内容
-                +e.content
-                  +e.textarea
-                    textarea(name="テキストエリア",placeholder="お問い合わせ内容をご記入ください。")
+                    button(onclick="AjaxZip3.zip2addr('郵便番号','','ご住所','ご住所');",type="button").c-forms__button#zipauto 住所を自動入力
+                +e.flexbox
+                  span ご住所
+                  +e.input: input(type="text",name="ご住所",placeholder="（例）愛知県名古屋市千種区今池3丁目12-20 KAビル 6F")
+            +e.block
+              +e.title
+                | 郵便番号
+                span.c-forms__label 必須
+              +e.content
+                +e.flex-al
+                  +e.input.is-sm: input(type="text",name="郵便番号",placeholder="（例）464-0850")
+                  button(onclick="AjaxZip3.zip2addr('郵便番号','','住所','住所');",type="button").c-forms__button#zipauto 住所を自動入力
+            +e.block
+              +e.title
+                | 住所
+                span.c-forms__label 必須
+              +e.content
+                +e.input: input(type="text",name="住所",placeholder="（例）愛知県名古屋市千種区今池3丁目12-20 KAビル 6F")
+            +e.block
+              +e.title.is-vertical-top お問い合わせ内容
+              +e.content
+                +e.textarea
+                  textarea(name="テキストエリア",placeholder="お問い合わせ内容をご記入ください。")
 
-            +e.privacy
-              label
-                input(type="checkbox",name="「個人情報保護の取り扱いに関するご確認」を確認する",value="確認しました")
-                +a("/privacy-policy/")(target="_blank") 個人情報保護方針
-                | の内容に同意する
-            +e.submit
-              button.c-button.is-xlg 確認画面へ
-              //button.c-button.c-forms__submit__back.is-lg.is-secondary.is-arrow-left 戻る
-              //button.c-button.c-forms__submit__submit.is-lg 送信する
+          +e.privacy
+            label
+              input(type="checkbox",name="「個人情報保護の取り扱いに関するご確認」を確認する",value="確認しました")
+              +a("/privacy-policy/")(target="_blank") 個人情報保護方針
+              | の内容に同意する
+          +e.submit
+            button.c-button.is-xlg 確認画面へ
+            //button.c-button.c-forms__submit__back.is-lg.is-secondary.is-arrow-left 戻る
+            //button.c-button.c-forms__submit__submit.is-lg 送信する

--- a/app/download/index.pug
+++ b/app/download/index.pug
@@ -16,38 +16,38 @@ block page_header
   //+c_breadcrumb()
 
 block body
-  main.l-main
-    section.l-section.is-lg.is-bg-color
-      .l-container
-        +c_anchor-nav("u-mbs is-bottom",{
-          link: "#block01",
-          title: "タイトル1",
-        },{
-          link: "#block02",
-          title: "タイトル2",
-        })
-        +c.card-download.u-mbs.is-top#block01
-          +e.head.c-heading.is-sm.is-mg-level-4: b.is-main タイトル1
-          +e.blocks
-            +loop(3)
-              +ae("/download/page/").block
-                +e.image
-                  +bgimg("img-card-01.jpg").bg-img
-                  +e.label.c-label テキスト
-                +e.content
-                  +e.title.c-heading.is-xxs テキストテキスト
-                  +e.button: .c-button テキストテキスト
-        +c.card-download.is-three-col.u-mbs.is-lg.is-top#block02
-          +e.head.c-heading.is-sm.is-mg-level-4: b.is-main タイトル2
-          +e.blocks
-            +loop(6)
-              +ae("/download/page/").block
-                +e.image
-                  .is-no NO IMAGE
-                  +e.label.c-label テキスト
-                +e.content
-                  +e.title.c-heading.is-xxxs テキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキスト
-                  +e.button: .c-button テキストテキスト
-
+  section.l-section.is-lg.is-bg-color
+    .l-container
+      +c_anchor-nav("u-mbs is-bottom",{
+        link: "#block01",
+        title: "タイトル1",
+      },{
+        link: "#block02",
+        title: "タイトル2",
+      })
+      +c.card-download.u-mbs.is-top#block01
+        +e.head.c-heading.is-sm.is-mg-level-4: b.is-main タイトル1
+        +e.blocks
+          +loop(3)
+            +ae("/download/page/").block
+              +e.image
+                +bgimg("img-card-01.jpg").bg-img
+                +e.label.c-label テキスト
+              +e.content
+                +e.title.c-heading.is-xxs テキストテキスト
+                +e.button: .c-button テキストテキスト
+      +c.card-download.is-three-col.u-mbs.is-lg.is-top#block02
+        +e.head.c-heading.is-sm.is-mg-level-4: b.is-main タイトル2
+        +e.blocks
+          +loop(6)
+            +ae("/download/page/").block
+              +e.image
+                .is-no NO IMAGE
+                +e.label.c-label テキスト
+              +e.content
+                +e.title.c-heading.is-xxxs テキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキスト
+                +e.button: .c-button テキストテキスト
+                  
+block before_footer
   +l_offer
 

--- a/app/download/page/index.pug
+++ b/app/download/page/index.pug
@@ -10,76 +10,75 @@ block append config
 block page_header
 
 block body
-  main.l-main
-    section.l-section.is-lg.is-bg-color
-      .l-container
-        +c.form-head
-          +e.block
-            +h1.title.c-heading.is-md.is-mg-level-1.is-bottom: b.is-main 資料ダウンロードサンプル詳細
-        +c.block-document
-          +e.inner
-            +e.detail
-              +e.head.c-heading.is-sm.is-mg-level-3.is-bottom: b.is-main こんな方にオススメ
-              +ul.list.c-list.is-disc
-                li リストテキスト1
-                li リストテキスト2
-                li リストテキスト3
-                li リストテキスト4
-              +e.images
-                +e.image: .is-no NO IMAGE
-                +loop(5)
-                  +e.image.js-modal-image(data-modaal-content-source="/assets/images/img-card-01.jpg"): +bgimg("img-card-01.jpg").bg-img
-              +e.slider.swiper
-                .swiper-wrapper
-                  +e.image.swiper-slide: .is-no NO IMAGE
-                  +loop(3)
-                    +e.image.swiper-slide: +bgimg("img-card-01.jpg").bg-img
-                .swiper-nav
-                  .swiper-button-prev
-                  .swiper-button-next
-            +e("form").form
-              +e.subhead.c-heading.is-xs.is-mg-level-4 ダウンロードフォーム
-              +e.blocks
-                +e.block
-                  +e.title
-                    span.c-block-document__label 必須
-                    | 会社名
-                  +e.content
-                    +e.input: input(type="text",name="会社名",placeholder="例 : 株式会社カンパニー")
-                +e.block
-                  +e.title
-                    span.c-block-document__label 必須
-                    | ご担当者様名
-                  +e.content
-                    +e.input: input(type="text",name="ご担当者様名",placeholder="山田 太郎")
-                +e.block
-                  +e.title
-                    span.c-block-document__label 必須
-                    | メールアドレス
-                  +e.content
-                    +e.input: input(type="text",name="メールアドレス",placeholder="info@mail.com")
-                +e.block
-                  +e.title.is-vertical-top
-                    span.c-block-document__label 必須
-                    | 制作の開始時期について
-                  +e.content
-                    +e.select
-                      select(name="制作の開始時期について")
-                        option(value="" disabled selected) 選択してください
-                        option(value="1") 2023年
-                        option(value="2") 2022年
-                        option(value="3") 2021年
-                +e.block
-                  +e.title.is-vertical-top
-                    span.c-block-document__label 必須
-                    | 制作の開始時期について
-                  +e.textarea
-                    textarea(name="テキストエリア",placeholder="お問い合わせ内容をご記入ください。")
+  section.l-section.is-lg.is-bg-color
+    .l-container
+      +c.form-head
+        +e.block
+          +h1.title.c-heading.is-md.is-mg-level-1.is-bottom: b.is-main 資料ダウンロードサンプル詳細
+      +c.block-document
+        +e.inner
+          +e.detail
+            +e.head.c-heading.is-sm.is-mg-level-3.is-bottom: b.is-main こんな方にオススメ
+            +ul.list.c-list.is-disc
+              li リストテキスト1
+              li リストテキスト2
+              li リストテキスト3
+              li リストテキスト4
+            +e.images
+              +e.image: .is-no NO IMAGE
+              +loop(5)
+                +e.image.js-modal-image(data-modaal-content-source="/assets/images/img-card-01.jpg"): +bgimg("img-card-01.jpg").bg-img
+            +e.slider.swiper
+              .swiper-wrapper
+                +e.image.swiper-slide: .is-no NO IMAGE
+                +loop(3)
+                  +e.image.swiper-slide: +bgimg("img-card-01.jpg").bg-img
+              .swiper-nav
+                .swiper-button-prev
+                .swiper-button-next
+          +e("form").form
+            +e.subhead.c-heading.is-xs.is-mg-level-4 ダウンロードフォーム
+            +e.blocks
+              +e.block
+                +e.title
+                  span.c-block-document__label 必須
+                  | 会社名
+                +e.content
+                  +e.input: input(type="text",name="会社名",placeholder="例 : 株式会社カンパニー")
+              +e.block
+                +e.title
+                  span.c-block-document__label 必須
+                  | ご担当者様名
+                +e.content
+                  +e.input: input(type="text",name="ご担当者様名",placeholder="山田 太郎")
+              +e.block
+                +e.title
+                  span.c-block-document__label 必須
+                  | メールアドレス
+                +e.content
+                  +e.input: input(type="text",name="メールアドレス",placeholder="info@mail.com")
+              +e.block
+                +e.title.is-vertical-top
+                  span.c-block-document__label 必須
+                  | 制作の開始時期について
+                +e.content
+                  +e.select
+                    select(name="制作の開始時期について")
+                      option(value="" disabled selected) 選択してください
+                      option(value="1") 2023年
+                      option(value="2") 2022年
+                      option(value="3") 2021年
+              +e.block
+                +e.title.is-vertical-top
+                  span.c-block-document__label 必須
+                  | 制作の開始時期について
+                +e.textarea
+                  textarea(name="テキストエリア",placeholder="お問い合わせ内容をご記入ください。")
 
-              +e.privacy
-                label
-                  input(type="checkbox",name="「個人情報保護の取り扱いに関するご確認」を確認する",value="確認しました")
-                  +a-ex("https://www.kyoritsugroup.co.jp/privacy/") 個人情報保護方針
-                  | の内容に同意する
-              +e.submit
-                button.c-button 資料ダウンロード
+            +e.privacy
+              label
+                input(type="checkbox",name="「個人情報保護の取り扱いに関するご確認」を確認する",value="確認しました")
+                +a-ex("https://www.kyoritsugroup.co.jp/privacy/") 個人情報保護方針
+                | の内容に同意する
+            +e.submit
+              button.c-button 資料ダウンロード

--- a/app/format/index.pug
+++ b/app/format/index.pug
@@ -7,14 +7,16 @@ block append config
   - current.path = `/${current.id}/` // ページのpath
   - current.depth = 2 // ページの階層
 
-block body
+block page_header
   // メインビジュアル
   +l_page_header({
-      image: "img-page-header-format.jpg",
-      title: "量産ページ",
-      subtitle: "parent"
+    image: "img-page-header-format.jpg",
+    title: "量産ページ",
+    subtitle: "parent"
   })
   +c_breadcrumb()
+
+block body
   section.l-section.is-lg
     .l-container
 
@@ -35,5 +37,7 @@ block body
           include /format/components/_tab.pug
 
 
+block before_footer
+  +l_offer()
 
 

--- a/app/inc/foundation/_base.pug
+++ b/app/inc/foundation/_base.pug
@@ -9,7 +9,12 @@ block layout
   block page_header
 
   //- メインコンテンツ
-  block body
+  block before_main
+
+  main.l-main
+    block body
+
+  block before_footer
 
   //- フッター
   block footer

--- a/app/index.pug
+++ b/app/index.pug
@@ -10,76 +10,80 @@ block append config
   - current.path = "/" // ページのpath
   - current.depth = 1 // ページの階層
 
-block body
+
+block before_main
   +c_loader
   +c_main-visual()
-  main.l-main
-    section.l-section.is-lg.is-color-secondary
-      .l-container
-        +heading-xlg("私たちについて", "ABOUT").is-bottom
-        p.u-text-center テキストテキストテキストテキストテキストテキストテキストテキストテキスト<br>テキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキスト
-        +c.card.u-mbs.is-top.is-lg
-          .row.slide
-            .large-4.small-12
-              +e.block
-                +e.image: +img("img-card-01.jpg")
-                +e.content
-                  h3.c-card__title コンセプトタイトル
-                  p.c-card__text ここにテキストが入ります。ここにテキストが入ります。ここにテキストが入ります。ここにテキストが入ります。ここにテキストが入ります。
-            .large-4.small-12
-              +e.block
-                +e.image: +img("img-card-01.jpg")
-                +e.content
-                  h3.c-card__title コンセプトタイトル
-                  p.c-card__text ここにテキストが入ります。ここにテキストが入ります。ここにテキストが入ります。ここにテキストが入ります。ここにテキストが入ります。
-            .large-4.small-12
-              +e.block
-                +e.image: +img("img-card-01.jpg")
-                +e.content
-                  h3.c-card__title コンセプトタイトル
-                  p.c-card__text ここにテキストが入ります。ここにテキストが入ります。ここにテキストが入ります。ここにテキストが入ります。ここにテキストが入ります。
-    section.l-section.is-lg.is-top
-      .l-container
-        +heading-xlg("事業内容", "SERVICE").is-bottom
-      +c.hero-block-square
-        +e.block
-          +e.image: +img("img-hero-block-01.jpg")
-          .l-container
-            +e.content
-              +e.inner
-                h3.c-heading.is-sm.is-bottom タイトルがここに入ります。
-                p テキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキスト
-                +e.button: +a("#").c-button.is-sm ボタンテキスト
-        +e.block
-          +e.image: +img("img-hero-block-01.jpg")
-          .l-container
-            +e.content
-              +e.inner
-                h3.c-heading.is-sm.is-bottom タイトルがここに入ります。
-                p テキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキスト
-                +e.button: +a("#").c-button.is-sm ボタンテキスト
-        +e.block
-          +e.image: +img("img-hero-block-01.jpg")
-          .l-container
-            +e.content
-              +e.inner
-                h3.c-heading.is-sm.is-bottom タイトルがここに入ります。
-                p テキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキスト
-                +e.button: +a("#").c-button.is-sm ボタンテキスト
-    section.l-section.is-lg
-      .l-container
-        +c.news
-          .row
-            .large-3.small-12
-              +e.head
-                h2.c-news__title.c-heading.is-xlg
-                  span NEWS
-                  small お知らせ
-                +e.button: +a("/news/").c-button.is-sm 一覧を見る
-            .large-9.small-12
+
+block body
+  section.l-section.is-lg.is-color-secondary
+    .l-container
+      +heading-xlg("私たちについて", "ABOUT").is-bottom
+      p.u-text-center テキストテキストテキストテキストテキストテキストテキストテキストテキスト<br>テキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキスト
+      +c.card.u-mbs.is-top.is-lg
+        .row.slide
+          .large-4.small-12
+            +e.block
+              +e.image: +img("img-card-01.jpg")
               +e.content
-                +loop(3)
-                  +c_news__block("home")
+                h3.c-card__title コンセプトタイトル
+                p.c-card__text ここにテキストが入ります。ここにテキストが入ります。ここにテキストが入ります。ここにテキストが入ります。ここにテキストが入ります。
+          .large-4.small-12
+            +e.block
+              +e.image: +img("img-card-01.jpg")
+              +e.content
+                h3.c-card__title コンセプトタイトル
+                p.c-card__text ここにテキストが入ります。ここにテキストが入ります。ここにテキストが入ります。ここにテキストが入ります。ここにテキストが入ります。
+          .large-4.small-12
+            +e.block
+              +e.image: +img("img-card-01.jpg")
+              +e.content
+                h3.c-card__title コンセプトタイトル
+                p.c-card__text ここにテキストが入ります。ここにテキストが入ります。ここにテキストが入ります。ここにテキストが入ります。ここにテキストが入ります。
+  section.l-section.is-lg.is-top
+    .l-container
+      +heading-xlg("事業内容", "SERVICE").is-bottom
+    +c.hero-block-square
+      +e.block
+        +e.image: +img("img-hero-block-01.jpg")
+        .l-container
+          +e.content
+            +e.inner
+              h3.c-heading.is-sm.is-bottom タイトルがここに入ります。
+              p テキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキスト
+              +e.button: +a("#").c-button.is-sm ボタンテキスト
+      +e.block
+        +e.image: +img("img-hero-block-01.jpg")
+        .l-container
+          +e.content
+            +e.inner
+              h3.c-heading.is-sm.is-bottom タイトルがここに入ります。
+              p テキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキスト
+              +e.button: +a("#").c-button.is-sm ボタンテキスト
+      +e.block
+        +e.image: +img("img-hero-block-01.jpg")
+        .l-container
+          +e.content
+            +e.inner
+              h3.c-heading.is-sm.is-bottom タイトルがここに入ります。
+              p テキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキスト
+              +e.button: +a("#").c-button.is-sm ボタンテキスト
+  section.l-section.is-lg
+    .l-container
+      +c.news
+        .row
+          .large-3.small-12
+            +e.head
+              h2.c-news__title.c-heading.is-xlg
+                span NEWS
+                small お知らせ
+              +e.button: +a("/news/").c-button.is-sm 一覧を見る
+          .large-9.small-12
+            +e.content
+              +loop(3)
+                +c_news__block("home")
+
+block before_footer
   +c_cookie
   // オファーブロック
   +l_offer

--- a/app/news/category/index.pug
+++ b/app/news/category/index.pug
@@ -16,14 +16,15 @@ block page_header
   +c_breadcrumb("お知らせ","news")
 
 block body
-  main.l-main
-    section.l-section.is-lg
-      .l-container.is-sm
-        +c.news.is-onecolumn
-          h2.c-news__title.c-heading.is-md.is-line-under.is-color-primary カテゴリ
-          +e.content
-            +loop(10)
-              +c_news__block("is-news")
-        +c_pagination()
+  section.l-section.is-lg
+    .l-container.is-sm
+      +c.news.is-onecolumn
+        h2.c-news__title.c-heading.is-md.is-line-under.is-color-primary カテゴリ
+        +e.content
+          +loop(10)
+            +c_news__block("is-news")
+      +c_pagination()
+
+block before_footer
   +l_offer
 

--- a/app/news/category/page/index.pug
+++ b/app/news/category/page/index.pug
@@ -16,321 +16,322 @@ block page_header
   +c_breadcrumb("お知らせ","news","カテゴリ","category")
 
 block body
-  main.l-main
-    section.l-section.is-lg
-      .l-container.is-sm
-        +c.news-header
-          h1.c-news-header__title ここに記事のタイトルが入ります。 ここに記事のタイトルが入ります。 ここに記事のタイトルが入ります。
-          +e.sup
-            +e.label.c-label カテゴリ
-            +e.date 2018.10.10
-            +e.tag
-              ul
-                li: +a("#") #タグ
-                li: +a("#") #タグ
-                li: +a("#") #タグ
-        .l-post-content
-          +img("ogp.png")
-          <div id="toc_container" class="no_bullets"><p class="toc_title">目次 <span class="toc_toggle">[<a href="#">非表示</a>]</span></p><ul class="toc_list"><li><a href="#Web"><span class="toc_number toc_depth_1">1</span> Webマーケティングとは？</a></li><li><a href="#Web-2"><span class="toc_number toc_depth_1">2</span> Webマーケティングのメリットとは？</a><ul><li><a href="#i"><span class="toc_number toc_depth_2">2.1</span> あらゆる方たちに配信ができる</a></li><li><a href="#i-2"><span class="toc_number toc_depth_2">2.2</span> 素早く情報を配信できる</a></li><li><a href="#i-3"><span class="toc_number toc_depth_2">2.3</span> 修正を簡単に実行できる</a></li><li><a href="#i-4"><span class="toc_number toc_depth_2">2.4</span> 少ない費用で情報を配信できる</a></li><li><a href="#i-5"><span class="toc_number toc_depth_2">2.5</span> ターゲットを細かく設定できる</a></li></ul></li></ul></div>
+  section.l-section.is-lg
+    .l-container.is-sm
+      +c.news-header
+        h1.c-news-header__title ここに記事のタイトルが入ります。 ここに記事のタイトルが入ります。 ここに記事のタイトルが入ります。
+        +e.sup
+          +e.label.c-label カテゴリ
+          +e.date 2018.10.10
+          +e.tag
+            ul
+              li: +a("#") #タグ
+              li: +a("#") #タグ
+              li: +a("#") #タグ
+      .l-post-content
+        +img("ogp.png")
+        <div id="toc_container" class="no_bullets"><p class="toc_title">目次 <span class="toc_toggle">[<a href="#">非表示</a>]</span></p><ul class="toc_list"><li><a href="#Web"><span class="toc_number toc_depth_1">1</span> Webマーケティングとは？</a></li><li><a href="#Web-2"><span class="toc_number toc_depth_1">2</span> Webマーケティングのメリットとは？</a><ul><li><a href="#i"><span class="toc_number toc_depth_2">2.1</span> あらゆる方たちに配信ができる</a></li><li><a href="#i-2"><span class="toc_number toc_depth_2">2.2</span> 素早く情報を配信できる</a></li><li><a href="#i-3"><span class="toc_number toc_depth_2">2.3</span> 修正を簡単に実行できる</a></li><li><a href="#i-4"><span class="toc_number toc_depth_2">2.4</span> 少ない費用で情報を配信できる</a></li><li><a href="#i-5"><span class="toc_number toc_depth_2">2.5</span> ターゲットを細かく設定できる</a></li></ul></li></ul></div>
 
-          h2 見出し弐
-          p テキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキスト
-          h3 見出し参
-          p テキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキスト
-          h4 見出し四
-          p テキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキスト
-          h5 見出し五
-          p テキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキスト
-          h6 見出し六
-          p テキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキスト
+        h2 見出し弐
+        p テキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキスト
+        h3 見出し参
+        p テキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキスト
+        h4 見出し四
+        p テキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキスト
+        h5 見出し五
+        p テキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキスト
+        h6 見出し六
+        p テキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキスト
 
-          p
-            strong 強調テキスト強調テキスト強調テキスト強調テキスト強調テキスト強調テキスト強調テキスト強調テキスト強調テキスト強調テキスト強調テキスト強調テキスト強調テキスト強調テキスト強調テキスト強調テキスト強調テキスト
-          p
-            small 小さいテキスト小さいテキスト小さいテキスト小さいテキスト小さいテキスト小さいテキスト小さいテキスト小さいテキスト小さいテキスト小さいテキスト小さいテキスト小さいテキスト小さいテキスト小さいテキスト
-          p
-            a リンクテキストリンクテキストリンクテキストリンクテキストリンクテキストリンクテキストリンクテキストリンクテキストリンクテキストリンクテキストリンクテキストリンクテキストリンクテキスト
-          h2 引用 (Blockquote)
-          | 一行の引用:
-          blockquote 貪欲であれ、愚かであれ
-          h2 引用 (Blockquote)
-          | 引用元の参照のある複数行の引用:
-          blockquote
-            | 集中という意味は集中しなくてはいけないことにイエスということだと、人は言います。しかし、それはまったく違います。そうではなく、そこにある何百ものいいアイディアにノーということなのです。慎重に選択しなくてはいけません。実際、私は成し遂げたことと同じように成し遂げられなかったことにも満足しています。革新というのは1000ものことにノーということなのです。
-            cite スティーブ・ジョブズ - 1997年 Apple 世界的開発者会議
+        p
+          strong 強調テキスト強調テキスト強調テキスト強調テキスト強調テキスト強調テキスト強調テキスト強調テキスト強調テキスト強調テキスト強調テキスト強調テキスト強調テキスト強調テキスト強調テキスト強調テキスト強調テキスト
+        p
+          small 小さいテキスト小さいテキスト小さいテキスト小さいテキスト小さいテキスト小さいテキスト小さいテキスト小さいテキスト小さいテキスト小さいテキスト小さいテキスト小さいテキスト小さいテキスト小さいテキスト
+        p
+          a リンクテキストリンクテキストリンクテキストリンクテキストリンクテキストリンクテキストリンクテキストリンクテキストリンクテキストリンクテキストリンクテキストリンクテキストリンクテキスト
+        h2 引用 (Blockquote)
+        | 一行の引用:
+        blockquote 貪欲であれ、愚かであれ
+        h2 引用 (Blockquote)
+        | 引用元の参照のある複数行の引用:
+        blockquote
+          | 集中という意味は集中しなくてはいけないことにイエスということだと、人は言います。しかし、それはまったく違います。そうではなく、そこにある何百ものいいアイディアにノーということなのです。慎重に選択しなくてはいけません。実際、私は成し遂げたことと同じように成し遂げられなかったことにも満足しています。革新というのは1000ものことにノーということなのです。
+          cite スティーブ・ジョブズ - 1997年 Apple 世界的開発者会議
 
-          h2 テーブル
-          table
-            tbody
-              tr
-                th 従業員
-                th 給与
-                th
-              tr
-                td: a(href=".") ジェーン
-                td $￥1
-                td スティーブ・ジョブズの必要な給与。
-              tr
-                td: a(href=".") ジョン
-                td ￥10万
-                td ブログのすべて。
-              tr
-                td: a(href=".") ジェーン
-                td ￥1億
-                td 百聞は一見にしかず。だよね ? なのでトムは1000倍。
-              tr
-                td: a(href=".") ジェーン
-                td ￥1000億
-                td これみたいな髪?! もういいよね…
-          h2 定義リスト
-          dl
-            dt 定義リストタイトル
-            dd これは定義リストです。
-            dt スタートアップ
-            dd スタートアップ会社もしくはスタートアップとは、反復可能でスケーラブルなビジネスモデルを追い求める会社もしくは一時的な組織です。
-            dt #dowork
-            dd ロブ・ダイデクと彼の個人的なボディーガードのクリストファー"ビッグ・ブラック"ボイキンスが作った言い回しで、"仕事しよう" が自己動機付けとして、友達を動機付けるために機能する。
-            dt ライブでやろう
-            dd ビル・オライリーが <a title="We'll Do It Live" href="https://www.youtube.com/watch?v=O_HyZ5aW76c">説明</a> してもらいましょう。
+        h2 テーブル
+        table
+          tbody
+            tr
+              th 従業員
+              th 給与
+              th
+            tr
+              td: a(href=".") ジェーン
+              td $￥1
+              td スティーブ・ジョブズの必要な給与。
+            tr
+              td: a(href=".") ジョン
+              td ￥10万
+              td ブログのすべて。
+            tr
+              td: a(href=".") ジェーン
+              td ￥1億
+              td 百聞は一見にしかず。だよね ? なのでトムは1000倍。
+            tr
+              td: a(href=".") ジェーン
+              td ￥1000億
+              td これみたいな髪?! もういいよね…
+        h2 定義リスト
+        dl
+          dt 定義リストタイトル
+          dd これは定義リストです。
+          dt スタートアップ
+          dd スタートアップ会社もしくはスタートアップとは、反復可能でスケーラブルなビジネスモデルを追い求める会社もしくは一時的な組織です。
+          dt #dowork
+          dd ロブ・ダイデクと彼の個人的なボディーガードのクリストファー"ビッグ・ブラック"ボイキンスが作った言い回しで、"仕事しよう" が自己動機付けとして、友達を動機付けるために機能する。
+          dt ライブでやろう
+          dd ビル・オライリーが <a title="We'll Do It Live" href="https://www.youtube.com/watch?v=O_HyZ5aW76c">説明</a> してもらいましょう。
 
-          h2 非順序リスト（ネスト化）
-          ul
-            li リストアイテム1
-              ul
-                li リストアイテム1
-                  ul
-                    li リストアイテム1
-                    li リストアイテム2
-                    li リストアイテム3
-                    li リストアイテム4
-                li リストアイテム2
-                li リストアイテム3
-                li リストアイテム4
-            li リストアイテム2
-            li リストアイテム3
-            li リストアイテム4
+        h2 非順序リスト（ネスト化）
+        ul
+          li リストアイテム1
+            ul
+              li リストアイテム1
+                ul
+                  li リストアイテム1
+                  li リストアイテム2
+                  li リストアイテム3
+                  li リストアイテム4
+              li リストアイテム2
+              li リストアイテム3
+              li リストアイテム4
+          li リストアイテム2
+          li リストアイテム3
+          li リストアイテム4
 
-          h2 順序リスト
-          ol
-            li リストアイテム1
-              ol
-                li リストアイテム1
-                  ol
-                    li リストアイテム1
-                    li リストアイテム2
-                    li リストアイテム3
-                    li リストアイテム4
-                li リストアイテム2
-                li リストアイテム3
-                li リストアイテム4
-            li リストアイテム2
-            li リストアイテム3
-            li リストアイテム4
-          h2 HTML　要素タグテスト
-          p 他の HTML タグは <a href="http://ja.support.wordpress.com/code/" rel="nofollow" target="_blank">FAQ</a> をご覧ください。
+        h2 順序リスト
+        ol
+          li リストアイテム1
+            ol
+              li リストアイテム1
+                ol
+                  li リストアイテム1
+                  li リストアイテム2
+                  li リストアイテム3
+                  li リストアイテム4
+              li リストアイテム2
+              li リストアイテム3
+              li リストアイテム4
+          li リストアイテム2
+          li リストアイテム3
+          li リストアイテム4
+        h2 HTML　要素タグテスト
+        p 他の HTML タグは <a href="http://ja.support.wordpress.com/code/" rel="nofollow" target="_blank">FAQ</a> をご覧ください。
 
-          p
-            strong 住所タグ<br>
-            | 以下は住所の例です。<br>
-            code &lt;address&gt;
-            | タグを使用しています:
-            address 〒100-0000 東京都千代田区1-1-1 日本
+        p
+          strong 住所タグ<br>
+          | 以下は住所の例です。<br>
+          code &lt;address&gt;
+          | タグを使用しています:
+          address 〒100-0000 東京都千代田区1-1-1 日本
 
-          p
-            strong anchor タグ (リンク)<br>
-            | これは
-            a(href=".", rel="nofollow")
-              code &lt;anchor&gt;
+        p
+          strong anchor タグ (リンク)<br>
+          | これは
+          a(href=".", rel="nofollow")
+            code &lt;anchor&gt;
 
-          p
-            strong abbr タグ<br>
-            | この
-            abbr(title="abbreviation") abbr
-            | は文章の中にある
-            code &lt;abbr&gt;
-            | タグの例です。
+        p
+          strong abbr タグ<br>
+          | この
+          abbr(title="abbreviation") abbr
+          | は文章の中にある
+          code &lt;abbr&gt;
+          | タグの例です。
 
-          p
-            strong Acronym タグ (<em>HTML5 では非推奨</em>)<br>
-            | これは <code>&lt;acronym&gt;</code> タグを使用した
-            acronym(title="three-letter acronym") TLA
-            | です。
+        p
+          strong Acronym タグ (<em>HTML5 では非推奨</em>)<br>
+          | これは <code>&lt;acronym&gt;</code> タグを使用した
+          acronym(title="three-letter acronym") TLA
+          | です。
 
-          p
-            strong Big タグ(<em>HTML5 では非推奨</em>)
-            | このテストは
-            big 大きな
-            | 文字を表す <code>&lt;big&gt;</code> タグの例ですが、このタグは HTML5 ではサポートされていません。
+        p
+          strong Big タグ(<em>HTML5 では非推奨</em>)
+          | このテストは
+          big 大きな
+          | 文字を表す <code>&lt;big&gt;</code> タグの例ですが、このタグは HTML5 ではサポートされていません。
 
-          p
-            strong Cite タグ<br>
-            | "Code is poetry." --
-            cite WordPress
+        p
+          strong Cite タグ<br>
+          | "Code is poetry." --
+          cite WordPress
 
-          p
-            strong Code タグ<br>
-            code &lt;code&gt;
-            |  タグはこのように使います:<br>
-            code word-wrap: break-word;
+        p
+          strong Code タグ<br>
+          code &lt;code&gt;
+          |  タグはこのように使います:<br>
+          code word-wrap: break-word;
 
-          p
-            strong Delete タグ<br>
-            code &lt;del&gt;
-            |  タグは
-            del 打ち消し線
-            | などで表現されますが、このタグは HTML5 ではサポートされていません (代わりに <code>&lt;strike&gt;</code> を使ってください)。
+        p
+          strong Delete タグ<br>
+          code &lt;del&gt;
+          |  タグは
+          del 打ち消し線
+          | などで表現されますが、このタグは HTML5 ではサポートされていません (代わりに <code>&lt;strike&gt;</code> を使ってください)。
 
-          p
-            strong Emphasize タグ<br>
-            code &lt;em&gt;
-            |  タグは<em>文章の強調</em>に使われます。欧文では斜体になっていることがよくあります。
+        p
+          strong Emphasize タグ<br>
+          code &lt;em&gt;
+          |  タグは<em>文章の強調</em>に使われます。欧文では斜体になっていることがよくあります。
 
-          p
-            strong Insert タグ<br>
-            code &lt;ins&gt;
-            |  タグは
-            ins 挿入されたコンテンツ
-            | を意味します。
+        p
+          strong Insert タグ<br>
+          code &lt;ins&gt;
+          |  タグは
+          ins 挿入されたコンテンツ
+          | を意味します。
 
-          p
-            strong Keyboard タグ<br>
-            | このあまり知られていない
-            code &lt;kbd&gt;
-            |  タグは
-            kbd Ctrl
-            |  のようにキーボードテキストをエミュレートします。通常、<code>&lt;code&gt;</code> タグと同じようにスタイリングされます。
+        p
+          strong Keyboard タグ<br>
+          | このあまり知られていない
+          code &lt;kbd&gt;
+          |  タグは
+          kbd Ctrl
+          |  のようにキーボードテキストをエミュレートします。通常、<code>&lt;code&gt;</code> タグと同じようにスタイリングされます。
 
-          p
-            strong Preformatted タグ<br>
-            code &lt;pre&gt;
-            |  タグは複数行のコードのスタイリングに使います。
-            pre
-              | .post-title {
-              |     margin: 0 0 5px;
-              |     font-weight: bold;
-              |     font-size: 38px;
-              |     line-height: 1.2;
-              |     and here's a line of some really, really, really, really long text, just to see how the PRE tag handles it and to find out how it overflows;
-              | }
+        p
+          strong Preformatted タグ<br>
+          code &lt;pre&gt;
+          |  タグは複数行のコードのスタイリングに使います。
+          pre
+            | .post-title {
+            |     margin: 0 0 5px;
+            |     font-weight: bold;
+            |     font-size: 38px;
+            |     line-height: 1.2;
+            |     and here's a line of some really, really, really, really long text, just to see how the PRE tag handles it and to find out how it overflows;
+            | }
 
-          p
-            strong Quote タグ<br>
-            q デベロッパーズ、デベロッパーズ, デベロッパーズ...
-            | --スティーブ・バルマー
+        p
+          strong Quote タグ<br>
+          q デベロッパーズ、デベロッパーズ, デベロッパーズ...
+          | --スティーブ・バルマー
 
-          p
-            strong Strike タグ (<em>HTML5 では非推奨</em>)<br>
-            | このタグは
-            strike 打ち消し線
-            | を表しています。
+        p
+          strong Strike タグ (<em>HTML5 では非推奨</em>)<br>
+          | このタグは
+          strike 打ち消し線
+          | を表しています。
 
-          p
-            strong Strong タグ<br>
-            | このタグは
-            strong 太字
-            | テキストを表しています。
+        p
+          strong Strong タグ<br>
+          | このタグは
+          strong 太字
+          | テキストを表しています。
 
-          p
-            strong Subscript タグ<br>
-            | Subscript タグ
-            code &lt;sub&gt;
-            |  を使うと H
-            sub 2
-            | O のような表示の際に「2」が下付きになります。
+        p
+          strong Subscript タグ<br>
+          | Subscript タグ
+          code &lt;sub&gt;
+          |  を使うと H
+          sub 2
+          | O のような表示の際に「2」が下付きになります。
 
-          p
-            strong Superscript タグ<br>
-            |  Superscript タグ
-            code &lt;sup&gt;
-            |  を使うと E = MC
-            sup 2
-            | のような表示の際に「2」が上付きになります。
+        p
+          strong Superscript タグ<br>
+          |  Superscript タグ
+          code &lt;sup&gt;
+          |  を使うと E = MC
+          sup 2
+          | のような表示の際に「2」が上付きになります。
 
-          p
-            strong Teletype タグ (<em>HTML5 では非推奨</em>)<br>
-            code &lt;tt&gt;
-            |  はあまり使われないタグですが、
-            tt テレタイプテキスト
-            |  として通常 <code>&lt;code&gt;</code> タグのようにスタイリングされます。
+        p
+          strong Teletype タグ (<em>HTML5 では非推奨</em>)<br>
+          code &lt;tt&gt;
+          |  はあまり使われないタグですが、
+          tt テレタイプテキスト
+          |  として通常 <code>&lt;code&gt;</code> タグのようにスタイリングされます。
 
-          p
-            strong Variable タグ<br>
-            code &lt;tt&gt;
-            |  変数や引数を表す
-            var variables
-            |  タグです。
-
+        p
+          strong Variable タグ<br>
+          code &lt;tt&gt;
+          |  変数や引数を表す
+          var variables
+          |  タグです。
 
 
-          div.u-mbs.is-bottom
-            +c.button-social
 
-        hr.c-hr
-        +c.box-share
-          +e.inner
-            +e.title この記事が気に入ったら<br class="u-hidden-lg">「いいね！」
-            +e.items
-              <div class="fb-like fb_iframe_widget" data-href="https://www.facebook.com/GrowGroupLLC/" data-width="100" data-layout="box_count" data-action="like" data-show-faces="true" data-share="false" fb-xfbml-state="rendered" fb-iframe-plugin-query="action=like&amp;app_id=&amp;container_width=712&amp;href=https%3A%2F%2Fwww.facebook.com%2FGrowGroupLLC%2F&amp;layout=box_count&amp;locale=ja_JP&amp;sdk=joey&amp;share=false&amp;show_faces=true&amp;width=100"><span style="vertical-align: bottom; width: 72px; height: 40px;"><iframe name="ffbce1802e0a34" width="100px" height="1000px" title="fb:like Facebook Social Plugin" frameborder="0" allowtransparency="true" allowfullscreen="true" scrolling="no" allow="encrypted-media" src="https://www.facebook.com/v2.8/plugins/like.php?action=like&amp;app_id=&amp;channel=https%3A%2F%2Fstaticxx.facebook.com%2Fconnect%2Fxd_arbiter.php%3Fversion%3D44%23cb%3Df2abe0a77578bb8%26domain%3Dgrow-group.jp%26origin%3Dhttps%253A%252F%252Fgrow-group.jp%252Ffb94e260fbe5c4%26relation%3Dparent.parent&amp;container_width=712&amp;href=https%3A%2F%2Fwww.facebook.com%2FGrowGroupLLC%2F&amp;layout=box_count&amp;locale=ja_JP&amp;sdk=joey&amp;share=false&amp;show_faces=true&amp;width=100" style="border: none; visibility: visible; width: 72px; height: 40px;" class=""></iframe></span></div>
+        div.u-mbs.is-bottom
+          +c.button-social
 
-        h4 この記事を書いた人
-        +c.block
+      hr.c-hr
+      +c.box-share
+        +e.inner
+          +e.title この記事が気に入ったら<br class="u-hidden-lg">「いいね！」
+          +e.items
+            <div class="fb-like fb_iframe_widget" data-href="https://www.facebook.com/GrowGroupLLC/" data-width="100" data-layout="box_count" data-action="like" data-show-faces="true" data-share="false" fb-xfbml-state="rendered" fb-iframe-plugin-query="action=like&amp;app_id=&amp;container_width=712&amp;href=https%3A%2F%2Fwww.facebook.com%2FGrowGroupLLC%2F&amp;layout=box_count&amp;locale=ja_JP&amp;sdk=joey&amp;share=false&amp;show_faces=true&amp;width=100"><span style="vertical-align: bottom; width: 72px; height: 40px;"><iframe name="ffbce1802e0a34" width="100px" height="1000px" title="fb:like Facebook Social Plugin" frameborder="0" allowtransparency="true" allowfullscreen="true" scrolling="no" allow="encrypted-media" src="https://www.facebook.com/v2.8/plugins/like.php?action=like&amp;app_id=&amp;channel=https%3A%2F%2Fstaticxx.facebook.com%2Fconnect%2Fxd_arbiter.php%3Fversion%3D44%23cb%3Df2abe0a77578bb8%26domain%3Dgrow-group.jp%26origin%3Dhttps%253A%252F%252Fgrow-group.jp%252Ffb94e260fbe5c4%26relation%3Dparent.parent&amp;container_width=712&amp;href=https%3A%2F%2Fwww.facebook.com%2FGrowGroupLLC%2F&amp;layout=box_count&amp;locale=ja_JP&amp;sdk=joey&amp;share=false&amp;show_faces=true&amp;width=100" style="border: none; visibility: visible; width: 72px; height: 40px;" class=""></iframe></span></div>
+
+      h4 この記事を書いた人
+      +c.block
+        .row
+          .large-3.small-4
+            +e.image: +img("img-thumbnail-01.jpg")
+          .large-9.small-8
+            +e.content
+              h6 名前名前
+              p テキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキスト
+              div.u-text-right.u-mbs.is-top.is-xxs
+                +a("").c-button.is-xs この執筆者の記事一覧
+      hr.c-hr
+      +c_post_nav("news")
+      h3 関連コンテンツ
+      +c.news-lg.is-image-display
+        +a("#").c-news-lg__block
+          +e.image: +img("img-thumbnail-01.jpg")
+          +e.content
+            +e.sup
+              +e.label.c-label.is-sm お知らせ
+              +e.date 2018.06.01
+            +e.title お知らせの投稿タイトルがここに入ります。
+            +e.excerpt 本文内容の一文が抜粋されてここに掲載を行います。本文内容の一文が抜粋されてここに掲載を行います。本文内容の一文が抜粋されてここに掲載を行います。本…[続きを見る]
+        +a("#").c-news-lg__block
+          +e.image: +img("img-thumbnail-01.jpg")
+          +e.content
+            +e.sup
+              +e.label.c-label.is-sm お知らせ
+              +e.date 2018.06.01
+            +e.title お知らせの投稿タイトルがここに入ります。
+            +e.excerpt 本文内容の一文が抜粋されてここに掲載を行います。本文内容の一文が抜粋されてここに掲載を行います。本文内容の一文が抜粋されてここに掲載を行います。本…[続きを見る]
+      div.u-mbs.is-top.is-lg
+        +c.card-post.is-tag-hidden
           .row
-            .large-3.small-4
-              +e.image: +img("img-thumbnail-01.jpg")
-            .large-9.small-8
-              +e.content
-                h6 名前名前
-                p テキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキスト
-                div.u-text-right.u-mbs.is-top.is-xxs
-                  +a("").c-button.is-xs この執筆者の記事一覧
-        hr.c-hr
-        +c_post_nav("news")
-        h3 関連コンテンツ
-        +c.news-lg.is-image-display
-          +a("#").c-news-lg__block
-            +e.image: +img("img-thumbnail-01.jpg")
-            +e.content
-              +e.sup
-                +e.label.c-label.is-sm お知らせ
-                +e.date 2018.06.01
-              +e.title お知らせの投稿タイトルがここに入ります。
-              +e.excerpt 本文内容の一文が抜粋されてここに掲載を行います。本文内容の一文が抜粋されてここに掲載を行います。本文内容の一文が抜粋されてここに掲載を行います。本…[続きを見る]
-          +a("#").c-news-lg__block
-            +e.image: +img("img-thumbnail-01.jpg")
-            +e.content
-              +e.sup
-                +e.label.c-label.is-sm お知らせ
-                +e.date 2018.06.01
-              +e.title お知らせの投稿タイトルがここに入ります。
-              +e.excerpt 本文内容の一文が抜粋されてここに掲載を行います。本文内容の一文が抜粋されてここに掲載を行います。本文内容の一文が抜粋されてここに掲載を行います。本…[続きを見る]
-        div.u-mbs.is-top.is-lg
-          +c.card-post.is-tag-hidden
-            .row
-              .large-4.small-6
-                +e.block
-                  +a.c-card-post__image
-                    +img("img-card-01.jpg")
-                  +e.content
-                    +e.sup
-                      span.c-card-post__label.c-label.is-sm カテゴリ名
-                      +e.date 2018.01.01
-                    +e.title タイトルが入ります。タイトルが入ります。
-              .large-4.small-6
-                +e.block
-                  +a.c-card-post__image
-                    +img("img-card-01.jpg")
-                  +e.content
-                    +e.sup
-                      span.c-card-post__label.c-label.is-sm カテゴリ名
-                      +e.date 2018.01.01
-                    +e.title タイトルが入ります。タイトルが入ります。
-              .large-4.small-6
-                +e.block
-                  +a.c-card-post__image
-                    +img("img-card-01.jpg")
-                  +e.content
-                    +e.sup
-                      span.c-card-post__label.c-label.is-sm カテゴリ名
-                      +e.date 2018.01.01
-                    +e.title タイトルが入ります。タイトルが入ります。
+            .large-4.small-6
+              +e.block
+                +a.c-card-post__image
+                  +img("img-card-01.jpg")
+                +e.content
+                  +e.sup
+                    span.c-card-post__label.c-label.is-sm カテゴリ名
+                    +e.date 2018.01.01
+                  +e.title タイトルが入ります。タイトルが入ります。
+            .large-4.small-6
+              +e.block
+                +a.c-card-post__image
+                  +img("img-card-01.jpg")
+                +e.content
+                  +e.sup
+                    span.c-card-post__label.c-label.is-sm カテゴリ名
+                    +e.date 2018.01.01
+                  +e.title タイトルが入ります。タイトルが入ります。
+            .large-4.small-6
+              +e.block
+                +a.c-card-post__image
+                  +img("img-card-01.jpg")
+                +e.content
+                  +e.sup
+                    span.c-card-post__label.c-label.is-sm カテゴリ名
+                    +e.date 2018.01.01
+                  +e.title タイトルが入ります。タイトルが入ります。
+
+block before_footer
   +l_offer

--- a/app/news/index.pug
+++ b/app/news/index.pug
@@ -16,8 +16,7 @@ block page_header
   +c_breadcrumb()
 
 block body
-  main.l-main
-    section.l-section.is-lg
+  section.l-section.is-lg
       .l-container.is-sm
         +c.news.is-onecolumn
           h2.c-news__title.c-heading.is-md.is-line-under.is-color-primary すべて
@@ -67,5 +66,7 @@ block body
                       +e.date 2018.01.01
                     +e.title タイトルが入ります。タイトルが入ります。
         +c_pagination()
+        
+block before_footer
   +l_offer
 

--- a/app/page/index.pug
+++ b/app/page/index.pug
@@ -16,8 +16,8 @@ block page_header
   +c_breadcrumb()
 
 block body
-  main.l-main
-    section.l-section
+  section.l-section
 
+block before_footer
   +l_offer
 

--- a/app/result/index.pug
+++ b/app/result/index.pug
@@ -16,13 +16,13 @@ block page_header
   +c_breadcrumb()
 
 block body
-  main.l-main
-    section.l-section.is-lg
-      .l-container
-        +c.news.u-maxwidth944
-          +e.content
-            +c_news__block("is-result")
-        +c_pagination()
-
+  section.l-section.is-lg
+    .l-container
+      +c.news.u-maxwidth944
+        +e.content
+          +c_news__block("is-result")
+      +c_pagination()
+      
+block before_footer
   +l_offer
 

--- a/app/sitemap/index.pug
+++ b/app/sitemap/index.pug
@@ -16,77 +16,79 @@ block page_header
   +c_breadcrumb()
 
 block body
-  main.l-main
-    section.l-section.is-md
-      .l-container.is-sm
-        +c.sitemap
-          +e.inner
-            +e.list
-              +e.item: +a("/") ホーム
-              +e.item.is-parent
-                +a("/features/") 特長
-                +e.sublist
+  section.l-section.is-md
+    .l-container.is-sm
+      +c.sitemap
+        +e.inner
+          +e.list
+            +e.item: +a("/") ホーム
+            +e.item.is-parent
+              +a("/features/") 特長
+              +e.sublist
+                +e.subitem
+                  +a("/features/quality/") こだわりの高品質
+                  ul
+                    li: +a("/features/quality/establishment/") 高度な業務フローの確立
+                    li: +a("/features/quality/grasp/") 適正数量の把握
+                    li: +a("/features/quality/pursuit/") 作業空間の追求
+                    li: +a("/features/quality/kpi/") 納期遵守のKPI管理
+                    li: +a("/features/quality/effort/") その他高品質への取り組み
+                +e.subitem
+                  +a("/features/achievement/") 豊富なスキャン実績
+                +e.subitem
+                  +a("/features/security/") 安心のセキュリティ体制
+                +e.subitem
+                  +a("/features/staff/") プロフェッショナルなスタッフ
+            +e.item.is-parent
+              +a("/service/") スキャンサービス
+              +e.flex
+                +e.sublist.is-three-col
                   +e.subitem
-                    +a("/features/quality/") こだわりの高品質
-                    ul
-                      li: +a("/features/quality/establishment/") 高度な業務フローの確立
-                      li: +a("/features/quality/grasp/") 適正数量の把握
-                      li: +a("/features/quality/pursuit/") 作業空間の追求
-                      li: +a("/features/quality/kpi/") 納期遵守のKPI管理
-                      li: +a("/features/quality/effort/") その他高品質への取り組み
+                    +a("/service/scan01/") 契約書
                   +e.subitem
-                    +a("/features/achievement/") 豊富なスキャン実績
+                    +a("/service/scan07/") レシート・領収書
                   +e.subitem
-                    +a("/features/security/") 安心のセキュリティ体制
+                    +a("/service/scan11/") 図面・製図（大判）
                   +e.subitem
-                    +a("/features/staff/") プロフェッショナルなスタッフ
-              +e.item.is-parent
-                +a("/service/") スキャンサービス
-                +e.flex
-                  +e.sublist.is-three-col
-                    +e.subitem
-                      +a("/service/scan01/") 契約書
-                    +e.subitem
-                      +a("/service/scan07/") レシート・領収書
-                    +e.subitem
-                      +a("/service/scan11/") 図面・製図（大判）
-                    +e.subitem
-                      +a("/service/scan05/") 申込書・同意書
-                    +e.subitem
-                      +a("/service/scan10/") 名刺
-                    +e.subitem
-                      +a("/service/scan15/") 新聞
-                    +e.subitem
-                      +a("/service/scan09/") 一般書類
-                    +e.subitem
-                      +a("/service/scan14/") 調査票・アンケート
-                    +e.subitem
-                      +a("/service/scan04/") 履歴書・職務経歴書
-                    +e.subitem
-                      +a("/service/scan13/") 写真
-                    +e.subitem
-                      +a("/service/scan03/") マニュアル・手引書
-                    +e.subitem
-                      +a("/service/scan08/") カタログ
-                    +e.subitem
-                      +a("/service/scan02/") 見積書・納品書・請求書
-                    +e.subitem
-                      +a("/service/scan06/") 社内広報誌
-                    +e.subitem
-                      +a("/service/scan12/") ポスター（大判）
-                    +e.subitem
-                      +a("/service/scan16/") その他
-              +e.item: +a("/case/") 活用事例
-              +e.item: +a("/charge/") 料金
-              +e.item: +a("/flow/") ご利用の流れ
-              +e.item: +a("/faq/") よくあるご質問
-              +e.item: +a("/news/") お知らせ
-              +e.item: +a("/column/") お役立ちコラム
-              +e.item: +a("/contact/") お問い合わせ・お見積り
-              +e.item: +a("/document/") 資料請求
-              +e.item: +a("/estimate/") 料金シミュレーション
-              +e.item: +a("https://www.uluru-bpo.jp/company")(target="_blank").is-outlink 運営会社
-              +e.item: +a("https://www.uluru-bpo.jp/privacypolicy")(target="_blank").is-outlink プライバシーポリシー
+                    +a("/service/scan05/") 申込書・同意書
+                  +e.subitem
+                    +a("/service/scan10/") 名刺
+                  +e.subitem
+                    +a("/service/scan15/") 新聞
+                  +e.subitem
+                    +a("/service/scan09/") 一般書類
+                  +e.subitem
+                    +a("/service/scan14/") 調査票・アンケート
+                  +e.subitem
+                    +a("/service/scan04/") 履歴書・職務経歴書
+                  +e.subitem
+                    +a("/service/scan13/") 写真
+                  +e.subitem
+                    +a("/service/scan03/") マニュアル・手引書
+                  +e.subitem
+                    +a("/service/scan08/") カタログ
+                  +e.subitem
+                    +a("/service/scan02/") 見積書・納品書・請求書
+                  +e.subitem
+                    +a("/service/scan06/") 社内広報誌
+                  +e.subitem
+                    +a("/service/scan12/") ポスター（大判）
+                  +e.subitem
+                    +a("/service/scan16/") その他
+            +e.item: +a("/case/") 活用事例
+            +e.item: +a("/charge/") 料金
+            +e.item: +a("/flow/") ご利用の流れ
+            +e.item: +a("/faq/") よくあるご質問
+            +e.item: +a("/news/") お知らせ
+            +e.item: +a("/column/") お役立ちコラム
+            +e.item: +a("/contact/") お問い合わせ・お見積り
+            +e.item: +a("/document/") 資料請求
+            +e.item: +a("/estimate/") 料金シミュレーション
+            +e.item: +a("https://www.uluru-bpo.jp/company")(target="_blank").is-outlink 運営会社
+            +e.item: +a("https://www.uluru-bpo.jp/privacypolicy")(target="_blank").is-outlink プライバシーポリシー
 
-  +l_offer
+
+block before_footer
+  +l_offer()
+
 


### PR DESCRIPTION
▼関連改善事項
https://www.notion.so/growgroup/l-main-base-e44d3968fefa438bb8a5b4f31d61d568

# やりたいこと
l-mainからメインコンテンツが意図せず飛び出すことがないようにbaseごと工夫したい

# やったこと
1カラムレイアウト用のpugについても、_base.pug側に .l-main を設置するように変更しました。

## _base.pugを以下のように変更
![image](https://github.com/growgroup/gg-styleguide/assets/97862690/faa4d5a6-3bca-46f5-8365-c95adbcae95d)


## 各ページのpugを以下のように変更
![image](https://github.com/growgroup/gg-styleguide/assets/97862690/d201d342-984a-4255-a3a7-ef56f72e52fd)
