### PR TITLE
[update] normalize.scss : min-width 0 追加

### DIFF
--- a/app/assets/scss/foundation/_normalize.scss
+++ b/app/assets/scss/foundation/_normalize.scss
@@ -28,6 +28,7 @@ html {
   -moz-box-sizing: border-box;
   box-sizing: border-box;
   letter-spacing: var(--letter-spacing); //全要素へ基準のletter-spacingを当てる
+  min-width: 0; //flexboxのoverflow対策(from destyle.css)
 }
 
 /**


### PR DESCRIPTION
▼関連改善事項
https://www.notion.so/growgroup/normalize-scss-min-width-0-c057ed135d2c49de91758de2b596eb66

## やったこと
normalize.scssに対して全称セレクタで `min-width:0` の追加。

## 目的
display:flex（やgrid）関連で、min-width:0が付いていないと予想と違う動作になることがあるため

▼参考
https://github.com/nicolas-cusan/destyle.css/issues/23
https://zenn.dev/kagan/articles/css-chrome-aspect-ratio