### PR TITLE
[add] +picture(pug) / @include img-option()(scss)

### DIFF
--- a/app/assets/js/app/swiper.js
+++ b/app/assets/js/app/swiper.js
@@ -48,7 +48,7 @@ export default class SwiperSlider {
     //->スライダー
     this.targetAll.imagesLoaded(function () {
 
-      if ($('.c-main-visual.swiper').length <= 0) {
+      if ($('.c-main-visual .swiper').length <= 0) {
         return;
       }
 
@@ -56,7 +56,7 @@ export default class SwiperSlider {
       let pagination = document.querySelector('.c-main-visual__pagination');
       let delayTime = 3500;
 
-      const mainVisualSwiper = new Swiper(".c-main-visual.swiper", {
+      const mainVisualSwiper = new Swiper(".c-main-visual .swiper", {
         loop: true,
         effect: 'fade',
         autoplay: {

--- a/app/assets/scss/foundation/_mixin.scss
+++ b/app/assets/scss/foundation/_mixin.scss
@@ -415,6 +415,13 @@
   @include bg-option();
 }
 
+@mixin img-option($object-fit:cover) {
+  width: 100%;
+  height: 100%;
+  max-width: initial;
+  object-fit: $object-fit;
+}
+
 @mixin card-block(){
   display: block;
   text-decoration: none;

--- a/app/assets/scss/layout/_page-header.scss
+++ b/app/assets/scss/layout/_page-header.scss
@@ -13,27 +13,22 @@ category: Layout
 @use "sass:math";
 
 .l-page-header {
-  width: 100%;
   position: relative;
-  overflow: hidden;
+
 
   &__image {
     position: absolute;
-    top: 0;
-    right: 0;
-    bottom: 0;
-    left: 0;
-    margin:auto;
+    inset: 0;
+
+    img {
+      @include img-option();
+    }
 
     &::after {
       @include img-curtain($color-black,0.2);
     }
   }
-  &__bgimg {
-    @include bg-option();
-    width: 100%;
-    height: 100%;
-  }
+
   &__inner {
     position: relative;
     text-align: center;
@@ -43,6 +38,8 @@ category: Layout
       padding: rem-calc(46) rem-calc(8);
     }
   }
+
+
   &__title {
     @include webfont();
     font-size: rem-calc(42);

--- a/app/assets/scss/object/components/_card-download.scss
+++ b/app/assets/scss/object/components/_card-download.scss
@@ -51,7 +51,7 @@
     &:hover {
       opacity: 1;
 
-      .bg-img {
+      img {
         transform: scale(1.1);
       }
 
@@ -65,30 +65,20 @@
   &__image {
     overflow: hidden;
     position: relative;
-    padding-top: calc(311/504*100%);
     background: $color-background;
+    aspect-ratio: 504/311;
 
-    .bg-img {
-      position: absolute;
-      top: 0;
-      right: 0;
-      bottom: 0;
-      left: 0;
-      margin:auto;
-      width: 100%;
-      height: 100%;
-      background-repeat: no-repeat;
-      background-position: center center;
-      background-size: contain;
+    img {
+      @include img-option();
       @include transition();
     }
 
     .is-no {
-      position: absolute;
-      top: 50%;
-      left: 50%;
-      transform: translateX(-50%) translateY(-50%);
-      @include font-format(17,0.05,25,400);
+      width: 100%;
+      height: 100%;
+      display: grid;
+      place-content: center;
+      font-size: rem-calc(17);
       color: rgba($font-base-color,0.5);
 
       @include breakpoint(small only) {

--- a/app/assets/scss/object/components/_card-post.scss
+++ b/app/assets/scss/object/components/_card-post.scss
@@ -27,8 +27,8 @@ category: News
     display: block;
 
     img {
-      width: 100%;
-      height: auto;
+      @include img-option(cover);
+      aspect-ratio: 16/9;
     }
   }
 

--- a/app/assets/scss/object/components/_forms-document-detail.scss
+++ b/app/assets/scss/object/components/_forms-document-detail.scss
@@ -13,37 +13,28 @@
   }
 
   &__image {
+    display: block;
     overflow: hidden;
     position: relative;
-    padding-top: calc(141/251*100%);
     background: $color-background;
+    aspect-ratio: 282/158;
+    padding: rem-calc(16);
 
     &.swiper-slide {
       cursor: pointer;
     }
 
-    .bg-img {
-      position: absolute;
-      top: 0;
-      right: 0;
-      bottom: 0;
-      left: 0;
-      margin:auto;
-      width: 100%;
-      height: 100%;
-      max-height: calc(100% - 30px);
-      background-repeat: no-repeat;
-      background-position: center center;
-      background-size: contain;
+    img {
+      @include img-option(contain);
       @include transition();
     }
 
     .is-no {
-      position: absolute;
-      top: 50%;
-      left: 50%;
-      transform: translateX(-50%) translateY(-50%);
-      @include font-format(17,0.05,25,400);
+      width: 100%;
+      height: 100%;
+      display: grid;
+      place-content: center;
+      font-size: rem-calc(17);
       color: rgba($font-base-color,0.5);
 
       @include breakpoint(small only) {

--- a/app/assets/scss/object/components/_gallery-card.scss
+++ b/app/assets/scss/object/components/_gallery-card.scss
@@ -11,16 +11,9 @@
   }
 
   &__image {
-    position: relative;
-
-    &:before {
-      content: "";
-      display: block;
-      padding-top: calc(320/500*100%);
-    }
-
-    .bg-img {
-      @include bg-img();
+    img {
+      @include img-option();
+      aspect-ratio: 500/320;
     }
   }
 

--- a/app/assets/scss/object/components/_gallery-logo.scss
+++ b/app/assets/scss/object/components/_gallery-logo.scss
@@ -20,15 +20,9 @@
       max-width: rem-calc(120);
     }
 
-    &:before {
-      content: "";
-      display: block;
-      padding-top: calc(64/160*100%);
-    }
-
-    .bg-img {
-      @include bg-img();
-      background-size: contain;
+    img {
+      @include img-option(contain);
+      aspect-ratio: 160/64;
     }
   }
 

--- a/app/assets/scss/object/components/_gallery-slider.scss
+++ b/app/assets/scss/object/components/_gallery-slider.scss
@@ -150,19 +150,6 @@
     &-image {
       position: relative;
     }
-
-    &-bgimg {
-      width: 100%;
-      background-size: cover;
-      background-position: center center;
-      background-repeat: no-repeat;
-
-      &::before {
-        content: '';
-        display: block;
-        padding-top: math.div(500,748) * 100%;
-      }
-    }
   }
 
   //nav画像
@@ -202,22 +189,13 @@
       &:hover {
         opacity: 1;
       }
-    }
 
-    &-bgimg {
-      width: 100%;
-      @include bg-option();
-
-      &::before {
-        content: '';
-        display: block;
-        padding-top: math.div(92,138)*100%;
-
-        @include breakpoint(small only) {
-          padding-top: math.div(80,138)*100%;
-        }
+      img {
+        @include img-option();
+        aspect-ratio: 138/92;
       }
     }
+
 
     .slick-slide {
       margin: 0 6px;

--- a/app/assets/scss/object/components/_main-visual.scss
+++ b/app/assets/scss/object/components/_main-visual.scss
@@ -12,20 +12,25 @@ category: Components
   &__image {
     position: relative;
     width: 100%;
-    height: calc(100vh - 75px) !important;
+    height: calc(100vh - 75px);
+    max-height: rem-calc(1080);
 
     @include breakpoint(medium down) {
       height: 50vw;
       min-height: 280px;
     }
 
-    .bg-img {
-      @include bg-img();
+    img {
+      position: absolute;
+      inset: 0;
+      width: 100%;
+      height: 100%;
+      object-fit: cover;
+    }
 
-      &:after {
-        @include img-curtain($font-base-color,0.15);
-        mix-blend-mode: multiply;
-      }
+    &::after {
+      @include img-curtain($font-base-color, 0.15);
+      mix-blend-mode: multiply;
     }
   }
 
@@ -97,10 +102,6 @@ category: Components
   .swiper-wrapper {
 
     .swiper-slide-active {
-
-      .bg-img {
-        //animation: zoomOut 6s forwards;
-      }
     }
   }
 

--- a/app/download/index.pug
+++ b/app/download/index.pug
@@ -31,7 +31,7 @@ block body
           +loop(3)
             +ae("/download/page/").block
               +e.image
-                +bgimg("img-card-01.jpg").bg-img
+                +img("img-card-01.jpg")
                 +e.label.c-label テキスト
               +e.content
                 +e.title.c-heading.is-xxs テキストテキスト
@@ -47,7 +47,7 @@ block body
               +e.content
                 +e.title.c-heading.is-xxxs テキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキスト
                 +e.button: .c-button テキストテキスト
-                  
+
 block before_footer
   +l_offer
 

--- a/app/download/page/index.pug
+++ b/app/download/page/index.pug
@@ -28,12 +28,13 @@ block body
             +e.images
               +e.image: .is-no NO IMAGE
               +loop(5)
-                +e.image.js-modal-image(data-modaal-content-source="/assets/images/img-card-01.jpg"): +bgimg("img-card-01.jpg").bg-img
+                +ae("/assets/images/img-card-01.jpg").image.js-modal-image
+                  +img("img-card-01.jpg")
             +e.slider.swiper
               .swiper-wrapper
                 +e.image.swiper-slide: .is-no NO IMAGE
                 +loop(3)
-                  +e.image.swiper-slide: +bgimg("img-card-01.jpg").bg-img
+                  +e.image.swiper-slide: +img("img-card-01.jpg")
               .swiper-nav
                 .swiper-button-prev
                 .swiper-button-next
@@ -86,6 +87,6 @@ block body
                 input(type="checkbox", name="「個人情報保護の取り扱いに関するご確認」を確認する", value="確認しました")
                 +a("/privacy-policy/")(target="_blank") 個人情報保護方針
                 | の内容に同意する
-              
+
             +e.submit
               button.c-button 資料ダウンロード

--- a/app/format/components/_other.pug
+++ b/app/format/components/_other.pug
@@ -30,7 +30,7 @@ div.u-mbs.is-bottom
       +e.slider.swiper
         +e.images.swiper-wrapper
           +loop(10)
-            +e.image.swiper-slide: +bgimg("logo.png").bg-img
+            +e.image.swiper-slide: +img("logo.png")
 
 div.u-mbs.is-bottom
   +c.gallery-card.swiper
@@ -38,13 +38,13 @@ div.u-mbs.is-bottom
       +h2.head.c-heading.is-md.is-center.is-mg-level-2 会社紹介ギャラリー
     +e.cards.swiper-wrapper
       +e.card.swiper-slide
-        +e.image: +bgimg("img-sample.jpg").bg-img
+        +e.image: +img("img-sample.jpg","",803, 451)
         +e.text テキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキスト
       +e.card.swiper-slide
-        +e.image: +bgimg("img-sample.jpg").bg-img
+        +e.image: +img("img-sample.jpg","",803, 451)
         +e.text テキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキスト
       +e.card.swiper-slide
-        +e.image: +bgimg("img-sample.jpg").bg-img
+        +e.image: +img("img-sample.jpg","",803, 451)
         +e.text テキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキスト
     .l-container
       .swiper-content

--- a/app/inc/layout/_footer.pug
+++ b/app/inc/layout/_footer.pug
@@ -43,6 +43,6 @@ footer(class=className)
           li: +a("/voice/") お客様の声
           li: +a("/contact/") お問い合わせ
     .l-footer__content
-      +a("/").l-footer__logo: +img("logo-white.png","ロゴ")
+      +a("/").l-footer__logo: +img("logo-white.png","ロゴ",350,96)
       address.l-footer__address 〒464-0850 <br>愛知県名古屋市千種区今池3丁目12-20 KAビル6F<br>TEL：052-753-6413 / FAX：052-753-6414
       small.l-footer__copyright ©<span class="js-current-year"></span> サンプル Co.Ltd.

--- a/app/inc/layout/_header.pug
+++ b/app/inc/layout/_header.pug
@@ -13,9 +13,9 @@
 header(class=className)
   .l-header__content
     if current.id == 'home'
-      h1.l-header__logo: +a("/"): +img("logo.png","株式会社 サンプル")
+      h1.l-header__logo: +a("/"): +img("logo.png","株式会社 サンプル",175,40)
     else
-      .l-header__logo: +a("/"): +img("logo.png","株式会社 サンプル")
+      .l-header__logo: +a("/"): +img("logo.png","株式会社 サンプル",175,40)
     nav.l-header__nav
       ul
         li: +a("/page/") 1COLUMN

--- a/app/inc/mixins/_main-visual.pug
+++ b/app/inc/mixins/_main-visual.pug
@@ -4,14 +4,14 @@ mixin c_main-visual
     +e.wrapper.swiper
       +e.slider.swiper-wrapper
         +loop(3)
-          +e.image.swiper-slide: +bgimg("img-main-visual-01.jpg").bg-img
-          +e.image.swiper-slide: +bgimg("img-sample.jpg").bg-img
+          +e.image.swiper-slide
+            +picture("img-main-visual-01.jpg", "img-sample.jpg","", 1600, 620, 803, 451)
       +e.animation
         +e.bar: span
         +e.pagination
       +e.inner
         .l-container
-          +e.title: +img("img-main-visual-text.png","キャッチコピーが入ります")
+          +e.title: +img("img-main-visual-text.png","キャッチコピーが入ります",1048,118)
           +e.text テキストテキストテキスト。テキストテキストテキスト。<br>テキストテキストテキスト。
 
 

--- a/app/inc/mixins/_misc.pug
+++ b/app/inc/mixins/_misc.pug
@@ -22,7 +22,7 @@ mixin picture(pc,sp,alt,width,height,widthSp,heightSp,media,fetchpriority)
     }
   picture&attributes(attributes)
     source(srcset=config.rootpath + "/assets/images/" + sp + "" media=media width!=widthSp, height!=heightSp)
-    img(src=config.rootpath + "/assets/images/" + pc, alt=alt width!=width, height!=height fetchpriority=fetchpriority)
+    img(src=config.rootpath + "/assets/images/" + pc, alt=alt width!=width, height!=height fetchpriority!=fetchpriority)
 
 //- video タグ
 mixin video(file)

--- a/app/inc/mixins/_misc.pug
+++ b/app/inc/mixins/_misc.pug
@@ -6,6 +6,24 @@ mixin img(file,alt,width,height)
     }
   img(src=config.rootpath + "/assets/images/" + file, alt!=alt, width!=width, height!=height)&attributes(attributes)
 
+//- picture タグ
+//-+picture("img-sample-pc.jpg", "img-sample-sp.jpg","text", 1920, 1080, 768, 768)
+//-PC/SPでaspect比共通ならSP用のwidthとheightは不要
+mixin picture(pc,sp,alt,width,height,widthSp,heightSp,media,fetchpriority)
+  -
+    if (typeof alt === "undefined") {
+      var alt = ""
+    }
+  -
+    if (typeof media === "undefined" || media === "") {
+      var media = '(max-width:46.8125em)'
+    } else if (media === "medium") {
+      var media = '(max-width:59.3125em)'
+    }
+  picture&attributes(attributes)
+    source(srcset=config.rootpath + "/assets/images/" + sp + "" media=media width!=widthSp, height!=heightSp)
+    img(src=config.rootpath + "/assets/images/" + pc, alt=alt width!=width, height!=height fetchpriority=fetchpriority)
+
 //- video タグ
 mixin video(file)
   video(src=config.rootpath + "/assets/files/" + file)&attributes(attributes)

--- a/app/inc/mixins/_page-header.pug
+++ b/app/inc/mixins/_page-header.pug
@@ -1,7 +1,8 @@
 //- ページヘッダー
 mixin l_page_header(data)
   .l-page-header
-    .l-page-header__image: +bgimg(data.image).l-page-header__bgimg
+    .l-page-header__image
+      +img(data.image)
     .l-page-header__inner
       .l-page-header__subtitle !{data.subtitle}
       h1.l-page-header__title !{data.title}

--- a/app/index.pug
+++ b/app/index.pug
@@ -24,19 +24,19 @@ block body
         .row.slide
           .large-4.small-12
             +e.block
-              +e.image: +img("img-card-01.jpg")
+              +e.image: +img("img-card-01.jpg","",712,420)
               +e.content
                 h3.c-card__title コンセプトタイトル
                 p.c-card__text ここにテキストが入ります。ここにテキストが入ります。ここにテキストが入ります。ここにテキストが入ります。ここにテキストが入ります。
           .large-4.small-12
             +e.block
-              +e.image: +img("img-card-01.jpg")
+              +e.image: +img("img-card-01.jpg","",712,420)
               +e.content
                 h3.c-card__title コンセプトタイトル
                 p.c-card__text ここにテキストが入ります。ここにテキストが入ります。ここにテキストが入ります。ここにテキストが入ります。ここにテキストが入ります。
           .large-4.small-12
             +e.block
-              +e.image: +img("img-card-01.jpg")
+              +e.image: +img("img-card-01.jpg","",712,420)
               +e.content
                 h3.c-card__title コンセプトタイトル
                 p.c-card__text ここにテキストが入ります。ここにテキストが入ります。ここにテキストが入ります。ここにテキストが入ります。ここにテキストが入ります。
@@ -45,7 +45,7 @@ block body
       +heading-xlg("事業内容", "SERVICE").is-bottom
     +c.hero-block-square
       +e.block
-        +e.image: +img("img-hero-block-01.jpg")
+        +e.image: +img("img-hero-block-01.jpg","",700,400)
         .l-container
           +e.content
             +e.inner
@@ -53,7 +53,7 @@ block body
               p テキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキスト
               +e.button: +a("#").c-button.is-sm ボタンテキスト
       +e.block
-        +e.image: +img("img-hero-block-01.jpg")
+        +e.image: +img("img-hero-block-01.jpg","",700,400)
         .l-container
           +e.content
             +e.inner
@@ -61,7 +61,7 @@ block body
               p テキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキスト
               +e.button: +a("#").c-button.is-sm ボタンテキスト
       +e.block
-        +e.image: +img("img-hero-block-01.jpg")
+        +e.image: +img("img-hero-block-01.jpg","",700,400)
         .l-container
           +e.content
             +e.inner


### PR DESCRIPTION
▼関連改善事項
https://www.notion.so/growgroup/bg-img-bgimg-img-picture-d54a33af7afd435c9b98f6b90aea0aee

# やりたいこと
HTML上にstyle属性でbackground-imageを置く方法（`+bgimg`）をやめる。

## 理由
- すべての画像（写真とか）にbackground-imageを利用すると若干レンダリングパフォーマンスに悪影響があるため
（プリロードスキャナ等のレンダリングの仕組みの都合上）
- もともとbackground-size:cover を利用するためにbackground-image指定をしていたが、
object-fit:cover で対処できるようになり、background-image指定である必然性も無くなったため。
- WP側でビジュアルエディタ上で画像差し替えするにもimgタグの方が良い場合が多いため。

# やったこと
- picture タグ用のpug mixinの追加
- object-fit用のscss mixinの追加
- 既存のpug/scssから`+bgimg`関連の記述の除去

# 使い方

## scss：img-option()：ほとんどの`+bgimg()`を`+img()`に置き換えた上で利用

※引数にcontainを渡す事もできます
```
  &__image {
    img {
      @include img-option();
      aspect-ratio: 16/9;
    }
  }

```

```
c-hoge__image img {
  width: 100%;
  height: 100%;
  max-width: initial;
  object-fit: cover;
  aspect-ratio: 16/9;
}
```

## picture：PCとSPで画像を切り替えたいとき、特にファーストビュー画像で利用
※loading=lazy属性を付ける場合（ファーストビュー画像以外）では、display:noneでの切り替えも有効です。

### 最小限の書き方
```
+picture("img-main-visual-01.jpg", "img-main-visual-01-sp.jpg")
```

```
<picture>
    <source srcset="/assets/images/img-main-visual-01-sp.jpg" media="(max-width:46.8125em)">
    <img src="/assets/images/img-main-visual-01.jpg" alt="">
</picture>
```



### PCとSPで画像の縦横比が同じ時:レイアウトシフト対策
```
  +picture("img-main-visual-01.jpg", "img-main-visual-01-sp.jpg","", 1400, 600)
```
```
<picture>
    <source srcset="/assets/images/img-main-visual-01-sp.jpg" media="(max-width:46.8125em)">
    <img src="/assets/images/img-main-visual-01.jpg" alt="" width="1400" height="600">
</picture>
```

### PCとSPで画像の縦横比が変わるとき:レイアウトシフト対策
```
  +picture("img-main-visual-01.jpg", "img-main-visual-01-sp.jpg","", 1400, 600, 750, 1000)
```
```
<picture>
    <source srcset="/assets/images/img-main-visual-01-sp.jpg" media="(max-width:46.8125em)" width="750" height="1000">
    <img src="/assets/images/img-main-visual-01.jpg" alt="" width="1400" height="600">
</picture>
```

### 画像の切り替えタイミングを 950pxにしたいとき
※`"medium"` の部分は直接メディアクエリの指定値も書けます。例：`"(max-width:600px)"`
```
  +picture("img-main-visual-01.jpg", "img-main-visual-01-sp.jpg","", 1400, 600,"","","medium")
```



```
<picture>
    <source srcset="/assets/images/img-main-visual-01-sp.jpg" media="(max-width:59.3125em)" width="" height="">
    <img src="/assets/images/img-main-visual-01.jpg" alt="" width="1400" height="600">
</picture>
```


### imgタグにfetchpriorityを付けたいとき（使用時要動作検証）

```
  +picture("img-main-visual-01.jpg", "img-main-visual-01-sp.jpg","", 1400, 600,"","","","high")
```
```
<picture>
  <source srcset="/assets/images/img-main-visual-01-sp.jpg" media="(max-width:46.8125em)" width="" height="">
  <img src="/assets/images/img-main-visual-01.jpg" alt="" width="1400" height="600" fetchpriority="high">
</picture>
```
