### PR TITLE
[add] c-icon-font : ".material-icons-*** "を .c-icon-font に置き換え、フォント名を$font-icon-family管理に変更など

### DIFF
--- a/app/assets/js/app/owl-carousel.js
+++ b/app/assets/js/app/owl-carousel.js
@@ -63,7 +63,7 @@ export default class OwlCarousel {
         autoHeight: false,
         center: true,
         animateOut: 'fadeOut',
-        navText: ['<i class="material-icons-outlined">arrow_back_ios</i>', '<i class="material-icons-outlined">arrow_forward_ios</i>'],
+        navText: ['<i class="c-icon-font">arrow_back_ios</i>', '<i class="c-icon-font">arrow_forward_ios</i>'],
       });
 
     });
@@ -93,7 +93,7 @@ export default class OwlCarousel {
         autoHeight: false,
         center: true,
         speed: 400,
-        navText: ['<i class="material-icons-outlined">arrow_back_ios</i>', '<i class="material-icons-outlined">arrow_forward_ios</i>'],
+        navText: ['<i class="c-icon-font">arrow_back_ios</i>', '<i class="c-icon-font">arrow_forward_ios</i>'],
         responsive: {
           // breakpoint from 0 up
           0: {

--- a/app/assets/scss/font.scss
+++ b/app/assets/scss/font.scss
@@ -1,4 +1,4 @@
-/*! 
+/*!
 * マテリアルアイコン設定
 */
 
@@ -12,3 +12,4 @@
 @include material-icons.faces(
   $display: block,
 );
+

--- a/app/assets/scss/foundation/_mixin.scss
+++ b/app/assets/scss/foundation/_mixin.scss
@@ -504,3 +504,15 @@
     }
   }
 }
+
+@mixin icon-font-style {
+  font-weight: normal;
+  font-style: normal;
+  line-height: 1;
+  letter-spacing: 0;
+  text-transform: none;
+  display: inline-block;
+  width: 1em;
+  height: 1em;
+  overflow: hidden;
+}

--- a/app/assets/scss/foundation/_settings.scss
+++ b/app/assets/scss/foundation/_settings.scss
@@ -67,6 +67,8 @@ $font-base-size-en: 15px !default; // body.en のフォントサイズ
 $font-base-line-height-en: 1.8 !default; // body.en のフォントサイズ
 $font-base-letter-spacing-en: 0 !default; // body.en のフォントサイズ
 
+//icon
+$font-icon-family: 'Material Icons Outlined' !default; // アイコンフォントファミリー
 
 // ==============================
 // # 3. border

--- a/app/assets/scss/foundation/_webfont.scss
+++ b/app/assets/scss/foundation/_webfont.scss
@@ -3,43 +3,43 @@
   font-family: 'Roboto', sans-serif;
 }
 
-@mixin material-icon-default() {
-  font-weight: normal;
-  font-style: normal;
-  font-size: 24px;
-  line-height: 1;
-  letter-spacing: normal;
-  text-transform: none;
-  display: inline-block;
-  white-space: nowrap;
-  word-wrap: normal;
-  direction: ltr;
-  -webkit-font-feature-settings: 'liga';
-  -webkit-font-smoothing: antialiased;
-}
 
-.material-icons-round {
-  font-family: 'Material Icons Round';
-  @include material-icon-default();
-}
-
-.material-icons-outlined {
-  font-family: 'Material Icons Outlined';
-  @include material-icon-default();
-}
-
-.material-icons {
-  font-family: 'Material Icons';
-  @include material-icon-default();
-}
-
-.material-icons-sharp {
-  font-family: 'Material Icons Sharp';
-  @include material-icon-default();
-}
-
-.material-icons-two-tone {
-  font-family: 'Material Icons Two Tone';
-  @include material-icon-default();
-}
+//@mixin material-icon-default() {
+//  font-weight: normal;
+//  font-style: normal;
+//  font-size: 24px;
+//  line-height: 1;
+//  letter-spacing: normal;
+//  text-transform: none;
+//  display: inline-block;
+//  white-space: nowrap;
+//  word-wrap: normal;
+//  direction: ltr;
+//  -webkit-font-feature-settings: 'liga';
+//  -webkit-font-smoothing: antialiased;
+//}
+//.material-icons-round {
+//  font-family: 'Material Icons Round';
+//  @include material-icon-default();
+//}
+//
+//.material-icons-outlined {
+//  font-family: 'Material Icons Outlined';
+//  @include material-icon-default();
+//}
+//
+//.material-icons {
+//  font-family: 'Material Icons';
+//  @include material-icon-default();
+//}
+//
+//.material-icons-sharp {
+//  font-family: 'Material Icons Sharp';
+//  @include material-icon-default();
+//}
+//
+//.material-icons-two-tone {
+//  font-family: 'Material Icons Two Tone';
+//  @include material-icon-default();
+//}
 

--- a/app/assets/scss/foundation/_webfont.scss
+++ b/app/assets/scss/foundation/_webfont.scss
@@ -3,7 +3,7 @@
   font-family: 'Roboto', sans-serif;
 }
 
-@mixin iconfont() {
+@mixin icon-font() {
   font-family: $font-icon-family;
   @include icon-font-style();
 }

--- a/app/assets/scss/foundation/_webfont.scss
+++ b/app/assets/scss/foundation/_webfont.scss
@@ -3,6 +3,10 @@
   font-family: 'Roboto', sans-serif;
 }
 
+@mixin iconfont() {
+  font-family: $font-icon-family;
+  @include icon-font-style();
+}
 
 //@mixin material-icon-default() {
 //  font-weight: normal;

