### PR TITLE
アクセシビリティ関連の小さな修正

### DIFF
--- a/app/assets/scss/object/components/_buttons.scss
+++ b/app/assets/scss/object/components/_buttons.scss
@@ -6,7 +6,6 @@ category: Buttons
 */
 .c-button {
   position: relative;
-  outline: none;
   display: inline-flex;
   align-items: center;
   justify-content: center;

--- a/app/inc/layout/_footer.pug
+++ b/app/inc/layout/_footer.pug
@@ -3,7 +3,7 @@
 
 footer.l-footer
   +c.pagetop.js-fixedheader
-    +a("#top")(data-anchor-target="html").js-anchor
+    +a("#top")(data-anchor-target="html", aria-label="ページ上部に戻る").js-anchor
   .l-container
     .l-footer__menu
       .l-footer__block


### PR DESCRIPTION
▼関連改善事項
https://www.notion.so/c-button-outline-none-002e4733baf843678e2938cee2788d18
https://www.notion.so/growgroup/pagetop-aria-label-96a3c410241540d2b7fb7b6cd9161ed5


# c-button の outline: noneの削除
参考: https://blog.studio.design/ja/posts/outline0
キーボードフォーカスが当たるようにするため

# c-pagetopのaria-labelの追加
アイコンしかないaタグに意味のあるアクセシブルな名前を追加するため

※設定するラベル名はデジタル庁のデザインシステムより
 https://www.figma.com/community/file/1255349027535859598/design-system-1-4-0