### PR TITLE
[update] server.js : npm start 時のpugビルドの挙動を変更

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,6 @@
     "build:webpack": "webpack --config webpack.config.babel.js --mode production",
     "develop:webpack": "webpack --config webpack.config.babel.js --mode development  --watch --watch-options-stdin --progress",
     "build:pug": "pug -O build/pug.js app --out dist -s",
-    "develop:pug": "pug -O build/pug.js app --out dist -w -s",
     "build:wp": "node build/wp.js",
     "build:autoprefixer": "postcss -o dist/assets/css/style.css dist/assets/css/style.css",
     "make-admin-style": "postcss -o dist/assets/css/admin-style.css dist/assets/css/style.css",

--- a/server.js
+++ b/server.js
@@ -52,7 +52,7 @@ function pugMiddleWare(req, res, next) {
   var content = pug.renderFile(pugPath, pugConfig);
   res.setHeader('Content-Type', 'text/html');
   // コンパイル結果をレスポンスに渡す
-  res.end(new Buffer(content));
+  res.end(new Buffer.from(content));
   // next();
 }
 
@@ -79,26 +79,31 @@ var config = {
 /**
  * 監視タスク
  */
-bs.watch(["dist/*.html","dist/**/*.html"]).on("change", function (event) {
+
+bs.watch(["app/*.pug", "app/**/*.pug"]).on("change", function (event) {
   bs.reload("*.html")
-  notifier.notify({
-    title: 'Grow Template',
-    message: 'Compiled the HTML'
-  });
 });
+
+// bs.watch(["dist/*.html","dist/**/*.html"]).on("change", function (event) {
+//   bs.reload("*.html")
+//   notifier.notify({
+//     title: 'Grow Template',
+//     message: 'Compiled the HTML'
+//   });
+// });
 bs.watch("dist/assets/**/*.css").on("change", function (event) {
   bs.reload("*.css")
-  notifier.notify({
-    title: 'Grow Template',
-    message: 'Compiled the CSS'
-  });
+  // notifier.notify({
+  //   title: 'Grow Template',
+  //   message: 'Compiled the CSS'
+  // });
 });
 bs.watch("dist/assets/**/*.js").on("change", function () {
   bs.reload("*.js")
-  notifier.notify({
-    title: 'GrowTemplate',
-    message: 'Compiled the JavaScript'
-  });
+  // notifier.notify({
+  //   title: 'GrowTemplate',
+  //   message: 'Compiled the JavaScript'
+  // });
 });
 
 bs.init(config)


### PR DESCRIPTION
▼関連改善事項
https://www.notion.so/growgroup/develop-pug-pug-O-build-pug-js-app-out-dist-w-s-browsersync-pug-ef259e01232946a2838240efaaa7410f

## 解決したかった問題
- server.jsでpugを全ビルドしないように設定しているにもかかわらず、
 npm scriptsでpugを全ビルドしているためpugの処理が重い？
- npm startをした時点で生成されるページ数の数だけbrowsersyncがブラウザをリロードさせる？のか
 リロード挙動がおかしい場合がある

## やったこと
### package.json
以下の処理を削除
```
    "develop:pug": "pug -O build/pug.js app --out dist -w -s",
```

### server.js
- pugファイルの変更時にbrowsersyncのリロードが走るようにする
- node-notifierが走る必要がない気がするので切る

## 結果
- npm start中はdist内にhtmlファイルを生成しなくなりました（browsersyncのレスポンスでのみpugをコンパイルします）
- pug変更時のブラウザリロード動作が軽快になりました
- build時の挙動に変更はありません

## 注意点
- mixin等にミスがあるとき、今までは常にターミナルにエラーが出ましたが、
 mixinを使用するページを開いているときのみエラーが出るようになりました（たぶん）