--- a/app/assets/scss/layout/_footer.scss
+++ b/app/assets/scss/layout/_footer.scss
@@ -46,7 +46,7 @@ category: Layout
       background-color: $font-base-color;
       &::before {
         content: "chevron_right";
-        font-family: 'Material Icons Outlined';
+        font-family: $font-icon-family;
         line-height: 1;
         letter-spacing: 0;
         color: $color-primary;

--- a/app/assets/scss/layout/_footer.scss
+++ b/app/assets/scss/layout/_footer.scss
@@ -46,7 +46,7 @@ category: Layout
       background-color: $font-base-color;
       &::before {
         content: "chevron_right";
-        @include iconfont();
+        @include icon-font();
         color: $color-primary;
         padding-right: rem-calc(12);
       }

--- a/app/assets/scss/layout/_footer.scss
+++ b/app/assets/scss/layout/_footer.scss
@@ -47,8 +47,7 @@ category: Layout
       &::before {
         content: "chevron_right";
         font-family: $font-icon-family;
-        line-height: 1;
-        letter-spacing: 0;
+        @include icon-font-style();
         color: $color-primary;
         padding-right: rem-calc(12);
       }

--- a/app/assets/scss/layout/_footer.scss
+++ b/app/assets/scss/layout/_footer.scss
@@ -46,8 +46,7 @@ category: Layout
       background-color: $font-base-color;
       &::before {
         content: "chevron_right";
-        font-family: $font-icon-family;
-        @include icon-font-style();
+        @include iconfont();
         color: $color-primary;
         padding-right: rem-calc(12);
       }

--- a/app/assets/scss/layout/_header.scss
+++ b/app/assets/scss/layout/_header.scss
@@ -55,13 +55,12 @@ category: Layout
       left: rem-calc(18);
       top: 50%;
       transform: translateY(-50%);
-      line-height: 1;
       background-repeat: no-repeat;
       background-position: center center;
       background-size: cover;
       font-family: $font-icon-family;
       content: "search";
-      font-feature-settings: "liga";
+      @include icon-font-style();
       font-size: rem-calc(18);
     }
 

--- a/app/assets/scss/layout/_header.scss
+++ b/app/assets/scss/layout/_header.scss
@@ -58,9 +58,8 @@ category: Layout
       background-repeat: no-repeat;
       background-position: center center;
       background-size: cover;
-      font-family: $font-icon-family;
+      @include iconfont();
       content: "search";
-      @include icon-font-style();
       font-size: rem-calc(18);
     }
 

--- a/app/assets/scss/layout/_header.scss
+++ b/app/assets/scss/layout/_header.scss
@@ -59,7 +59,7 @@ category: Layout
       background-repeat: no-repeat;
       background-position: center center;
       background-size: cover;
-      font-family: "Material Icons Outlined";
+      font-family: $font-icon-family;
       content: "search";
       font-feature-settings: "liga";
       font-size: rem-calc(18);

--- a/app/assets/scss/layout/_header.scss
+++ b/app/assets/scss/layout/_header.scss
@@ -58,7 +58,7 @@ category: Layout
       background-repeat: no-repeat;
       background-position: center center;
       background-size: cover;
-      @include iconfont();
+      @include icon-font();
       content: "search";
       font-size: rem-calc(18);
     }

