### PR TITLE
[add] text-autospace: no-autospace;

### DIFF
--- a/app/assets/scss/foundation/_normalize.scss
+++ b/app/assets/scss/foundation/_normalize.scss
@@ -19,6 +19,7 @@ html {
   font-family: $font-base-family;
   line-height: 1.15; /* 1 */
   -webkit-text-size-adjust: 100%; /* 2 */
+  text-autospace: no-autospace; /* スクリプト間スペースの自動挿入防止 */
 }
 
 * {


### PR DESCRIPTION
[Chromeに導入予定の新しい CSS 機能](https://developer.chrome.com/blog/css-i18n-features?hl=ja) 対策として
いったん `html` に対して `text-autospace: no-autospace;` を追加しました。

### 備考
作成時点ではChromeの `chrome://flags/#enable-experimental-web-platform-features` を
Enableにしたときのみ効くCSSだが
ブラウザのデフォルト動作が変わることが想定されているため事前設定。
今後の仕様変更によっては調整必要。

2024年1月現在では`text-spacing-trim` についてはテストができないため未対応。