### PR TITLE
l-main・l-containerの調整 ＆ l-root-containerの追加

### DIFF
--- a/app/assets/scss/layout/_container.scss
+++ b/app/assets/scss/layout/_container.scss
@@ -15,7 +15,9 @@
 // Styleguide 5.5.0
 
 .l-container {
-  @extend .container;
+  max-width: $grid-row-width;
+  margin-left: auto;
+  margin-right: auto;
   box-sizing: content-box;
   padding-inline: 32px;
 

--- a/app/assets/scss/layout/_header.scss
+++ b/app/assets/scss/layout/_header.scss
@@ -22,66 +22,19 @@ category: Layout
     position: fixed;
   }
 
-  &__inner {
+
+  &__content {
+    max-width: rem-calc(2560);
+    margin: 0 auto;
     display: flex;
     align-items: center;
-    margin-bottom: 8px;
+    padding: rem-calc(16) rem-calc(32) rem-calc(24);
+    height: rem-calc(80);
+
     @include breakpoint(medium down) {
-      flex-wrap: wrap;
+      padding: rem-calc(3) rem-calc(64) rem-calc(3) rem-calc(16);
+      height: rem-calc(55);
     }
-  }
-
-  &__search {
-    //border: 1px solid $border-base-color;
-    //color: $font-base-color;
-    position: relative;
-    display: block;
-    margin-left: 1.7857142857rem;
-    max-width: 11.4285714286rem;
-    width: 100%;
-    border: 1px solid $font-base-color;
-    color: $font-base-color;
-    background: none;
-    border-radius: 16px;
-    font-size: 0.7142857143rem;
-    letter-spacing: 0.1em;
-    line-height: 1.5;
-    font-weight: 400;
-    padding: 0.5rem 1.2857142857rem 0.5rem 2.7142857143rem;
-    transition: all 0.2s ease-out;
-
-    &:before {
-      position: absolute;
-      left: rem-calc(18);
-      top: 50%;
-      transform: translateY(-50%);
-      line-height: 1;
-      background-repeat: no-repeat;
-      background-position: center center;
-      background-size: cover;
-      font-family: "Material Icons Outlined";
-      content: "search";
-      font-feature-settings: "liga";
-      font-size: rem-calc(18);
-    }
-
-    &:hover, &.is-active {
-      background: $color-primary;
-      color: $color-white;
-      border-color: $color-primary;
-
-      &:before {
-      }
-    }
-  }
-
-  &__search-icon {
-    background: none;
-    border: none;
-    border-radius: 0;
-    line-height: 1;
-    font-size: rem-calc(20);
-    margin-left: auto;
   }
 
   &__logo {
@@ -95,18 +48,6 @@ category: Layout
     a,
     img {
       display: block;
-    }
-  }
-
-  &__content {
-    display: flex;
-    align-items: center;
-    padding: rem-calc(16) rem-calc(32) rem-calc(24);
-    height: rem-calc(80);
-
-    @include breakpoint(medium down) {
-      padding: rem-calc(3) rem-calc(64) rem-calc(3) rem-calc(16);
-      height: rem-calc(55);
     }
   }
 
@@ -286,6 +227,60 @@ category: Layout
       font-size: rem-calc(22);
       margin-right: rem-calc(8);
     }
