### PR TITLE
[add] Utils.responsiveMatch()

### DIFF
--- a/app/assets/js/app/accordion.js
+++ b/app/assets/js/app/accordion.js
@@ -7,7 +7,7 @@
  * ====================================================================
  *
  * # example:
- * <div class="c-panel js-accordion" accordion-responsive="950">
+ * <div class="c-panel js-accordion" data-accordion-responsive="950">
  *     <div class="c-panel__title" data-accordion-title>
  *         Title
  *     </div>
@@ -17,6 +17,10 @@
  * </div>
  *
  */
+
+import Utils from "./utils";
+
+const utils = new Utils();
 
 
 var defaultOptions = {
@@ -59,31 +63,54 @@ export default class Accordion {
    * 実行する
    */
   run() {
-    let win = $(window).innerWidth();
-
     for (var i = 0; i < this.targetAll.length; i++) {
-      var target = $(this.targetAll[i]);
+      let target = $(this.targetAll[i]);
 
       target.responsive = target.data("accordion-responsive");
-      if (win >= target.responsive) {
-        return false;
-      }
-
-      target.title = target.find('*[' + this.options.titleTargetAttr + ']').eq(0);
-      target.content = target.find('*[' + this.options.contentTargetAttr + ']').eq(0);
-      this.accordion(target);
-      if (this.options.defaultOpen) {
-        target.content.slideDown();
+      // レスポンシブの設定がある場合
+      if (target.responsive !== undefined) {
+        // Media Query にマッチするか確認
+        utils.responsiveMatch(
+          () => {
+            this.elementInit(target);
+          },
+          () => {
+            this.elementDestroy(target);
+          },
+          "max-width: " + target.responsive + "px"
+        );
+      } else {
+        // レスポンシブの設定がない場合、 そのまま実行
+        this.elementInit(target);
       }
     }
   }
+
+  // ターゲットの初期化
+  elementInit(target) {
+    target.title = target.find('*[' + this.options.titleTargetAttr + ']').eq(0);
+    target.content = target.find('*[' + this.options.contentTargetAttr + ']').eq(0);
+    this.accordion(target);
+    if (this.options.defaultOpen) {
+      target.content.slideDown();
+    }
+  }
+
+  // ターゲットの破棄
+  elementDestroy(target) {
+    if (target.title === undefined) {
+      return false;
+    }
+    target.title.off('click');
+    target.title.off('mouseover');
+  }
+
 
   /**
    * アコーディオンの動作
    * @param el
    */
   accordion(el) {
-
 
     $(el.title).on('click', (e) => {
       e.preventDefault();

--- a/app/assets/js/app/utils.js
+++ b/app/assets/js/app/utils.js
@@ -212,6 +212,32 @@ export default class Utils {
         }
         return requestAnimFrame;
     }
+
+  /**
+   * matchMediaを使ったレスポンシブ対応を便利にする
+   *
+   * @param {Function} onMatch - The function to execute when the media query matches.
+   * @param {Function} onUnMatch - The function to execute when the media query does not match.
+   * @param {string} [media='max-width: 46.8125em'] - The media query to evaluate.
+   */
+  responsiveMatch = (onMatch, onUnMatch, media = 'max-width: 46.8125em') => {
+    //第3引数に入れたメディアクエリもしくは750pxのところでMediaQueryList作成
+    const mql = window.matchMedia('(' + media + ')');
+
+    //MediaQueryListにマッチした時の動作、しなかった時の動作を引数から受け取る
+    function mediaChange(e) {
+      if (e.matches) {
+        onMatch();
+      } else {
+        onUnMatch();
+      }
+    }
+
+    //MediaQueryListのChangeイベント時に発火させる
+    mql.addEventListener("change", mediaChange);
+    //ページ読み込み時にも発火させる
+    mediaChange(mql);
+  }
 }
 
 


### PR DESCRIPTION
▼関連改善事項
https://www.notion.so/growgroup/JavaScript-utils-b280955b3c0c4b2d92a07d496861eeaa

# やったこと
- window.matchMediaを簡単にサイトのあちこちで使えるようにするための便利関数追加。
- 追加関数を利用したaccordion.jsの調整

## 便利関数追加について
window.matchMedia / mediaQueryList.onChangeはサイト内の随所で使うには書くことが多いため
指定を多少シンプルにする関数を追加しました。

```
import Utils from "./utils";

const utils = new Utils();

utils.responsiveMatch(
  () => {
    //match時の処理
  },
  () => {
    //unmatch時の処理
  },
  //メディアクエリ（"max-width: 949px"など。省略可）
);

```

MediaQueryList: change イベント: https://developer.mozilla.org/ja/docs/Web/API/MediaQueryList/change_event
参考: https://deep-space.blue/web/3186
動作サンプル: https://codepen.io/miral_kashiwagi/pen/zYXEgVN


## 追加関数を利用したaccordion.jsの調整について
accordion.jsのdata-accordion-responsiveは
ウィンドウリサイズ後再読み込みしたときのみ効果がありましたが、
再読み込み無しで効果が出るようにしました。

▼動作
https://capture.dropbox.com/F4iW1tC2r0kc0YhY

