### PR TITLE
[update] current-nav.js : urlの利用をやめる

### DIFF
--- a/app/assets/js/app/current-nav.js
+++ b/app/assets/js/app/current-nav.js
@@ -1,5 +1,3 @@
-import url from "url";
-
 var defaultOptions = {
   targetSelector: '.js-current-nav', // 実行するセレクタ
   childrenData: "data-parent-nav",
@@ -71,9 +69,9 @@ export default class CurrentNav {
   }
 
   isHttp(targetHref) {
-    var match = targetHref.match(/^http/g);
-    if (!$.isEmptyObject(match) && match[0] === "http") {
-      return url.parse(targetHref).pathname;
+    var match = targetHref.match(/^https?:\/\/[^\/]+(.*)/);
+    if (match) {
+      return match[1]; // フルURLからpathname部分を返す
     }
     return targetHref;
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,8 +25,7 @@
         "scroll-hint": "^1.2.5",
         "simple-parallax-js": "^5.6.2",
         "slick-carousel": "^1.8.1",
-        "swiper": "^8.4.7",
-        "url": "^0.11.0"
+        "swiper": "^8.4.7"
       },
       "devDependencies": {
         "@babel/cli": "^7.16.0",
@@ -8944,20 +8943,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/qs": {
-      "version": "6.11.2",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.11.2.tgz",
-      "integrity": "sha512-tDNIz22aBzCDxLtVH++VnTfzxlfeK5CbqohpSqpJgj1Wg/cQbStNAz3NuqCs5vV+pjBsK4x4pN9HlVh7rcYRiA==",
-      "dependencies": {
-        "side-channel": "^1.0.4"
-      },
-      "engines": {
-        "node": ">=0.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/queue-microtask": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
@@ -11060,20 +11045,6 @@
       "dependencies": {
         "punycode": "^2.1.0"
       }
-    },
-    "node_modules/url": {
-      "version": "0.11.3",
-      "resolved": "https://registry.npmjs.org/url/-/url-0.11.3.tgz",
-      "integrity": "sha512-6hxOLGfZASQK/cijlZnZJTq8OXAkt/3YGfQX45vvMYXpZoo8NdWZcY73K108Jf759lS1Bv/8wXnHDTSz17dSRw==",
-      "dependencies": {
-        "punycode": "^1.4.1",
-        "qs": "^6.11.2"
-      }
-    },
-    "node_modules/url/node_modules/punycode": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
-      "integrity": "sha512-jmYNElW7yvO7TV33CjSmvSiE2yco3bV2czu/OzDKdMNVZQWfxCblURLhf+47syQRBntjfLdd/H0egrzIG+oaFQ=="
     },
     "node_modules/util-deprecate": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -77,8 +77,7 @@
     "scroll-hint": "^1.2.5",
     "simple-parallax-js": "^5.6.2",
     "slick-carousel": "^1.8.1",
-    "swiper": "^8.4.7",
-    "url": "^0.11.0"
+    "swiper": "^8.4.7"
   },
   "skipInheritances": [
     "node_modules"


### PR DESCRIPTION
▼関連改善事項
https://www.notion.so/growgroup/current-nav-js-url-68e0f626216746019bf26c4565644086

# やったこと
current-nav.jsで、hrefに記載のurlがhttpではじまる場合にURLのパス部分だけを返すようにする処理について
urlパッケージの利用をやめて、JavaScriptでなんとかするように変更

# どんないいことがあるか
app.jsの最終ビルドサイズが45KBくらい小さくなる
![image](https://github.com/growgroup/gg-styleguide/assets/97862690/ad4b29a4-e145-4078-8f7c-8d80d67a9a35)

# 動作確認したこと
hrefに記載のURLがhttpやhttpsではじまる場合も、パス部分を正しく抽出しており
期待通りのタイミングでis-currentが付与される

![CleanShot 2024-04-22 at 11 16 16@2x](https://github.com/growgroup/gg-styleguide/assets/97862690/7be55c1f-9604-4ecc-baf8-aa75c33ba9d4)
![CleanShot 2024-04-22 at 11 17 15@2x](https://github.com/growgroup/gg-styleguide/assets/97862690/2906c54c-b7d3-496a-b5b4-e1b8f7b8f528)
