### PR TITLE
[update] +a, +ae, +img, +picture, +video, +bgimg : 引数がhttpからはじまるかどうかの判定処理追加

### DIFF
--- a/app/inc/_settings.pug
+++ b/app/inc/_settings.pug
@@ -140,4 +140,32 @@
     return (word[0] === word[0].toUpperCase());
   }
 
+  setSrcValue = function (src, path) {//+img()用のsrc属性判定＆設定
+    if (src === undefined) {
+      return undefined;
+    } else if (src.startsWith('http')) {
+      return src;
+    } else {
+      return config.rootpath + path + src;
+    }
+  }
 
+  setHrefValue = function (href) {//+a()用のhref属性判定＆設定
+    if (href === undefined) {
+      return undefined;
+    } else if (href.startsWith('http')) {
+      return href;
+    } else {
+      return config.rootpath + href;
+    }
+  }
+
+  setTargetValue = function (href, autoTarget) {//+a()用のtarget属性判定＆設定
+    if (href === undefined) {
+      return undefined;
+    } else if (href.startsWith('http') || href.endsWith('.pdf') || autoTarget === 'blank') {
+      return "_blank";
+    } else {
+      return undefined;
+    }
+  }

--- a/app/inc/mixins/_anchor.pug
+++ b/app/inc/mixins/_anchor.pug
@@ -1,9 +1,29 @@
 //- アンカータグ
-mixin a(href)
-  a(href!= config.rootpath + href )&attributes(attributes)
+  +a("https://example.com")
+  →　-<a href="https://example.com" target="_blank"></a>
+  +a("/assets/files/sample.pdf")
+  →　<a href="/assets/files/sample.pdf" target="_blank"></a>
+  +a("/format/")
+  →　<a href="/format/"></a>
+  +a("https://example.com",false)
+  →　<a href="https://example.com"></a>
+  +a("/format/",'blank') または +a("/format/")(target="_blank")
+  →　<a href="/format/" target="_blank"></a>
+mixin a(href,autoTarget)
+  -
+    if (autoTarget === undefined) {//autoTargetが未定義の場合はtrueとする
+      autoTarget = true;
+    }
+    href = setHrefValue(href);//hrefの値に応じてconfig.rootpathを付与する
+    if (autoTarget) {//autoTargetがtrueの場合はtarget属性を設定する
+      target = setTargetValue(href, autoTarget);
+    }
+  a(href!= href target!=target)&attributes(attributes)
     block
 
 //- external link
+//- DEPRECATED: Use `a(href)`
 mixin a-ex(href)
+  - href = setHrefValue(href);
   a(href!= href target="_blank")&attributes(attributes)
     block

--- a/app/inc/mixins/_cssrules.pug
+++ b/app/inc/mixins/_cssrules.pug
@@ -189,16 +189,26 @@ mixin li
   li(class=className)&attributes(attributes)
     block
 
-mixin ae(href)
+mixin ae(href,autoTarget)
+  -
+    if (autoTarget === undefined) {//autoTargetが未定義の場合はtrueとする
+      autoTarget = true;
+    }
+    href = setHrefValue(href);//hrefの値に応じてconfig.rootpathを付与する
+    if (autoTarget) {//autoTargetがtrueの場合はtarget属性を設定する
+      target = setTargetValue(href, autoTarget);
+    }
   -
     className = utils.inheritClassName(attributes)
-  a(href!= config.rootpath + href, class = className)&attributes(attributes)
+  a(href!= href, class = className target!=target)&attributes(attributes)
     block
 
+//- DEPRECATED: Use `ae(href)`
 mixin aex(href)
+  - href = setHrefValue(href);
   -
     className = utils.inheritClassName(attributes)
-  a(href!= config.rootpath + href, class = className, target="_blank")&attributes(attributes)
+  a(href!= href, class = className, target="_blank")&attributes(attributes)
     block
 
 //- 見出しタグ

--- a/app/inc/mixins/_misc.pug
+++ b/app/inc/mixins/_misc.pug
@@ -1,15 +1,20 @@
 //- img タグ
 mixin img(file,alt,width,height)
   -
+    src = setSrcValue(file, "/assets/images/")
+  -
     if ( typeof alt === "undefined" ){
     var alt = ""
     }
-  img(src=config.rootpath + "/assets/images/" + file, alt!=alt, width!=width, height!=height)&attributes(attributes)
+  img(src=src, alt!=alt, width!=width, height!=height)&attributes(attributes)
 
 //- picture タグ
 //-+picture("img-sample-pc.jpg", "img-sample-sp.jpg","text", 1920, 1080, 768, 768)
 //-PC/SPでaspect比共通ならSP用のwidthとheightは不要
 mixin picture(pc,sp,alt,width,height,widthSp,heightSp,media,fetchpriority)
