### PR TITLE
[update] pug : 旧来の記述が残っているpugファイル群の整理

### DIFF
--- a/app/archive-twocolumns/category/index.pug
+++ b/app/archive-twocolumns/category/index.pug
@@ -1,11 +1,12 @@
 extends /inc/foundation/_base-twocolumn.pug
 block append config
-  - current.id = "archive-twocolumns" // ページのID
-  - current.title = "アーカイブ_2カラム" // タイトル
+  - current.id = "category" // ページのID
+  - current.title = "カテゴリ" // タイトル
   - current.description = `これは${current.title}についての説明文です` // 説明文
   - current.bodyClass = `${current.id}` // body に付与するクラス
-  - current.path = `/${current.id}/` // ページのpath
-  - current.depth = 2 // ページの階層
+  - current.path = `/archive-twocolumns/${current.id}/` // ページのpath
+  - current.depth = 3 // ページの階層
+
 
 block page_header
   +l_page_header({
@@ -26,24 +27,24 @@ block body
     +e.block
       +e.title カテゴリ
       ul
-        li: +a("/news/") すべて
-        li: +a("/news/category/") お知らせ
-        li: +a("/news/category/") ブログ
+        li: +a("/archive-twocolumns/category/") すべて
+        li: +a("/archive-twocolumns/category/") お知らせ
+        li: +a("/archive-twocolumns/category/") ブログ
     +e.block
       +e.title 年月アーカイブ
       ul
-        li: +a("/news/category/") 2019年01月
-        li: +a("/news/category/") 2019年01月
-        li: +a("/news/category/") 2019年01月
-        li: +a("/news/category/") 2019年01月
-        li: +a("/news/category/") 2019年01月
-        li: +a("/news/category/") 2019年01月
-        li: +a("/news/category/") 2019年01月
-        li: +a("/news/category/") 2019年01月
-        li: +a("/news/category/") 2019年01月
+        li: +a("/archive-twocolumns/category/") 2019年01月
+        li: +a("/archive-twocolumns/category/") 2019年01月
+        li: +a("/archive-twocolumns/category/") 2019年01月
+        li: +a("/archive-twocolumns/category/") 2019年01月
+        li: +a("/archive-twocolumns/category/") 2019年01月
+        li: +a("/archive-twocolumns/category/") 2019年01月
+        li: +a("/archive-twocolumns/category/") 2019年01月
+        li: +a("/archive-twocolumns/category/") 2019年01月
+        li: +a("/archive-twocolumns/category/") 2019年01月
   +c.news-lg.u-mbs.is-top.is-lg
     +loop(5)
-      +a("/news/category/page/").c-news-lg__block
+      +a("/archive-twocolumns/category/page/").c-news-lg__block
         +e.sup
           +e.label.c-label.is-sm お知らせ
           +e.date 2018.06.01

--- a/app/archive-twocolumns/category/page/index.pug
+++ b/app/archive-twocolumns/category/page/index.pug
@@ -1,15 +1,19 @@
 extends /inc/foundation/_base-twocolumn.pug
 block append config
-  - current.id = "post-twocolumns" // ページのID
-  - current.title = "ポスト_2カラム" // タイトル
+  - current.id = "post" // ページのID
+  - current.title = "ここに記事のタイトルが入ります。" // タイトル
   - current.description = `これは${current.title}についての説明文です` // 説明文
-  - current.bodyClass = `${current.id}` // body に付与するクラス
-  - current.path = "/archive-twocolumns/page/" // ページのpath
-  - current.depth = 3 // ページの階層
+  - current.bodyClass = `single-${current.id}` // body に付与するクラス
+  - current.path = "/archive-twocolumns/category/page/" // ページのpath
+  - current.depth = 4 // ページの階層
 
 block page_header
-  +l_page_header("img-page-header-format.jpg","POST 2COLUMNS","ポスト_2カラム")
-  +c_breadcrumb("アーカイブ_2カラム","archive-twocolumns")
+  +l_page_header({
+    image: "img-page-header-format.jpg",
+    title: "お知らせ",
+    subtitle: "news"
+  })
+  +c_breadcrumb("お知らせ","news","カテゴリ","category")
 
 block body
   +c.news-header

--- a/app/assets/scss/layout/_offer.scss
+++ b/app/assets/scss/layout/_offer.scss
@@ -18,8 +18,14 @@ category: Layout
     padding: rem-calc(64) 0;
   }
   &__items {
+    display: grid;
+    grid-template-columns: repeat(2, 1fr);
+    gap: rem-calc(36);
+
     margin-top: rem-calc(48);
     @include breakpoint(small only) {
+      grid-template-columns: 1fr;
+      gap: rem-calc(16);
       margin-top: rem-calc(24);
     }
     // ボタン1つ

--- a/app/assets/scss/object/components/_news.scss
+++ b/app/assets/scss/object/components/_news.scss
@@ -10,10 +10,22 @@ category: News
     padding-bottom: rem-calc(72);
   }
 
-  &__head {
+  //============================
+  //  TOPページ
+  //============================
+
+  &__columns {
+    display: grid;
+    grid-template-columns: 3fr 9fr;
+    gap: rem-calc(36);
+
     @include breakpoint(small only) {
-      margin-bottom: rem-calc(16);
+      grid-template-columns: 1fr;
+      gap: rem-calc(16);
     }
+  }
+
+  &__head {
   }
 
   &__title {
@@ -36,6 +48,9 @@ category: News
     }
   }
 
+  //============================
+  //  共通
+  //============================
   &__block {
     text-decoration: none;
     color: $font-base-color;

--- a/app/format/components/_text.pug
+++ b/app/format/components/_text.pug
@@ -7,26 +7,28 @@ div.u-mbs.is-bottom
 div.u-mbs.is-bottom
   +heading-xlg("TEXTLEVEL1", "見出しレベル1")
 
+
+// -> h2見出し
 div.u-mbs.is-bottom
   +heading-lg("見出しレベル2")
 
 
-// -> h2見出し
-div.u-mbs.is-bottom
-  div.c-heading.is-md 見出しレベル2見出しレベル2見出しレベル2
-
 // -> h3見出し
 div.u-mbs.is-bottom
-  div.c-heading.is-sm 見出しレベル3見出しレベル3見出しレベル3見出しレベ
-
+  div.c-heading.is-md 見出しレベル3見出しレベル3見出しレベル3
 
 // -> h4見出し
 div.u-mbs.is-bottom
-  div.c-heading.is-xs 見出しレベル4見出しレベル4見出しレベル4見出しレベ
+  div.c-heading.is-sm 見出しレベル4見出しレベル4見出しレベル4見出しレベ
+
 
 // -> h5見出し
 div.u-mbs.is-bottom
-  div.c-heading.is-xxs 見出しレベル5見出しレベル5見出しレベル5見出しレベ
+  div.c-heading.is-xs 見出しレベル5見出しレベル5見出しレベル5見出しレベ
+
+// -> h6見出し
+div.u-mbs.is-bottom
+  div.c-heading.is-xxs 見出しレベル6見出しレベル6見出しレベル6見出しレベ
 
 
 // 基本テキストのスタイル
@@ -73,7 +75,7 @@ div.u-mbs.is-bottom
   ol.c-list.is-outline
     li リスト1
     li リスト2
-      ol.c-list.is-outline
+      ol
         li リスト2の子要素
         li リスト2の子要素
     li リスト2
@@ -117,35 +119,34 @@ div.u-mbs.is-bottom
         td テキストテキストテキストテキストテキスト
 
 div.u-mbs.is-bottom
-  .row
-    .large-7.small-12
-      table.c-table-sm
-        thead
-          tr
-            th 受付時間
-            td 月
-            td 火
-            td 水
-            td 木
-            td 金
-            td 土
-            td 日・祝
-        tbody
-          tr
-            th <span>午前</span>9:00～12:30
-            td 院長
-            td 院長
-            td 院長
-            td 院長
-            td 院長
-            td 院長
-            td <span>×</span>
-          tr
-            th <span>午後</span>14:30～18:00
-            td 院長
-            td 院長
-            td 院長
-            td 院長
-            td 院長
-            td <span>×</span>
-            td <span>×</span>
+  .l-container.is-sm
+    table.c-table-sm
+      thead
+        tr
+          th 受付時間
+          td 月
+          td 火
+          td 水
+          td 木
+          td 金
+          td 土
+          td 日・祝
+      tbody
+        tr
+          th <span>午前</span>9:00～12:30
+          td 院長
+          td 院長
+          td 院長
+          td 院長
+          td 院長
+          td 院長
+          td <span>×</span>
+        tr
+          th <span>午後</span>14:30～18:00
+          td 院長
+          td 院長
+          td 院長
+          td 院長
+          td 院長
+          td <span>×</span>
+          td <span>×</span>

--- a/app/inc/layout/_global-nav.pug
+++ b/app/inc/layout/_global-nav.pug
@@ -1,9 +1,0 @@
-nav.l-global-nav
-  ul
-    each item in nav("global_nav")
-      li
-        +a(item.url)!= item.text
-        if item.children
-          ul
-          each child_item in item.children
-            li: +a(child_item.url)!= child_item.text

--- a/app/inc/mixins/_misc.pug
+++ b/app/inc/mixins/_misc.pug
@@ -65,14 +65,21 @@ mixin c_news__block(data)
       +e.date 2018.10.10
       +e.label.c-label.is-white カテゴリ
       +e.text お知らせの投稿タイトルがここに入ります。お知らせの投稿タイトルがここに入ります。
-  else if data == "is-news"
+  else if data == "news"
     +ae("/news/category/page/").block
       +e.date 2022.01.01
       +e.label.c-label.is-white カテゴリ
       +e.inner
         +e.text テキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキスト
         +e.excerpt 本文内容の一文が抜粋されてここに掲載を行います。本文内容の一文が抜粋されてここに掲載を行います。本文内容の一文が抜粋されてここに掲載を行います…[続きを見る]
-  else if data == "is-result"
+  else if data == "twocolumns"
+    +ae("/archive-twocolumns/category/page/").block
+      +e.date 2022.01.01
+      +e.label.c-label.is-white カテゴリ
+      +e.inner
+        +e.text テキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキスト
+        +e.excerpt 本文内容の一文が抜粋されてここに掲載を行います。本文内容の一文が抜粋されてここに掲載を行います。本文内容の一文が抜粋されてここに掲載を行います…[続きを見る]
+  else if data == "result"
     +ae("/news/category/page/").block
       +e.label.c-label お知らせ
       +e.text テキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキスト

--- a/app/inc/mixins/_offer.pug
+++ b/app/inc/mixins/_offer.pug
@@ -8,17 +8,14 @@ mixin l_offer
           small お問い合わせ
         .l-offer__text 弊社のサービスへ興味をお持ちの方は、<br>下記の電話番号、もしくはお問い合わせフォームよりお気軽に問い合わせください。
         .l-offer__items
-          .row
-            .large-5.is-push-lg-1.small-12
-              .l-offer__box
-                .l-offer__box-text お電話の際は「ホームページを見て」と<br>お伝えください。
-                .l-offer__box-tel
-                  | <span class="material-icons-outlined">call</span>00-000-0000
-                  small 電話受付時間 / 平日00：00～00：00
-            .large-5.small-12
-              .l-offer__box
-                .l-offer__box-text メールでのご相談・ご質問は<br>お問い合わせフォームをご活用ください。
-                +a("#").c-button.is-lg.is-white お問い合わせフォーム
+          .l-offer__box
+            .l-offer__box-text お電話の際は「ホームページを見て」と<br>お伝えください。
+            .l-offer__box-tel
+              | <span class="material-icons-outlined">call</span>00-000-0000
+              small 電話受付時間 / 平日00：00～00：00
+          .l-offer__box
+            .l-offer__box-text メールでのご相談・ご質問は<br>お問い合わせフォームをご活用ください。
+            +a("#").c-button.is-lg.is-white お問い合わせフォーム
 
 mixin l_offer-recruit
   .l-offer.is-padding-lg

--- a/app/index.pug
+++ b/app/index.pug
@@ -71,17 +71,15 @@ block body
   section.l-section.is-lg
     .l-container
       +c.news
-        .row
-          .large-3.small-12
-            +e.head
-              h2.c-news__title.c-heading.is-xlg
-                span NEWS
-                small お知らせ
-              +e.button: +a("/news/").c-button.is-sm 一覧を見る
-          .large-9.small-12
-            +e.content
-              +loop(3)
-                +c_news__block("home")
+        +e.columns
+          +e.head
+            h2.c-news__title.c-heading.is-xlg
+              span NEWS
+              small お知らせ
+            +e.button: +a("/news/").c-button.is-sm 一覧を見る
+          +e.content
+            +loop(3)
+              +c_news__block("home")
 
 block before_footer
   +c_cookie

--- a/app/news/category/index.pug
+++ b/app/news/category/index.pug
@@ -22,7 +22,7 @@ block body
         h2.c-news__title.c-heading.is-md.is-line-under.is-color-primary カテゴリ
         +e.content
           +loop(10)
-            +c_news__block("is-news")
+            +c_news__block("news")
       +c_pagination()
 
 block before_footer

--- a/app/news/index.pug
+++ b/app/news/index.pug
@@ -22,7 +22,7 @@ block body
           h2.c-news__title.c-heading.is-md.is-line-under.is-color-primary すべて
           +e.content
             +loop(3)
-              +c_news__block("is-news")
+              +c_news__block("news")
         +c_pagination()
         +c.box-archive.u-mbs.is-top.is-lg
           +e.block
@@ -66,7 +66,7 @@ block body
                       +e.date 2018.01.01
                     +e.title タイトルが入ります。タイトルが入ります。
         +c_pagination()
-        
+
 block before_footer
   +l_offer
 

--- a/app/result/index.pug
+++ b/app/result/index.pug
@@ -17,12 +17,12 @@ block page_header
 
 block body
   section.l-section.is-lg
-    .l-container
-      +c.news.u-maxwidth944
+    .l-container.is-sm
+      +c.news
         +e.content
-          +c_news__block("is-result")
+          +c_news__block("result")
       +c_pagination()
-      
+
 block before_footer
   +l_offer
 

--- a/app/twocolumns/index.pug
+++ b/app/twocolumns/index.pug
@@ -16,76 +16,36 @@ block page_header
   +c_breadcrumb()
 
 block body
-  h2 見出しレベル2
-  +c.anchor-nav
-    .row
-      .large-3.small-6
-        +a("#").c-button.is-sm ページ内リンク
-      .large-3.small-6
-        +a("#").c-button.is-sm ページ内リンク
-      .large-3.small-6
-        +a("#").c-button.is-sm ページ内リンク
-      .large-3.small-6
-        +a("#").c-button.is-sm ページ内リンク
-  div.u-mbs.is-top.is-lg
-    p 基本文章テキストです。基本文章テキストです。基本文章テキストです。基本文章テキストです。基本文章テキストです。基本文章テキストです。基本文章テキストです。基本文章テキストです。基本文章テキストです。基本文章テキストです。基本文章テキストです。基本文章テキストです。基本文章テキストです。基本文章テキストです。基本文章テキストです。基本文章テキストです。
-  div.u-mbs.is-top.is-lg
-    h3 見出しレベル3見出しレベル3見出しレベル3見出しレベ
-    +c.block
-      +e.block
-        .row
-          .large-5.small-12
-            +e.image: +img("img-block-01.jpg")
-          .large-7.small-12
-            +e.content
-              h4 見出しレベル4見出しレベル4
-              p ブロックテキストブロックテキストブロックテキストブロックテキストブロックテキストブロックテキストブロックテキストブロックテキストブロックテキストブロックテキストブロックテキストブロックテキストブロックテキスト
-      +e.block
-        h4 見出しレベル4見出しレベル4
-        .row
-          .large-7.small-12
-            +e.content
-              p ブロックテキストブロックテキストブロックテキストブロックテキストブロックテキストブロックテキストブロックテキストブロックテキストブロックテキストブロックテキストブロックテキストブロックテキストブロックテキスト
-          .large-5.small-12
-            +e.image: +img("img-block-01.jpg")
-
-  div.u-mbs.is-top.is-lg
+  section.l-section.is-lg.is-bottom
+    h2.c-heading.is-lg.is-mg-level-6 セクションタイトル
+    +c_anchor-nav("u-mbs is-bottom",{
+      link: "#section01",
+      title: "テキストテキスト",
+    },{
+      link: "#section02",
+      title: "テキストテキスト",
+    },{
+      link: "#section03",
+      title: "テキストテキスト",
+    },{
+      link: "#section04",
+      title: "テキストテキスト",
+    })
+    .u-mbs.is-sm
+      p
+        | 基本文章テキストです。基本文章テキストです。基本文章テキストです。基本文章テキストです。基本文章テキストです。基本文章テキストです。基本文章テキストです。基本文章テキストです。基本文章テキストです。基本文章テキストです。基本文章テキストです。基本文章テキストです。基本文章テキストです。基本文章テキストです。基本文章テキストです。基本文章テキストです。
     +c.box
       +e.block
         +e.content
-          h5 <i class="fa fa-circle-o" aria-hidden="true"></i>見出しレベル5
-          p ブロックテキストブロックテキストブロックテキストブロックテキストブロックテキストブロックテキストブロックテキストブロックテキストブロックテキストブロックテキストブロックテキストブロックテキストブロックテキストブロックテキストブロックテキストブロックテキスト
+          h3.c-heading.is-md サブタイトル
+          p テキストテキストテキストテキストテキストテキストテキストテキスト
+          +img("img-sample.jpg")
+          +a("/").c-button.is-sm ボタンテキスト
 
-  div.u-mbs.is-top.is-lg
-    table.c-table
-      tbody
-        tr
-          th thテキスト
-          td tdテキストテキストテキストテキストテキスト
-        tr
-          th thテキスト
-          td tdテキストテキストテキストテキストテキスト
-        tr
-          th thテキスト
-          td tdテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキスト
-  div.u-mbs.is-top.is-lg
-    +img("img-sample-lg.jpg")
-
-  div.u-mbs.is-top.is-lg
-    .row
-      .large-6.small-12
-        +img("img-sample-lg.jpg")
-      .large-6.small-12
-        +img("img-sample-lg.jpg")
-
-  div.u-mbs.is-top.is-lg
-    .row
-      .large-4.small-12
-        +img("img-sample-sm.jpg")
-      .large-4.small-12
-        +img("img-sample-sm.jpg")
-      .large-4.small-12
-        +img("img-sample-sm.jpg")
+  section.l-section.is-lg.is-bottom
+    h2.c-heading.is-lg セクションタイトル
+    p
+      | 基本文章テキストです。基本文章テキストです。基本文章テキストです。基本文章テキストです。基本文章テキストです。基本文章テキストです。基本文章テキストです。基本文章テキストです。基本文章テキストです。基本文章テキストです。基本文章テキストです。基本文章テキストです。基本文章テキストです。
 
 block aside
   +l-aside()


### PR DESCRIPTION
▼関連改善事項
https://www.notion.so/growgroup/archive-twocolumns-pug-news-HTML-8d7eb6b2646640dca73ff16b2ad89b0a

# 目的
新人研修や初期の案件の際に分かりづらいと感じるpugの記述の除去・修正

# 主な対応箇所
- archive-twocolumns
    - /page/のpage-header周辺の記述
    - paginationのmixin利用
   
- .rowを使っている箇所の撤廃
    - TOPのnews
    - l-offerの中身
    - formatの c-table-smのところ
   
- _global-nav.pugの削除

- format
    - 見出しのエリアのコメントが間違っているのを修正
    - ol.c-list.is-outlineの内側のolからクラスを消す（ulと統一）

- result
    - .u-maxwidth944を.l-container.is-smに変更
   
- twocolumns
    - /page/の2カラム版なので不要な記述を減らす。mixinを利用したものに調整。