### PR TITLE
[update] c-breadcrumb : iOS17でパンくずがクリックできない問題の応急処置

### DIFF
--- a/app/assets/scss/object/components/_breadcrumb.scss
+++ b/app/assets/scss/object/components/_breadcrumb.scss
@@ -28,6 +28,7 @@
       }
 
       a {
+        display: inline-flex; //iOS17でパンくずがクリックできない問題の対応
         @include font-format-light(12,19);
       }
     }


### PR DESCRIPTION
▼関連改善事項
https://www.notion.so/growgroup/iOS17-de501e996864469ab98e2f662dc5cefb

# 問題
iOS17だと、パンくず内のリンクがクリックできない。

# 対処
とりあえずaタグをdisplay: inline-flexにする