### PR TITLE
current-nav.jsで下階層にも対応したい

### DIFF
--- a/app/assets/js/app/current-nav.js
+++ b/app/assets/js/app/current-nav.js
@@ -54,22 +54,19 @@ export default class CurrentNav {
       href = this.isHttp(href);
       href = this.isIndexPage(href);
 
-      if ($element.attr(defaultOptions.childrenData) === "true" && this.currentPathname.includes(href)) {
-        $(this.target[i]).addClass(this.activeClass);
-        // 1個だけにする場合はbreakを有効にする
-        // break;
-      } else if (this.isMatch(href)) {
+      //ここでelementを渡す
+      if (this.isMatch(href, $element)) {
         $(this.target[i]).addClass(this.activeClass);
       }
     }
   }
 
-  isMatch(path) {
+  // ここでelementを受け取る
+  isMatch(path, $element) {
     path = path.replace(/^(.*(?:\.\.?))/,'')
-    if (this.currentPathname === path) {
+    if (this.currentPathname === path || $element.attr(defaultOptions.childrenData) === "true" && this.currentPathname.includes(path)) {
       return true;
     }
-
     return false;
   }
 

--- a/app/assets/js/app/current-nav.js
+++ b/app/assets/js/app/current-nav.js
@@ -3,6 +3,7 @@ import url from "url";
 var defaultOptions = {
   targetSelector: '.js-current-nav', // 実行するセレクタ
   childrenClass: "js-current-children",
+  childrenData: "data-parent-nav",
   activeClass: "is-current", // 付与するクラス
 }
 
@@ -54,7 +55,7 @@ export default class CurrentNav {
       href = this.isHttp(href);
       href = this.isIndexPage(href);
 
-      if ($element.hasClass(defaultOptions.childrenClass) && this.currentPathname.includes(href)) {
+      if ($element.attr(defaultOptions.childrenData) === "true" && this.currentPathname.includes(href)) {
         $(this.target[i]).addClass(this.activeClass);
         // 1個だけにする場合はbreakを有効にする
         // break;

--- a/app/assets/js/app/current-nav.js
+++ b/app/assets/js/app/current-nav.js
@@ -2,8 +2,8 @@ import url from "url";
 
 var defaultOptions = {
   targetSelector: '.js-current-nav', // 実行するセレクタ
+  childrenClass: "js-current-children",
   activeClass: "is-current", // 付与するクラス
-  // include_children: true
 }
 
 export default class CurrentNav {
@@ -49,10 +49,16 @@ export default class CurrentNav {
   run() {
     this.reset();
     for (var i = this.target.length - 1; i >= 0; i--) {
-      var href = $(this.target[i]).attr('href');
-      var href = this.isHttp(href);
+      var $element = $(this.target[i]);
+      var href = $element.attr('href');
+      href = this.isHttp(href);
       href = this.isIndexPage(href);
-      if (this.isMatch(href)) {
+
+      if ($element.hasClass(defaultOptions.childrenClass) && this.currentPathname.includes(href)) {
+        $(this.target[i]).addClass(this.activeClass);
+        // 1個だけにする場合はbreakを有効にする
+        // break;
+      } else if (this.isMatch(href)) {
         $(this.target[i]).addClass(this.activeClass);
       }
     }

--- a/app/assets/js/app/current-nav.js
+++ b/app/assets/js/app/current-nav.js
@@ -2,7 +2,6 @@ import url from "url";
 
 var defaultOptions = {
   targetSelector: '.js-current-nav', // 実行するセレクタ
-  childrenClass: "js-current-children",
   childrenData: "data-parent-nav",
   activeClass: "is-current", // 付与するクラス
 }

--- a/app/assets/scss/object/components/_menu-list.scss
+++ b/app/assets/scss/object/components/_menu-list.scss
@@ -13,8 +13,9 @@ category: Navigation
     padding: rem-calc(12) rem-calc(16);
   }
 
-  ul {
-    li {
+  > ul {
+
+    > li {
       border-bottom: 1px solid $border-base-color;
 
       a {
@@ -51,7 +52,7 @@ category: Navigation
         }
 
         //*hover
-        &:hover {
+        &:hover, &.is-current {
           opacity: 1;
           color: $color-primary;
 
@@ -127,13 +128,13 @@ category: Navigation
       }
 
       a {
-        font-weight: 400 !important;
-        font-size: rem-calc(14) !important;
-        padding: rem-calc(20) rem-calc(16) rem-calc(20) rem-calc(20) !important;
+        font-weight: 400;
+        font-size: rem-calc(14);
+        padding: rem-calc(20) rem-calc(16) rem-calc(20) rem-calc(20);
 
         &::before {
-          left: 0 !important;
-          top: rem-calc(20) !important;
+          left: 0;
+          top: rem-calc(20);
         }
 
         &::after {

--- a/app/inc/layout/_aside.pug
+++ b/app/inc/layout/_aside.pug
@@ -3,33 +3,33 @@ mixin l-aside(data)
     +c.menu-list
       +e.head ページ_2カラム
       ul
-          li: +a("#") カテゴリ
-          li: +a("#") カテゴリ
-          li: +a("#") カテゴリ
-          li: +a("#") カテゴリ
+        li: +a("/archive-twocolumns/").js-current-nav すべて
+        li: +a("/archive-twocolumns/category/").js-current-nav カテゴリ
+        li: +a("/archive-twocolumns/").js-current-nav(data-parent-nav="true") 子階層滞在時もis-current
+        li: +a("#").js-current-nav カテゴリ
   else
     +c.menu-list
       +e.head ページ_2カラム
       +e.banners.js-accordion
-          +a("#").c-menu-list__block(data-accordion-title="accordion-title") コンテンツタイトル
-          ul.c-menu-list__submenu(data-accordion-content="accordion-text")
-              li: +a("#") カテゴリ
-              li: +a("#") カテゴリ
-              li: +a("#") カテゴリ
+        +a("#").c-menu-list__block(data-accordion-title="accordion-title") コンテンツタイトル
+        ul.c-menu-list__submenu(data-accordion-content="accordion-text")
+          li: +a("#") カテゴリ
+          li: +a("#") カテゴリ
+          li: +a("#") カテゴリ
       +e.banners.js-accordion
-          +a("#").c-menu-list__block(data-accordion-title="accordion-title") コンテンツタイトル
-          ul.c-menu-list__submenu(data-accordion-content="accordion-text")
-              li: +a("#") カテゴリ
-              li: +a("#") カテゴリ
-              li: +a("#") カテゴリ
+        +a("#").c-menu-list__block(data-accordion-title="accordion-title") コンテンツタイトル
+        ul.c-menu-list__submenu(data-accordion-content="accordion-text")
+          li: +a("#") カテゴリ
+          li: +a("#") カテゴリ
+          li: +a("#") カテゴリ
       +e.banners.js-accordion
-          +a("#").c-menu-list__block(data-accordion-title="accordion-title") コンテンツタイトル
-          ul.c-menu-list__submenu(data-accordion-content="accordion-text")
-              li: +a("#") カテゴリ
-              li: +a("#") カテゴリ
-              li: +a("#") カテゴリ
+        +a("#").c-menu-list__block(data-accordion-title="accordion-title") コンテンツタイトル
+        ul.c-menu-list__submenu(data-accordion-content="accordion-text")
+          li: +a("#") カテゴリ
+          li: +a("#") カテゴリ
+          li: +a("#") カテゴリ
       +e.banners.js-accordion
-          +a("#").c-menu-list__block(data-accordion-title="accordion-title") コンテンツタイトル
-          ul.c-menu-list__submenu(data-accordion-content="accordion-text")
-              li: +a("#") カテゴリ
-              li: +a("#") カテゴリ
+        +a("#").c-menu-list__block(data-accordion-title="accordion-title") コンテンツタイトル
+        ul.c-menu-list__submenu(data-accordion-content="accordion-text")
+          li: +a("#") カテゴリ
+          li: +a("#") カテゴリ


### PR DESCRIPTION
# What
js-current-navにjs-current-childrenが付いていたら第3階層でもis-currentを付与したいので、current-nav.jsを改良しました。

# Why
urlが完全一致しないとis-currentが付与されないので、小階層までチェックし、小階層に滞在してもis-currentを付与したいため。

# 参考ページ
https://yokogawa-bridge.grgr.blue/company/history/1950/