### PR TITLE
mixinのbackground系の調整

### DIFF
--- a/app/assets/scss/foundation/_mixin.scss
+++ b/app/assets/scss/foundation/_mixin.scss
@@ -388,10 +388,10 @@
 //
 // Styleguide 6.5.0
 
-@mixin bg-option(){
+@mixin bg-option($size:cover){
   background-repeat: no-repeat;
   background-position: center center;
-  background-size: cover;
+  background-size: $size;
 }
 
 @mixin news-date() {
@@ -409,7 +409,7 @@
 }
 
 
-@mixin bg-img(){
+@mixin bg-img($size:cover){
   position: absolute;
   top: 0;
   right: 0;
@@ -418,7 +418,7 @@
   margin:auto;
   width: 100%;
   height: 100%;
-  @include bg-option();
+  @include bg-option($size);
 }
 
 @mixin card-block(){

--- a/app/assets/scss/object/components/_block-document.scss
+++ b/app/assets/scss/object/components/_block-document.scss
@@ -63,7 +63,7 @@
       cursor: pointer;
     }
 
-    .bg-img {
+    .u-bg-cover {
       position: absolute;
       top: 0;
       right: 0;

--- a/app/assets/scss/object/components/_card-download.scss
+++ b/app/assets/scss/object/components/_card-download.scss
@@ -51,7 +51,7 @@
     &:hover {
       opacity: 1;
 
-      .bg-img {
+      .u-bg-cover {
         transform: scale(1.1);
       }
 
@@ -68,18 +68,7 @@
     padding-top: calc(311/504*100%);
     background: $color-background;
 
-    .bg-img {
-      position: absolute;
-      top: 0;
-      right: 0;
-      bottom: 0;
-      left: 0;
-      margin:auto;
-      width: 100%;
-      height: 100%;
-      background-repeat: no-repeat;
-      background-position: center center;
-      background-size: contain;
+    .u-bg-contain {
       @include transition();
     }
 

--- a/app/assets/scss/object/components/_gallery-card.scss
+++ b/app/assets/scss/object/components/_gallery-card.scss
@@ -19,7 +19,7 @@
       padding-top: calc(320/500*100%);
     }
 
-    .bg-img {
+    .u-bg-cover {
       @include bg-img();
     }
   }

--- a/app/assets/scss/object/components/_gallery-logo.scss
+++ b/app/assets/scss/object/components/_gallery-logo.scss
@@ -26,8 +26,7 @@
       padding-top: calc(64/160*100%);
     }
 
-    .bg-img {
-      @include bg-img();
+    .u-bg-cover {
       background-size: contain;
     }
   }

--- a/app/assets/scss/object/components/_main-visual.scss
+++ b/app/assets/scss/object/components/_main-visual.scss
@@ -19,8 +19,7 @@ category: Components
       min-height: 280px;
     }
 
-    .bg-img {
-      @include bg-img();
+    .u-bg-cover {
 
       &:after {
         @include img-curtain($font-base-color,0.15);
@@ -98,7 +97,7 @@ category: Components
 
     .swiper-slide-active {
 
-      .bg-img {
+      .u-bg-cover {
         //animation: zoomOut 6s forwards;
       }
     }

--- a/app/assets/scss/object/utility/_image.scss
+++ b/app/assets/scss/object/utility/_image.scss
@@ -1,0 +1,16 @@
+.u-bg-cover {
+  @include bg-img();
+}
+
+.u-bg-contain {
+  @include bg-img(contain);
+}
+
+.u-img-fit {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}

--- a/app/download/index.pug
+++ b/app/download/index.pug
@@ -31,7 +31,7 @@ block body
           +loop(3)
             +ae("/download/page/").block
               +e.image
-                +bgimg("img-card-01.jpg").bg-img
+                +bgimg("img-card-01.jpg").u-bg-cover
                 +e.label.c-label テキスト
               +e.content
                 +e.title.c-heading.is-xxs テキストテキスト
@@ -47,7 +47,7 @@ block body
               +e.content
                 +e.title.c-heading.is-xxxs テキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキスト
                 +e.button: .c-button テキストテキスト
-                  
+
 block before_footer
   +l_offer
 

--- a/app/download/page/index.pug
+++ b/app/download/page/index.pug
@@ -27,12 +27,12 @@ block body
             +e.images
               +e.image: .is-no NO IMAGE
               +loop(5)
-                +e.image.js-modal-image(data-modaal-content-source="/assets/images/img-card-01.jpg"): +bgimg("img-card-01.jpg").bg-img
+                +e.image.js-modal-image(data-modaal-content-source="/assets/images/img-card-01.jpg"): +bgimg("img-card-01.jpg").u-bg-cover
             +e.slider.swiper
               .swiper-wrapper
                 +e.image.swiper-slide: .is-no NO IMAGE
                 +loop(3)
-                  +e.image.swiper-slide: +bgimg("img-card-01.jpg").bg-img
+                  +e.image.swiper-slide: +bgimg("img-card-01.jpg").u-bg-cover
               .swiper-nav
                 .swiper-button-prev
                 .swiper-button-next

--- a/app/format/components/_other.pug
+++ b/app/format/components/_other.pug
@@ -30,7 +30,7 @@ div.u-mbs.is-bottom
       +e.slider.swiper
         +e.images.swiper-wrapper
           +loop(10)
-            +e.image.swiper-slide: +bgimg("logo.png").bg-img
+            +e.image.swiper-slide: +bgimg("logo.png").u-bg-cover
 
 div.u-mbs.is-bottom
   +c.gallery-card.swiper
@@ -38,13 +38,13 @@ div.u-mbs.is-bottom
       +h2.head.c-heading.is-md.is-center.is-mg-level-2 会社紹介ギャラリー
     +e.cards.swiper-wrapper
       +e.card.swiper-slide
-        +e.image: +bgimg("img-sample.jpg").bg-img
+        +e.image: +bgimg("img-sample.jpg").u-bg-cover
         +e.text テキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキスト
       +e.card.swiper-slide
-        +e.image: +bgimg("img-sample.jpg").bg-img
+        +e.image: +bgimg("img-sample.jpg").u-bg-cover
         +e.text テキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキスト
       +e.card.swiper-slide
-        +e.image: +bgimg("img-sample.jpg").bg-img
+        +e.image: +bgimg("img-sample.jpg").u-bg-cover
         +e.text テキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキスト
     .l-container
       .swiper-content

--- a/app/inc/mixins/_main-visual.pug
+++ b/app/inc/mixins/_main-visual.pug
@@ -4,8 +4,8 @@ mixin c_main-visual
     +e.wrapper.swiper
       +e.slider.swiper-wrapper
         +loop(3)
-          +e.image.swiper-slide: +bgimg("img-main-visual-01.jpg").bg-img
-          +e.image.swiper-slide: +bgimg("img-sample.jpg").bg-img
+          +e.image.swiper-slide: +bgimg("img-main-visual-01.jpg").u-bg-cover
+          +e.image.swiper-slide: +bgimg("img-sample.jpg").u-bg-cover
       +e.animation
         +e.bar: span
         +e.pagination

--- a/app/inc/mixins/_misc.pug
+++ b/app/inc/mixins/_misc.pug
@@ -2,17 +2,36 @@
 mixin img(file,alt,width,height)
   -
     if ( typeof alt === "undefined" ){
-    var alt = ""
+      var alt = ""
     }
-  img(src=config.rootpath + "/assets/images/" + file, alt!=alt, width!=width, height!=height)&attributes(attributes)
+    if (file.startsWith("http")) {
+      url = file
+    } else {
+      url = config.rootpath + "/assets/images/" + file
+    }
+  img(src=url, alt!=alt, width!=width, height!=height)&attributes(attributes)
 
 //- video タグ
 mixin video(file)
-  video(src=config.rootpath + "/assets/files/" + file)&attributes(attributes)
+  -
+    var url = ""
+    if (file.startsWith("http")) {
+      url = file
+    } else {
+      url = config.rootpath + "/assets/images/" + file
+    }
+  video(src=url)&attributes(attributes)
 
 //- 背景画像
 mixin bgimg(file)
-  div(style="background-image: url(" + config.rootpath + "/assets/images/" + file + ")")&attributes(attributes)
+  -
+    var url = ""
+    if (file.startsWith("http")) {
+      url = file
+    } else {
+      url = config.rootpath + "/assets/images/" + file
+    }
+  div(style="background-image: url(" + url + ")")&attributes(attributes)
     block
 
 //- ループ


### PR DESCRIPTION
# What
mixinのbackground系のpugとscssを調整しました。

・misc.pug
引数のfileがいつも通りのファイル名のみのパターンは/assets/images/を先頭に加える。
引数のfileがhttpから始まるフルパスであればそのまま。

・mixin.scss
bg-optionの変更前はbackground-sizeはcoverしか選択できなかったが、変更後は引数を持たせてcontainも指定できる形に変更。

・_image.scss
新たにbackground系、img系のユーティリティを作成しました。

# Why
1. misc.pugではフルパスで書いた際に/assets/images/が入ってしまう
2. .bg-imgのクラスが人によって異なる、そもそもbg-imgってなんだ？is-bgまたはu-bgではないのか？
3. mixin.scssのbg-optionの中のbackground-sizeがcoverしか指定できない