--- a/app/assets/scss/layout/_offer.scss
+++ b/app/assets/scss/layout/_offer.scss
@@ -58,7 +58,7 @@ category: Layout
     }
     &::after {
       content: "chevron_right";
-      @include iconfont();
+      @include icon-font();
       position: absolute;
       font-size: rem-calc(20);
       top: 50%;

--- a/app/assets/scss/layout/_offer.scss
+++ b/app/assets/scss/layout/_offer.scss
@@ -58,8 +58,7 @@ category: Layout
     }
     &::after {
       content: "chevron_right";
-      font-family: $font-icon-family;
-      @include icon-font-style();
+      @include iconfont();
       position: absolute;
       font-size: rem-calc(20);
       top: 50%;

--- a/app/assets/scss/layout/_offer.scss
+++ b/app/assets/scss/layout/_offer.scss
@@ -59,6 +59,7 @@ category: Layout
     &::after {
       content: "chevron_right";
       font-family: $font-icon-family;
+      @include icon-font-style();
       position: absolute;
       font-size: rem-calc(20);
       top: 50%;

--- a/app/assets/scss/layout/_offer.scss
+++ b/app/assets/scss/layout/_offer.scss
@@ -58,7 +58,7 @@ category: Layout
     }
     &::after {
       content: "chevron_right";
-      font-family: 'Material Icons Outlined';
+      font-family: $font-icon-family;
       position: absolute;
       font-size: rem-calc(20);
       top: 50%;

--- a/app/assets/scss/layout/_post-content.scss
+++ b/app/assets/scss/layout/_post-content.scss
@@ -71,7 +71,7 @@
     &::before {
       content: "check";
       font-family: $font-icon-family;
-      letter-spacing: 0;
+      @include icon-font-style();
       float: left;
       margin-right: 0.3rem;
       color: $color-primary;

--- a/app/assets/scss/layout/_post-content.scss
+++ b/app/assets/scss/layout/_post-content.scss
@@ -70,8 +70,7 @@
 
     &::before {
       content: "check";
-      font-family: $font-icon-family;
-      @include icon-font-style();
+      @include iconfont();
       float: left;
       margin-right: 0.3rem;
       color: $color-primary;

--- a/app/assets/scss/layout/_post-content.scss
+++ b/app/assets/scss/layout/_post-content.scss
@@ -70,7 +70,7 @@
 
     &::before {
       content: "check";
-      font-family: 'Material Icons Outlined';
+      font-family: $font-icon-family;
       letter-spacing: 0;
       float: left;
       margin-right: 0.3rem;

--- a/app/assets/scss/layout/_post-content.scss
+++ b/app/assets/scss/layout/_post-content.scss
@@ -70,7 +70,7 @@
 
     &::before {
       content: "check";
-      @include iconfont();
+      @include icon-font();
       float: left;
       margin-right: 0.3rem;
       color: $color-primary;

--- a/app/assets/scss/layout/_searchform.scss
+++ b/app/assets/scss/layout/_searchform.scss
@@ -70,17 +70,14 @@
     }
 
     &__icon {
+      @include icon-font();
+      font-size: rem-calc(24);
       color: $font-base-color;
-      line-height: 1;
-      letter-spacing: 0;
       display: flex;
       align-items: center;
       justify-content: center;
       padding: rem-calc(20);
-
-      span{
-        font-size: rem-calc(30);
-      }
+      box-sizing: content-box;
 
       @include breakpoint(small only) {
         padding: rem-calc(10);

--- a/app/assets/scss/object/components/_accordion.scss
+++ b/app/assets/scss/object/components/_accordion.scss
@@ -43,7 +43,7 @@ category: Components
     //*矢印
     &::after {
       content: "expand_less";
-      @include iconfont();
+      @include icon-font();
       color: $color-primary;
       position: absolute;
       top: 50%;

--- a/app/assets/scss/object/components/_accordion.scss
+++ b/app/assets/scss/object/components/_accordion.scss
@@ -44,10 +44,9 @@ category: Components
     &::after {
       content: "expand_less";
       font-family: $font-icon-family;
+      @include icon-font-style();
       color: $color-primary;
       position: absolute;
-      line-height: 1;
-      letter-spacing: 0;
       top: 50%;
       transform: translateY(-50%);
       right: 0;

--- a/app/assets/scss/object/components/_accordion.scss
+++ b/app/assets/scss/object/components/_accordion.scss
@@ -43,7 +43,7 @@ category: Components
     //*矢印
     &::after {
       content: "expand_less";
-      font-family: 'Material Icons Outlined';
+      font-family: $font-icon-family;
       color: $color-primary;
       position: absolute;
       line-height: 1;

--- a/app/assets/scss/object/components/_accordion.scss
+++ b/app/assets/scss/object/components/_accordion.scss
@@ -43,8 +43,7 @@ category: Components
     //*矢印
     &::after {
       content: "expand_less";
-      font-family: $font-icon-family;
-      @include icon-font-style();
+      @include iconfont();
       color: $color-primary;
       position: absolute;
       top: 50%;

--- a/app/assets/scss/object/components/_banners.scss
+++ b/app/assets/scss/object/components/_banners.scss
@@ -24,8 +24,7 @@ category: Banners
     // *アイコン
     &::after {
       content: "chevron_right";
-      font-family: $font-icon-family;
-      @include icon-font-style();
+      @include iconfont();
       font-size: rem-calc(36);
       z-index: 99;
       position: absolute;

--- a/app/assets/scss/object/components/_banners.scss
+++ b/app/assets/scss/object/components/_banners.scss
@@ -24,7 +24,7 @@ category: Banners
     // *アイコン
     &::after {
       content: "chevron_right";
-      font-family: 'Material Icons Outlined';
+      font-family: $font-icon-family;
       line-height: 1;
       letter-spacing: 0;
       font-size: rem-calc(36);

--- a/app/assets/scss/object/components/_banners.scss
+++ b/app/assets/scss/object/components/_banners.scss
@@ -25,11 +25,8 @@ category: Banners
     &::after {
       content: "chevron_right";
       font-family: $font-icon-family;
-      line-height: 1;
-      letter-spacing: 0;
+      @include icon-font-style();
       font-size: rem-calc(36);
-      font-weight: 400;
-      position: relative;
       z-index: 99;
       position: absolute;
       right: rem-calc(24);

--- a/app/assets/scss/object/components/_banners.scss
+++ b/app/assets/scss/object/components/_banners.scss
@@ -24,7 +24,7 @@ category: Banners
     // *アイコン
     &::after {
       content: "chevron_right";
-      @include iconfont();
+      @include icon-font();
       font-size: rem-calc(36);
       z-index: 99;
       position: absolute;

--- a/app/assets/scss/object/components/_blockquote.scss
+++ b/app/assets/scss/object/components/_blockquote.scss
@@ -19,7 +19,7 @@ category: Base
   }
   &::before {
     content: "format_quote";
-    font-family: 'Material Icons Outlined';
+    font-family: $font-icon-family;
     line-height: 1;
     letter-spacing: 0;
     font-size: rem-calc(20);

--- a/app/assets/scss/object/components/_blockquote.scss
+++ b/app/assets/scss/object/components/_blockquote.scss
@@ -20,8 +20,7 @@ category: Base
   &::before {
     content: "format_quote";
     font-family: $font-icon-family;
-    line-height: 1;
-    letter-spacing: 0;
+    @include icon-font-style();
     font-size: rem-calc(20);
     color: $color-primary;
     position: absolute;

--- a/app/assets/scss/object/components/_blockquote.scss
+++ b/app/assets/scss/object/components/_blockquote.scss
@@ -19,8 +19,7 @@ category: Base
   }
   &::before {
     content: "format_quote";
-    font-family: $font-icon-family;
-    @include icon-font-style();
+    @include iconfont();
     font-size: rem-calc(20);
     color: $color-primary;
     position: absolute;

--- a/app/assets/scss/object/components/_blockquote.scss
+++ b/app/assets/scss/object/components/_blockquote.scss
@@ -19,7 +19,7 @@ category: Base
   }
   &::before {
     content: "format_quote";
-    @include iconfont();
+    @include icon-font();
     font-size: rem-calc(20);
     color: $color-primary;
     position: absolute;

--- a/app/assets/scss/object/components/_box-archive.scss
+++ b/app/assets/scss/object/components/_box-archive.scss
@@ -39,7 +39,7 @@ category: Navigation
       }
       &::before {
         content: "chevron_right";
-        font-family: 'Material Icons Outlined';
+        font-family: $font-icon-family;
         line-height: 1;
         letter-spacing: 0;
         color: $color-primary;

--- a/app/assets/scss/object/components/_box-archive.scss
+++ b/app/assets/scss/object/components/_box-archive.scss
@@ -39,7 +39,7 @@ category: Navigation
       }
       &::before {
         content: "chevron_right";
-        @include iconfont();
+        @include icon-font();
         color: $color-primary;
         padding-right: rem-calc(8);
       }

--- a/app/assets/scss/object/components/_box-archive.scss
+++ b/app/assets/scss/object/components/_box-archive.scss
@@ -40,8 +40,7 @@ category: Navigation
       &::before {
         content: "chevron_right";
         font-family: $font-icon-family;
-        line-height: 1;
-        letter-spacing: 0;
+        @include icon-font-style();
         color: $color-primary;
         padding-right: rem-calc(8);
       }

--- a/app/assets/scss/object/components/_box-archive.scss
+++ b/app/assets/scss/object/components/_box-archive.scss
@@ -39,8 +39,7 @@ category: Navigation
       }
       &::before {
         content: "chevron_right";
-        font-family: $font-icon-family;
-        @include icon-font-style();
+        @include iconfont();
         color: $color-primary;
         padding-right: rem-calc(8);
       }

--- a/app/assets/scss/object/components/_buttons.scss
+++ b/app/assets/scss/object/components/_buttons.scss
@@ -21,7 +21,7 @@ category: Buttons
   // *アイコン
   &::after {
     content: "chevron_right";
-    font-family: 'Material Icons Outlined';
+    font-family: $font-icon-family;
     line-height: 1;
     letter-spacing: 0;
     position: absolute;

--- a/app/assets/scss/object/components/_buttons.scss
+++ b/app/assets/scss/object/components/_buttons.scss
@@ -21,8 +21,7 @@ category: Buttons
   // *アイコン
   &::after {
     content: "chevron_right";
-    font-family: $font-icon-family;
-    @include icon-font-style();
+    @include iconfont();
     position: absolute;
     top: 50%;
     right: rem-calc(16);

--- a/app/assets/scss/object/components/_buttons.scss
+++ b/app/assets/scss/object/components/_buttons.scss
@@ -21,7 +21,7 @@ category: Buttons
   // *アイコン
   &::after {
     content: "chevron_right";
-    @include iconfont();
+    @include icon-font();
     position: absolute;
     top: 50%;
     right: rem-calc(16);

--- a/app/assets/scss/object/components/_buttons.scss
+++ b/app/assets/scss/object/components/_buttons.scss
@@ -22,13 +22,11 @@ category: Buttons
   &::after {
     content: "chevron_right";
     font-family: $font-icon-family;
-    line-height: 1;
-    letter-spacing: 0;
+    @include icon-font-style();
     position: absolute;
     top: 50%;
     right: rem-calc(16);
     transform: translateY(-50%);
-    font-weight: 400;
   }
 
   // *hover

--- a/app/assets/scss/object/components/_forms-document-detail.scss
+++ b/app/assets/scss/object/components/_forms-document-detail.scss
@@ -81,7 +81,7 @@
 
         &:after {
           content: "chevron_right";
-          @include iconfont();
+          @include icon-font();
           color: $color-primary;
         }
 

--- a/app/assets/scss/object/components/_forms-document-detail.scss
+++ b/app/assets/scss/object/components/_forms-document-detail.scss
@@ -82,6 +82,7 @@
         &:after {
           content: "chevron_right";
           font-family: $font-icon-family;
+          @include icon-font-style();
           color: $color-primary;
         }
 

--- a/app/assets/scss/object/components/_forms-document-detail.scss
+++ b/app/assets/scss/object/components/_forms-document-detail.scss
@@ -81,8 +81,7 @@
 
         &:after {
           content: "chevron_right";
-          font-family: $font-icon-family;
-          @include icon-font-style();
+          @include iconfont();
           color: $color-primary;
         }
 

--- a/app/assets/scss/object/components/_forms-document-detail.scss
+++ b/app/assets/scss/object/components/_forms-document-detail.scss
@@ -81,7 +81,7 @@
 
         &:after {
           content: "chevron_right";
-          font-family: "Material Icons Outlined";
+          font-family: $font-icon-family;
           color: $color-primary;
         }
 

--- a/app/assets/scss/object/components/_forms.scss
+++ b/app/assets/scss/object/components/_forms.scss
@@ -293,7 +293,7 @@
           &:checked {
             &::after {
               content: "check";
-              @include iconfont();
+              @include icon-font();
               display: grid;
               place-content: center;
               background: $color-primary;

--- a/app/assets/scss/object/components/_forms.scss
+++ b/app/assets/scss/object/components/_forms.scss
@@ -293,7 +293,7 @@
           &:checked {
             &::after {
               content: "check";
-              font-family: "Material Icons Outlined";
+              font-family: $font-icon-family;
               display: grid;
               place-content: center;
               background: $color-primary;

--- a/app/assets/scss/object/components/_forms.scss
+++ b/app/assets/scss/object/components/_forms.scss
@@ -294,13 +294,12 @@
             &::after {
               content: "check";
               font-family: $font-icon-family;
+              @include icon-font-style();
               display: grid;
               place-content: center;
               background: $color-primary;
               color: $color-white;
               font-size: rem-calc(20);
-              line-height: 1;
-              letter-spacing: 0;
             }
           }
         }

--- a/app/assets/scss/object/components/_forms.scss
+++ b/app/assets/scss/object/components/_forms.scss
@@ -293,8 +293,7 @@
           &:checked {
             &::after {
               content: "check";
-              font-family: $font-icon-family;
-              @include icon-font-style();
+              @include iconfont();
               display: grid;
               place-content: center;
               background: $color-primary;

--- a/app/assets/scss/object/components/_gallery-card.scss
+++ b/app/assets/scss/object/components/_gallery-card.scss
@@ -77,7 +77,7 @@
 
       &:after {
         content: "chevron_right";
-        font-family: "Material Icons Outlined";
+        font-family: $font-icon-family;
         color: $color-primary;
       }
 

--- a/app/assets/scss/object/components/_gallery-card.scss
+++ b/app/assets/scss/object/components/_gallery-card.scss
@@ -77,8 +77,7 @@
 
       &:after {
         content: "chevron_right";
-        font-family: $font-icon-family;
-        @include icon-font-style();
+        @include iconfont();
         color: $color-primary;
       }
 

--- a/app/assets/scss/object/components/_gallery-card.scss
+++ b/app/assets/scss/object/components/_gallery-card.scss
@@ -77,7 +77,7 @@
 
       &:after {
         content: "chevron_right";
-        @include iconfont();
+        @include icon-font();
         color: $color-primary;
       }
 

--- a/app/assets/scss/object/components/_gallery-card.scss
+++ b/app/assets/scss/object/components/_gallery-card.scss
@@ -78,6 +78,7 @@
       &:after {
         content: "chevron_right";
         font-family: $font-icon-family;
+        @include icon-font-style();
         color: $color-primary;
       }
 

--- a/app/assets/scss/object/components/_hero-block-line.scss
+++ b/app/assets/scss/object/components/_hero-block-line.scss
@@ -162,8 +162,7 @@
       &::after {
         content: "chevron_right";
         font-family: $font-icon-family;
-        line-height: 1;
-        letter-spacing: 0;
+        @include icon-font-style();
         color: $color-primary;
         position: absolute;
         top: 50%;

--- a/app/assets/scss/object/components/_hero-block-line.scss
+++ b/app/assets/scss/object/components/_hero-block-line.scss
@@ -161,8 +161,7 @@
 
       &::after {
         content: "chevron_right";
-        font-family: $font-icon-family;
-        @include icon-font-style();
+        @include iconfont();
         color: $color-primary;
         position: absolute;
         top: 50%;

--- a/app/assets/scss/object/components/_hero-block-line.scss
+++ b/app/assets/scss/object/components/_hero-block-line.scss
@@ -161,7 +161,7 @@
 
       &::after {
         content: "chevron_right";
-        @include iconfont();
+        @include icon-font();
         color: $color-primary;
         position: absolute;
         top: 50%;

--- a/app/assets/scss/object/components/_hero-block-line.scss
+++ b/app/assets/scss/object/components/_hero-block-line.scss
@@ -161,7 +161,7 @@
 
       &::after {
         content: "chevron_right";
-        font-family: 'Material Icons Outlined';
+        font-family: $font-icon-family;
         line-height: 1;
         letter-spacing: 0;
         color: $color-primary;

--- a/app/assets/scss/object/components/_icon-font.scss
+++ b/app/assets/scss/object/components/_icon-font.scss
@@ -1,0 +1,22 @@
+// ex.
+// span.c-icon-font close
+
+.c-icon-font {
+  font-family: $font-icon-family;
+  font-weight: normal;
+  font-style: normal;
+  line-height: 1;
+  letter-spacing: 0;
+  text-transform: none;
+  display: inline-block;
+  white-space: nowrap;
+  word-wrap: normal;
+  direction: ltr;
+  -webkit-font-feature-settings: 'liga';
+  -webkit-font-smoothing: antialiased;
+
+  //アイコンを複数混在させる必要がある場合
+  //&.is-outlined{
+  //font-family: 'Material Icons Outlined';
+  //}
+}

--- a/app/assets/scss/object/components/_icon-font.scss
+++ b/app/assets/scss/object/components/_icon-font.scss
@@ -2,8 +2,7 @@
 // span.c-icon-font close
 
 .c-icon-font {
-  font-family: $font-icon-family;
-  @include icon-font-style();
+  @include iconfont();
 
   //アイコンを複数混在させる必要がある場合
   //&.is-outlined{

--- a/app/assets/scss/object/components/_icon-font.scss
+++ b/app/assets/scss/object/components/_icon-font.scss
@@ -3,17 +3,7 @@
 
 .c-icon-font {
   font-family: $font-icon-family;
-  font-weight: normal;
-  font-style: normal;
-  line-height: 1;
-  letter-spacing: 0;
-  text-transform: none;
-  display: inline-block;
-  white-space: nowrap;
-  word-wrap: normal;
-  direction: ltr;
-  -webkit-font-feature-settings: 'liga';
-  -webkit-font-smoothing: antialiased;
+  @include icon-font-style();
 
   //アイコンを複数混在させる必要がある場合
   //&.is-outlined{

--- a/app/assets/scss/object/components/_icon-font.scss
+++ b/app/assets/scss/object/components/_icon-font.scss
@@ -2,7 +2,7 @@
 // span.c-icon-font close
 
 .c-icon-font {
-  @include iconfont();
+  @include icon-font();
 
   //アイコンを複数混在させる必要がある場合
   //&.is-outlined{

--- a/app/assets/scss/object/components/_list.scss
+++ b/app/assets/scss/object/components/_list.scss
@@ -67,7 +67,7 @@ category: Base
 
     &::before {
       content: "circle";
-      font-family: 'Material Icons Outlined';
+      font-family: $font-icon-family;
       font-size: rem-calc(10);
       color: $color-primary;
       position: absolute;

--- a/app/assets/scss/object/components/_list.scss
+++ b/app/assets/scss/object/components/_list.scss
@@ -67,7 +67,7 @@ category: Base
 
     &::before {
       content: "circle";
-      @include iconfont();
+      @include icon-font();
       font-size: rem-calc(10);
       color: $color-primary;
       position: absolute;

--- a/app/assets/scss/object/components/_list.scss
+++ b/app/assets/scss/object/components/_list.scss
@@ -67,8 +67,7 @@ category: Base
 
     &::before {
       content: "circle";
-      font-family: $font-icon-family;
-      @include icon-font-style();
+      @include iconfont();
       font-size: rem-calc(10);
       color: $color-primary;
       position: absolute;

--- a/app/assets/scss/object/components/_list.scss
+++ b/app/assets/scss/object/components/_list.scss
@@ -68,6 +68,7 @@ category: Base
     &::before {
       content: "circle";
       font-family: $font-icon-family;
+      @include icon-font-style();
       font-size: rem-calc(10);
       color: $color-primary;
       position: absolute;

--- a/app/assets/scss/object/components/_menu-list.scss
+++ b/app/assets/scss/object/components/_menu-list.scss
@@ -29,8 +29,7 @@ category: Navigation
         &::before {
           content: "chevron_right";
           font-family: $font-icon-family;
-          line-height: 1;
-          letter-spacing: 0;
+          @include icon-font-style();
           color: $color-primary;
           position: absolute;
           top: 50%;
@@ -109,6 +108,7 @@ category: Navigation
     &::after {
       content: "chevron_right";
       font-family: $font-icon-family;
+      @include icon-font-style();
       position: absolute;
       top: 50%;
       transform: translateY(-50%);

--- a/app/assets/scss/object/components/_menu-list.scss
+++ b/app/assets/scss/object/components/_menu-list.scss
@@ -28,8 +28,7 @@ category: Navigation
 
         &::before {
           content: "chevron_right";
-          font-family: $font-icon-family;
-          @include icon-font-style();
+          @include iconfont();
           color: $color-primary;
           position: absolute;
           top: 50%;
@@ -107,8 +106,7 @@ category: Navigation
 
     &::after {
       content: "chevron_right";
-      font-family: $font-icon-family;
-      @include icon-font-style();
+      @include iconfont();
       position: absolute;
       top: 50%;
       transform: translateY(-50%);

--- a/app/assets/scss/object/components/_menu-list.scss
+++ b/app/assets/scss/object/components/_menu-list.scss
@@ -28,7 +28,7 @@ category: Navigation
 
         &::before {
           content: "chevron_right";
-          @include iconfont();
+          @include icon-font();
           color: $color-primary;
           position: absolute;
           top: 50%;
@@ -106,7 +106,7 @@ category: Navigation
 
     &::after {
       content: "chevron_right";
-      @include iconfont();
+      @include icon-font();
       position: absolute;
       top: 50%;
       transform: translateY(-50%);

--- a/app/assets/scss/object/components/_menu-list.scss
+++ b/app/assets/scss/object/components/_menu-list.scss
@@ -28,7 +28,7 @@ category: Navigation
 
         &::before {
           content: "chevron_right";
-          font-family: 'Material Icons Outlined';
+          font-family: $font-icon-family;
           line-height: 1;
           letter-spacing: 0;
           color: $color-primary;
@@ -108,7 +108,7 @@ category: Navigation
 
     &::after {
       content: "chevron_right";
-      font-family: 'Material Icons Outlined';
+      font-family: $font-icon-family;
       position: absolute;
       top: 50%;
       transform: translateY(-50%);

--- a/app/assets/scss/object/components/_modaal.scss
+++ b/app/assets/scss/object/components/_modaal.scss
@@ -36,7 +36,7 @@
 
   &:after {
     content: "search";
-    @include iconfont();
+    @include icon-font();
     position: absolute;
     right: 0;
     bottom: 0;

--- a/app/assets/scss/object/components/_modaal.scss
+++ b/app/assets/scss/object/components/_modaal.scss
@@ -36,8 +36,7 @@
 
   &:after {
     content: "search";
-    font-family: $font-icon-family;
-    @include icon-font-style();
+    @include iconfont();
     position: absolute;
     right: 0;
     bottom: 0;

--- a/app/assets/scss/object/components/_modaal.scss
+++ b/app/assets/scss/object/components/_modaal.scss
@@ -37,6 +37,7 @@
   &:after {
     content: "search";
     font-family: $font-icon-family;
+    @include icon-font-style();
     position: absolute;
     right: 0;
     bottom: 0;
@@ -47,7 +48,6 @@
     height: rem-calc(20);
     background: $color-primary;
     color: $color-white;
-    @include font-format(14,0,14,400);
   }
 
   &:hover {

--- a/app/assets/scss/object/components/_modaal.scss
+++ b/app/assets/scss/object/components/_modaal.scss
@@ -36,7 +36,7 @@
 
   &:after {
     content: "search";
-    font-family: "Material Icons Outlined";
+    font-family: $font-icon-family;
     position: absolute;
     right: 0;
     bottom: 0;

--- a/app/assets/scss/object/components/_news-lg.scss
+++ b/app/assets/scss/object/components/_news-lg.scss
@@ -40,7 +40,7 @@ category: News
     &::before {
       content: "schedule";
       font-family: $font-icon-family;
-      letter-spacing: 0;
+      @include icon-font-style();
       margin-right: rem-calc(4);
       vertical-align: top;
     }

--- a/app/assets/scss/object/components/_news-lg.scss
+++ b/app/assets/scss/object/components/_news-lg.scss
@@ -39,8 +39,7 @@ category: News
 
     &::before {
       content: "schedule";
-      font-family: $font-icon-family;
-      @include icon-font-style();
+      @include iconfont();
       margin-right: rem-calc(4);
       vertical-align: top;
     }

--- a/app/assets/scss/object/components/_news-lg.scss
+++ b/app/assets/scss/object/components/_news-lg.scss
@@ -39,7 +39,7 @@ category: News
 
     &::before {
       content: "schedule";
-      @include iconfont();
+      @include icon-font();
       margin-right: rem-calc(4);
       vertical-align: top;
     }

--- a/app/assets/scss/object/components/_news-lg.scss
+++ b/app/assets/scss/object/components/_news-lg.scss
@@ -39,7 +39,7 @@ category: News
 
     &::before {
       content: "schedule";
-      font-family: 'Material Icons Outlined';
+      font-family: $font-icon-family;
       letter-spacing: 0;
       margin-right: rem-calc(4);
       vertical-align: top;

--- a/app/assets/scss/object/components/_pagetop.scss
+++ b/app/assets/scss/object/components/_pagetop.scss
@@ -38,8 +38,7 @@
 
     &:after {
       content: "expand_less";
-      font-family: $font-icon-family;
-      @include icon-font-style();
+      @include iconfont();
     }
 
     &:hover {

--- a/app/assets/scss/object/components/_pagetop.scss
+++ b/app/assets/scss/object/components/_pagetop.scss
@@ -38,7 +38,7 @@
 
     &:after {
       content: "expand_less";
-      @include iconfont();
+      @include icon-font();
     }
 
     &:hover {

--- a/app/assets/scss/object/components/_pagetop.scss
+++ b/app/assets/scss/object/components/_pagetop.scss
@@ -39,6 +39,7 @@
     &:after {
       content: "expand_less";
       font-family: $font-icon-family;
+      @include icon-font-style();
     }
 
     &:hover {

--- a/app/assets/scss/object/components/_pagetop.scss
+++ b/app/assets/scss/object/components/_pagetop.scss
@@ -38,7 +38,7 @@
 
     &:after {
       content: "expand_less";
-      font-family: 'Material Icons Outlined';
+      font-family: $font-icon-family;
     }
 
     &:hover {

--- a/app/assets/scss/object/components/_slidebar-menu.scss
+++ b/app/assets/scss/object/components/_slidebar-menu.scss
@@ -50,7 +50,7 @@
 
         &::after {
           content: "navigate_next";
-          @include iconfont();
+          @include icon-font();
         }
       }
 
@@ -213,7 +213,7 @@
         background-repeat: no-repeat;
         background-position: center center;
         background-size: cover;
-        @include iconfont();
+        @include icon-font();
         content: "search";
         font-size: rem-calc(18);
         color: $color-primary;

--- a/app/assets/scss/object/components/_slidebar-menu.scss
+++ b/app/assets/scss/object/components/_slidebar-menu.scss
@@ -51,8 +51,7 @@
         &::after {
           content: "navigate_next";
           font-family: $font-icon-family;
-          line-height: 1;
-          letter-spacing: 0;
+          @include icon-font-style();
         }
       }
 
@@ -217,7 +216,7 @@
         background-size: cover;
         font-family: $font-icon-family;
         content: "search";
-        font-feature-settings: "liga";
+        @include icon-font-style();
         font-size: rem-calc(18);
         color: $color-primary;
       }

--- a/app/assets/scss/object/components/_slidebar-menu.scss
+++ b/app/assets/scss/object/components/_slidebar-menu.scss
@@ -50,7 +50,7 @@
 
         &::after {
           content: "navigate_next";
-          font-family: "Material Icons Outlined";
+          font-family: $font-icon-family;
           line-height: 1;
           letter-spacing: 0;
         }
@@ -215,7 +215,7 @@
         background-repeat: no-repeat;
         background-position: center center;
         background-size: cover;
-        font-family: "Material Icons Outlined";
+        font-family: $font-icon-family;
         content: "search";
         font-feature-settings: "liga";
         font-size: rem-calc(18);

--- a/app/assets/scss/object/components/_slidebar-menu.scss
+++ b/app/assets/scss/object/components/_slidebar-menu.scss
@@ -50,8 +50,7 @@
 
         &::after {
           content: "navigate_next";
-          font-family: $font-icon-family;
-          @include icon-font-style();
+          @include iconfont();
         }
       }
 
@@ -214,9 +213,8 @@
         background-repeat: no-repeat;
         background-position: center center;
         background-size: cover;
-        font-family: $font-icon-family;
+        @include iconfont();
         content: "search";
-        @include icon-font-style();
         font-size: rem-calc(18);
         color: $color-primary;
       }

--- a/app/assets/scss/object/components/_tabs.scss
+++ b/app/assets/scss/object/components/_tabs.scss
@@ -37,7 +37,7 @@ category: Tabs
 
         &::after {
           content: "expand_more";
-          @include iconfont();
+          @include icon-font();
           position: absolute;
           font-size: rem-calc(24);
           font-weight: 400;

--- a/app/assets/scss/object/components/_tabs.scss
+++ b/app/assets/scss/object/components/_tabs.scss
@@ -37,7 +37,7 @@ category: Tabs
 
         &::after {
           content: "expand_more";
-          font-family: 'Material Icons Outlined';
+          font-family:$font-icon-family;
           position: absolute;
           font-size: rem-calc(24);
           font-weight: 400;

--- a/app/assets/scss/object/components/_tabs.scss
+++ b/app/assets/scss/object/components/_tabs.scss
@@ -37,7 +37,7 @@ category: Tabs
 
         &::after {
           content: "expand_more";
-          font-family:$font-icon-family;
+          @include iconfont();
           position: absolute;
           font-size: rem-calc(24);
           font-weight: 400;

--- a/app/assets/scss/object/project/_post-item.scss
+++ b/app/assets/scss/object/project/_post-item.scss
@@ -22,8 +22,7 @@
   }
   &::before {
     content: "chevron_right";
-    font-family: $font-icon-family;
-    @include icon-font-style();
+    @include iconfont();
     color: $color-primary;
     position: absolute;
     top: 50%;

--- a/app/assets/scss/object/project/_post-item.scss
+++ b/app/assets/scss/object/project/_post-item.scss
@@ -23,8 +23,7 @@
   &::before {
     content: "chevron_right";
     font-family: $font-icon-family;
-    line-height: 1;
-    letter-spacing: 0;
+    @include icon-font-style();
     color: $color-primary;
     position: absolute;
     top: 50%;

--- a/app/assets/scss/object/project/_post-item.scss
+++ b/app/assets/scss/object/project/_post-item.scss
@@ -22,7 +22,7 @@
   }
   &::before {
     content: "chevron_right";
-    @include iconfont();
+    @include icon-font();
     color: $color-primary;
     position: absolute;
     top: 50%;

--- a/app/assets/scss/object/project/_post-item.scss
+++ b/app/assets/scss/object/project/_post-item.scss
@@ -22,7 +22,7 @@
   }
   &::before {
     content: "chevron_right";
-    font-family: 'Material Icons Outlined';
+    font-family: $font-icon-family;
     line-height: 1;
     letter-spacing: 0;
     color: $color-primary;

--- a/app/assets/scss/object/utility/_text.scss
+++ b/app/assets/scss/object/utility/_text.scss
@@ -60,7 +60,7 @@ a{
 
     &:after {
       content: "picture_as_pdf";
-      font-family: 'Material Icons Outlined';
+      font-family: $font-icon-family;
       line-height: 1;
       letter-spacing: 0;
     }
@@ -72,7 +72,7 @@ a{
 
     &::before {
       content: "location_on";
-      font-family: 'Material Icons Outlined';
+      font-family: $font-icon-family;
       line-height: 1;
       letter-spacing: 0;
     }
@@ -82,7 +82,7 @@ a{
 
     &::after {
       content: "open_in_new";
-      font-family: 'Material Icons Outlined';
+      font-family: $font-icon-family;
       line-height: 1;
       letter-spacing: 0;
     }

--- a/app/assets/scss/object/utility/_text.scss
+++ b/app/assets/scss/object/utility/_text.scss
@@ -60,7 +60,7 @@ a{
 
     &:after {
       content: "picture_as_pdf";
-      @include iconfont();
+      @include icon-font();
     }
   }
 
@@ -70,7 +70,7 @@ a{
 
     &::before {
       content: "location_on";
-      @include iconfont();
+      @include icon-font();
     }
   }
 
@@ -78,7 +78,7 @@ a{
 
     &::after {
       content: "open_in_new";
-      @include iconfont();
+      @include icon-font();
     }
   }
 }

--- a/app/assets/scss/object/utility/_text.scss
+++ b/app/assets/scss/object/utility/_text.scss
@@ -60,8 +60,7 @@ a{
 
     &:after {
       content: "picture_as_pdf";
-      font-family: $font-icon-family;
-      @include icon-font-style();
+      @include iconfont();
     }
   }
 
@@ -71,8 +70,7 @@ a{
 
     &::before {
       content: "location_on";
-      font-family: $font-icon-family;
-      @include icon-font-style();
+      @include iconfont();
     }
   }
 
@@ -80,8 +78,7 @@ a{
 
     &::after {
       content: "open_in_new";
-      font-family: $font-icon-family;
-      @include icon-font-style();
+      @include iconfont();
     }
   }
 }

--- a/app/assets/scss/object/utility/_text.scss
+++ b/app/assets/scss/object/utility/_text.scss
@@ -61,8 +61,7 @@ a{
     &:after {
       content: "picture_as_pdf";
       font-family: $font-icon-family;
-      line-height: 1;
-      letter-spacing: 0;
+      @include icon-font-style();
     }
   }
 
@@ -73,8 +72,7 @@ a{
     &::before {
       content: "location_on";
       font-family: $font-icon-family;
-      line-height: 1;
-      letter-spacing: 0;
+      @include icon-font-style();
     }
   }
 
@@ -83,8 +81,7 @@ a{
     &::after {
       content: "open_in_new";
       font-family: $font-icon-family;
-      line-height: 1;
-      letter-spacing: 0;
+      @include icon-font-style();
     }
   }
 }

--- a/app/inc/layout/_header-variable.pug
+++ b/app/inc/layout/_header-variable.pug
@@ -21,6 +21,6 @@ header.l-header-variable
         li: +a("/recruit/requirements/")
           span RECRUIT
           small 募集要項
-    +a("/recruit/entry/").l-header-variable__button.c-button.is-sm <span class="material-icons-outlined">mail</span>
+    +a("/recruit/entry/").l-header-variable__button.c-button.is-sm <span class="c-icon-font">mail</span>
       span ENTRY
       small エントリー

--- a/app/inc/layout/_header.pug
+++ b/app/inc/layout/_header.pug
@@ -38,7 +38,7 @@ header(class=className)
                     .l-header__submenu__image: +img("img-sample-sm.jpg", "ブロック編集ページ")
                     span ブロック編集ページ
     button.l-header__search.js-header-searchform-open.u-hidden-md キーワードから検索
-    button.l-header__search-icon.js-header-searchform-open.u-visible-md <span class="material-icons-outlined">search</span>
-    +a("/contact/").l-header__button.c-button.is-sm <span class="material-icons-outlined">mail</span>お問い合わせ
+    button.l-header__search-icon.js-header-searchform-open.u-visible-md <span class="c-icon-font">search</span>
+    +a("/contact/").l-header__button.c-button.is-sm <span class="c-icon-font">mail</span>お問い合わせ
 
 +l_searchform

--- a/app/inc/mixins/_breadcrumb.pug
+++ b/app/inc/mixins/_breadcrumb.pug
@@ -6,7 +6,7 @@ mixin c_breadcrumb(parent,parentURL,parent2,parentURL2)
         span
           span
             +a("/") TOP
-            span.is-arrow <span class="material-icons-outlined">chevron_right</span>
+            span.is-arrow <span class="c-icon-font">chevron_right</span>
             if !parent
               //- parent設定がないとき
               span !{current.title}
@@ -14,7 +14,7 @@ mixin c_breadcrumb(parent,parentURL,parent2,parentURL2)
               //- parent設定があるとき
               span
                 +a('/' + parentURL + '/')=parent
-                span.is-arrow <span class="material-icons-outlined">chevron_right</span>
+                span.is-arrow <span class="c-icon-font">chevron_right</span>
                 if !parent2
                   //- parent2設定がないとき
                   span !{current.title}
@@ -22,5 +22,5 @@ mixin c_breadcrumb(parent,parentURL,parent2,parentURL2)
                   //- parent2設定があるとき
                   span
                     +a('/' + parentURL + '/' + parentURL2 + '/')=parent2
-                    span.is-arrow <span class="material-icons-outlined">chevron_right</span>
+                    span.is-arrow <span class="c-icon-font">chevron_right</span>
                     span !{current.title}

--- a/app/inc/mixins/_misc.pug
+++ b/app/inc/mixins/_misc.pug
@@ -36,7 +36,7 @@ mixin c_post_nav(listID)
   nav.c-post-navs
     ul
       li.c-post-navs__prev: +a(path +"page/").c-button.is-sm.is-arrow-left 前の記事へ
-      li.c-post-navs__archive: +a(path).c-button.is-sm <span class="material-icons-outlined">list</span>記事一覧へ
+      li.c-post-navs__archive: +a(path).c-button.is-sm <span class="c-icon-font">list</span>記事一覧へ
       li.c-post-navs__next: +a(path+"page/").c-button.is-sm 次の記事へ
 
 //- table row

--- a/app/inc/mixins/_offer.pug
+++ b/app/inc/mixins/_offer.pug
@@ -11,7 +11,7 @@ mixin l_offer
           .l-offer__box
             .l-offer__box-text お電話の際は「ホームページを見て」と<br>お伝えください。
             .l-offer__box-tel
-              | <span class="material-icons-outlined">call</span>00-000-0000
+              | <span class="c-icon-font">call</span>00-000-0000
               small 電話受付時間 / 平日00：00～00：00
           .l-offer__box
             .l-offer__box-text メールでのご相談・ご質問は<br>お問い合わせフォームをご活用ください。

--- a/app/inc/mixins/_pagination.pug
+++ b/app/inc/mixins/_pagination.pug
@@ -2,10 +2,10 @@
 mixin c_pagination(data)
   +c.pagination(class=data)
     ul
-      li: +a("#").c-pagination__prev <span class="material-icons-outlined">chevron_left</span>
+      li: +a("#").c-pagination__prev <span class="gg-icon">chevron_left</span>
       li: span.is-current 1
       li: +a("#") 2
       li: +a("#") 3
       li: span.is-dot …
       li: +a("#") 10
-      li: +a("#").c-pagination__next <span class="material-icons-outlined">chevron_right</span>
+      li: +a("#").c-pagination__next <span class="gg-icon">chevron_right</span>

--- a/app/inc/mixins/_searchform.pug
+++ b/app/inc/mixins/_searchform.pug
@@ -5,9 +5,9 @@ mixin l_searchform
     .l-container
       .l-searchform__inner
         button.l-searchform__close.js-header-searchform-close
-          span.material-icons-outlined.l-searchform__close__icon close
+          span.c-icon-font.l-searchform__close__icon close
         form.l-searchform__form.js-header-searchform-content
           label.l-searchform__form__label(for="searchform")
-            span.material-icons-outlined.l-searchform__form__icon(aria-label="キーワードから検索") search
+            span.c-icon-font.l-searchform__form__icon(aria-label="キーワードから検索") search
           input(type="text", placeholder="キーワードから検索")#searchform
           button 検索する

--- a/app/inc/mixins/_searchform.pug
+++ b/app/inc/mixins/_searchform.pug
@@ -8,6 +8,6 @@ mixin l_searchform
           span.c-icon-font.l-searchform__close__icon close
         form.l-searchform__form.js-header-searchform-content
           label.l-searchform__form__label(for="searchform")
-            span.c-icon-font.l-searchform__form__icon(aria-label="キーワードから検索") search
+            span.l-searchform__form__icon(aria-label="キーワードから検索") search
           input(type="text", placeholder="キーワードから検索")#searchform
           button 検索する

--- a/app/inc/mixins/_slidebar.pug
+++ b/app/inc/mixins/_slidebar.pug
@@ -58,7 +58,7 @@ mixin c_slidebar
     .l-container
       +e.buttons
         +ae("#").button.c-button
-          +span.button__icon.material-icons-outlined(aria-hidden="true") mail_outline
+          +span.button__icon.c-icon-font(aria-hidden="true") mail_outline
           |お問い合わせ
       +e.sns-btns
         //テンプレでは便宜上svgコードですが、実際にはimgタグ等での配置でOK


### PR DESCRIPTION
▼関連改善事項
https://www.notion.so/growgroup/Material-Icons-span-class-1-fc59468920e341e5a05403083ca1bfe1

## 改善したかったこと
pugなどの中に `class="material-icons-outlined"` を利用しており
scss内でも `font-family: "Material Icons Outlined";` の表記をしており、
案件デザインに応じて round等に変更する作業が煩雑。

Material Iconsの箇所はletter-spacingは0にした方がいいことが多いが忘れる。

Material Icons のリガチャが起こすFOUTを軽減するために毎回widthやoverflowを書いた方がいいが忘れる（面倒）。


## 変更したこと
- `class="material-icons-outlined"` を`class="c-icon-font"` へ変更。
- `@mixin icon-font-style` の追加。
  - 元々material-icons-** 系のclassがもっていたCSSを移植したもの
- `@mixin icon-font` の追加。
  - `mixin webfont()`のようにアイコンフォントが指定できるようにしたもの
  - `iconfont` としなかったのは、`c-icon-font` `mixin icon-font-style` との整合性のため