+  -
+    pc = setSrcValue(pc, "/assets/images/")
+    sp = setSrcValue(sp, "/assets/images/")
   -
     if (typeof alt === "undefined") {
       var alt = ""
@@ -21,16 +26,20 @@ mixin picture(pc,sp,alt,width,height,widthSp,heightSp,media,fetchpriority)
       var media = '(max-width:59.3125em)'
     }
   picture&attributes(attributes)
-    source(srcset=config.rootpath + "/assets/images/" + sp + "" media=media width!=widthSp, height!=heightSp)
-    img(src=config.rootpath + "/assets/images/" + pc, alt=alt width!=width, height!=height fetchpriority!=fetchpriority)
+    source(srcset=sp + "" media=media width!=widthSp, height!=heightSp)
+    img(src=pc, alt=alt width!=width, height!=height fetchpriority!=fetchpriority)
 
 //- video タグ
 mixin video(file)
-  video(src=config.rootpath + "/assets/files/" + file)&attributes(attributes)
+  -
+    file = setSrcValue(file, "/assets/files/")
+  video(src=file)&attributes(attributes)
 
 //- 背景画像
 mixin bgimg(file)
-  div(style="background-image: url(" + config.rootpath + "/assets/images/" + file + ")")&attributes(attributes)
+  -
+    file = setSrcValue(file, "/assets/images/")
+  div(style="background-image: url(" + file + ")")&attributes(attributes)
     block
 
 //- ループ


### PR DESCRIPTION
関連プルリク https://github.com/growgroup/gg-styleguide/pull/122

▼関連改善事項
https://www.notion.so/growgroup/aex-a-ex-https-config-rootpath-6bef52e832fe45a2a9275604a6764c85?pvs=25
https://www.notion.so/growgroup/bgimg-scss-ee170bdf87e041399977837bbd3ab18e
https://www.notion.so/growgroup/pug-a-mixin-4-64edcb32b5294f0b88958799e6d1fda2

## やったこと
- +aや+img等の引数に、httpではじまるURLが渡されたときは config.rootpath を付けない
- +aや+aeでhttpではじまるURLや、.pdfで終わるURLが渡されたときは target="_blank"自動付与
※この改善で **+a-exと+aexは不要に**なり、基本的に +a と +ae（+cの中で利用）だけで良くなる
「実際どうなる」の項目を参照。

### +aや+img等の引数に、httpではじまるURLが渡されたときは config.rootpath を付けない

### 該当処理
```
  setSrcValue = function (src, path) {//+img()用のsrc属性判定＆設定
    if (src === undefined) {
      return undefined;
    } else if (src.startsWith('http')) {
      return src;
    } else {
      return config.rootpath + path + src;
    }
  }
  setHrefValue = function (href) {//+a()用のhref属性判定＆設定
    if (href === undefined) {
      return undefined;
    } else if (href.startsWith('http')) {
      return href;
    } else {
      return config.rootpath + href;
    }
  }
```

### 例
```
mixin img(file,alt,width,height)
  -
    src = setSrcValue(file, "/assets/images/")
  -
    ＜略＞
  img(src=src, alt!=alt, width!=width, height!=height)&attributes(attributes)
```

```
mixin a(href,autoTarget)
  -
    ＜略＞
    href = setHrefValue(href);//hrefの値に応じてconfig.rootpathを付与する
    ＜略＞
  a(href!= href target!=target)&attributes(attributes)
    block
```


### +aや+aeでhttpではじまるURLや、.pdfで終わるURLが渡されたときは target="_blank"自動付与

### 該当処理
```
  setTargetValue = function (href, autoTarget) {//+a()用のtarget属性判定＆設定
    if (href === undefined) {
      return undefined;
    } else if (href.startsWith('http') || href.endsWith('.pdf') || autoTarget === 'blank') {
      return "_blank";
    } else {
      return undefined;
    }
  }
```

### 例
```
mixin a(href,autoTarget)
  -
    if (autoTarget === undefined) {//autoTargetが未定義の場合はtrueとする
      autoTarget = true;
    }
    ＜略＞
    if (autoTarget) {//autoTargetがtrueの場合はtarget属性を設定する
      target = setTargetValue(href, autoTarget);
    }
  a(href!= href target!=target)&attributes(attributes)
    block
```

## 実際どうなる

### +a
```
 +a("https://example.com")
  →　<a href="https://example.com" target="_blank"></a>

 +a("/assets/files/sample.pdf")
  →　<a href="/assets/files/sample.pdf" target="_blank"></a>

 +a("/format/") ※もとの挙動通り
  →　<a href="/format/"></a>

 +a("https://example.com",false)
  →　<a href="https://example.com"></a>

 +a("/format/",'blank') または +a("/format/")(target="_blank")
  →　<a href="/format/" target="_blank"></a>
```


### +img
```
+img("img-card-01.jpg") ※もとの挙動通り
→　<img src="/assets/images/img-card-01.jpg" alt="">

+img("https://placehold.jp/1920x1080.png")
→　<img src="https://placehold.jp/1920x1080.png" alt="">
```