+  }
+
+
+  &__search {
+    //border: 1px solid $border-base-color;
+    //color: $font-base-color;
+    position: relative;
+    display: block;
+    margin-left: 1.7857142857rem;
+    max-width: 11.4285714286rem;
+    width: 100%;
+    border: 1px solid $font-base-color;
+    color: $font-base-color;
+    background: none;
+    border-radius: 16px;
+    font-size: 0.7142857143rem;
+    letter-spacing: 0.1em;
+    line-height: 1.5;
+    font-weight: 400;
+    padding: 0.5rem 1.2857142857rem 0.5rem 2.7142857143rem;
+    transition: all 0.2s ease-out;
+
+    &:before {
+      position: absolute;
+      left: rem-calc(18);
+      top: 50%;
+      transform: translateY(-50%);
+      line-height: 1;
+      background-repeat: no-repeat;
+      background-position: center center;
+      background-size: cover;
+      font-family: "Material Icons Outlined";
+      content: "search";
+      font-feature-settings: "liga";
+      font-size: rem-calc(18);
+    }
+
+    &:hover, &.is-active {
+      background: $color-primary;
+      color: $color-white;
+      border-color: $color-primary;
+
+      &:before {
+      }
+    }
+  }
+
+  &__search-icon {
+    background: none;
+    border: none;
+    border-radius: 0;
+    line-height: 1;
+    font-size: rem-calc(20);
+    margin-left: auto;
   }
 }
 

--- a/app/assets/scss/layout/_main.scss
+++ b/app/assets/scss/layout/_main.scss
@@ -11,9 +11,8 @@
 
 
 .l-main {
-  width: 100%;
-  max-width: rem-calc(1920);
-  margin: 0 auto;
+  //width: 100%;
+  //margin: 0 auto;
 }
 
 .l-main.is-two-column {

--- a/app/assets/scss/layout/_root-container.scss
+++ b/app/assets/scss/layout/_root-container.scss
@@ -1,0 +1,4 @@
+.l-root-container {
+  max-width: rem-calc(2560);
+  margin: 0 auto;
+}

--- a/app/assets/scss/object/components/_grid.scss
+++ b/app/assets/scss/object/components/_grid.scss
@@ -45,12 +45,9 @@
 // Styleguide 2.2.1
 @use "sass:math";
 @use "sass:map";
-.container {
-  // @include container($susy);
-  max-width: $grid-row-width;
-  margin-left: auto;
-  margin-right: auto;
-}
+//.container {
+//  // @include container($susy);
+//}
 
 .row {
   margin-left: -(map.get($grid-column-responsive-gutter, medium) * 0.5);

--- a/app/inc/foundation/_head.pug
+++ b/app/inc/foundation/_head.pug
@@ -57,7 +57,8 @@ html(lang="ja")
   body(class!=current.bodyClass)
     //- スマホメニュー
     +c_slidebar
-    block layout
+    .l-root-container
+      block layout
 
     //- フッターに組み込むスクリプト
     block footer_scripts

--- a/app/index.pug
+++ b/app/index.pug
@@ -13,9 +13,9 @@ block append config
 
 block before_main
   +c_loader
-  +c_main-visual()
 
 block body
+  +c_main-visual()
   section.l-section.is-lg.is-color-secondary
     .l-container
       +heading-xlg("私たちについて", "ABOUT").is-bottom


### PR DESCRIPTION
▼関連改善事項
1.l-main関連
https://www.notion.so/growgroup/l-main-dd7f464e67c5484eb89dc2bd90614f80

2.l-container関連
https://www.notion.so/growgroup/_grid-scss-container-CSS-extend-l-container-f9d68ba7e2114fb2a1b91bd225e46d7f

## 1.l-main関連
### 実現したいこと
- l-mainに限らず要素の最大値を基本2560pxにしたい
- c-main-visualをl-mainの中に入れたい

### 行ったこと
- c-main-visualをl-mainの中に入れる
- bodyの直下に .l-root-container を作成し、max-widthを2560pxとする
- l-mainのmax-width指定は削除
- l-header__contentのmax-widthを2560pxとする（l-headerのright/leftの基準位置は画面端になるため）

### 補足
position:fixedのright/leftの指定の基準値は画面端になるため
position:fixedで配置する要素についてはmax-width:2560pxが効かない事に留意
![CleanShot 2024-02-29 at 17 15 43@2x](https://github.com/growgroup/gg-styleguide/assets/97862690/9f49dc94-fb5a-4b26-a952-9379b1ce308f)

# 2.l-container関連
### 行ったこと
- 利用していない .containerを削除し、.l-container単体で機能するように変更
（lp案件等で _grid.scssを削除可能にするため）
