### PR TITLE
[add] fonts.js: フォント読み込み用の記述をapp.cssから分離して、レンダリングブロックを減らす

### DIFF
--- a/app/assets/js/app.js
+++ b/app/assets/js/app.js
@@ -1,10 +1,6 @@
 //Material Icons
 import "../scss/font.scss";
-// 英語版作成時に本文書体で利用するためrobotoの400と700はコメントアウトしないでください
-import "@fontsource/roboto/400.css"
-import "@fontsource/roboto/700.css"
-import "@fontsource/noto-sans-jp/400.css"
-import "@fontsource/noto-sans-jp/700.css"
+
 
 import Utils from './app/utils.js';
 import Accordion from './app/accordion.js';

--- a/app/assets/js/fonts.js
+++ b/app/assets/js/fonts.js
@@ -1,0 +1,5 @@
+// 英語版作成時に本文書体で利用するためrobotoの400と700はコメントアウトしないでください
+import "@fontsource/roboto/400.css"
+import "@fontsource/roboto/700.css"
+import "@fontsource/noto-sans-jp/400.css"
+import "@fontsource/noto-sans-jp/700.css"

--- a/app/inc/foundation/_head.pug
+++ b/app/inc/foundation/_head.pug
@@ -46,7 +46,8 @@ html(lang="ja")
 
     //- スタイルシート
     block stylesheet
-      +link("/assets/css/app.css")(rel="stylesheet")
+      +link("/assets/css/app.css")(rel="preload" as="style" onload="this.onload=null;this.rel='stylesheet'")
+      +link("/assets/css/fonts.css")(rel="stylesheet" media="print" onload="this.media='all'")
       +link("/assets/css/style.css")(rel="stylesheet")
 
     //- ヘッダーに組み込むスクリプト

--- a/webpack.config.babel.js
+++ b/webpack.config.babel.js
@@ -19,6 +19,7 @@ module.exports = (env, argv) => {
         context: __dirname + '/app/',
         entry: {
             app: __dirname + '/app/assets/js/app.js',
+          fonts: __dirname + '/app/assets/js/fonts.js',
         },
         output: {
             path: path.join(__dirname, 'dist/'),


### PR DESCRIPTION
▼関連改善事項
https://www.notion.so/growgroup/CSS-app-css-42c421162eaf4473a181be1f8764fd97

# やったこと
フォント読み込み用の記述をapp.cssから分離して、
レンダリングブロックを減らす。

## 参考
https://github.com/growgroup/ach-wp/commit/c2fa79f1b095bbe7bb57e445c3f21313d9fbf3f2
https://github.com/growgroup/ach-wp/commit/390526992325eaa33ff7f6aaace226eaa4244a06
https://github.com/growgroup/ach-wp/commit/3a29dc620cfa31a6c5f890857d73d3cfa211db18

## js/css側
app.jsから フォントの読み込みを除外し（Material Icons以外）
fonts.jsに移動。
※ビルド後は /assets/css/fonts.cssになる

## pug側
fonts.cssはレンダリングブロックを回避するように変更。
また、app.cssもレンダリングブロックを回避するように変更。

```
    //- スタイルシート
    block stylesheet
      +link("/assets/css/app.css")(rel="preload" as="style" onload="this.onload=null;this.rel='stylesheet'")
      +link("/assets/css/fonts.css")(rel="stylesheet" media="print" onload="this.media='all'")
      +link("/assets/css/style.css")(rel="stylesheet")
```
### ▼ビルド後の姿

```
<link href="/assets/css/app.css" rel="preload" as="style" onload="this.onload=null;this.rel='stylesheet'"/>
<link href="/assets/css/fonts.css" rel="stylesheet" media="print" onload="this.media='all'"/>
<link href="/assets/css/style.css" rel="stylesheet"/>
```