### PR TITLE
ページロード時のanchorがheader分の高さが引けてない

### DIFF
--- a/app/assets/js/app/anchor.js
+++ b/app/assets/js/app/anchor.js
@@ -119,7 +119,7 @@ export default class Anchor {
     var url = $(location).attr('href');
     if (url.indexOf("#") !== -1) {
       if (self.options.headerElement) {
-        document.addEventListener("DOMContentLoaded", function(event) {
+        window.addEventListener("load", function () {
           headerHeight = $(self.options.headerElement).outerHeight();
           var id = url.split("#");
           var $target = $('#' + id[id.length - 1]);

--- a/app/assets/js/app/anchor.js
+++ b/app/assets/js/app/anchor.js
@@ -119,7 +119,7 @@ export default class Anchor {
     var url = $(location).attr('href');
     if (url.indexOf("#") !== -1) {
       if (self.options.headerElement) {
-        window.onload = function() {
+        document.addEventListener("DOMContentLoaded", function(event) {
           headerHeight = $(self.options.headerElement).outerHeight();
           var id = url.split("#");
           var $target = $('#' + id[id.length - 1]);
@@ -127,7 +127,7 @@ export default class Anchor {
             var pos = $target.offset().top - headerHeight;
             $("html, body").animate({scrollTop: pos}, 10);
           }
-        };
+        });
       }
     }
   }


### PR DESCRIPTION
# What
window.onload = function() {
を
document.addEventListener("DOMContentLoaded", function(event) {
に変更。

window.onload = function() {にconsole.logを差し込んでも反応無しでした。

# Why
遷移した際にheaderが被さるため。


# 参考サイト
https://yokogawa-bridge.grgr.blue/company/office/#osaka2