### PR TITLE
[update]   image-rendering: -webkit-optimize-contrast CSSハック変更

### DIFF
--- a/app/assets/scss/foundation/_normalize.scss
+++ b/app/assets/scss/foundation/_normalize.scss
@@ -74,10 +74,8 @@ body {
 
 /* chrome opera /
 /! autoprefixer: ignore next */
-@media screen and (-webkit-min-device-pixel-ratio: 0) and (min-resolution: .001dpcm) {
-  body {
+_:lang(x)::-internal-media-controls-overlay-cast-button, body {
     image-rendering: -webkit-optimize-contrast;
-  }
 }
 
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -3589,9 +3589,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001587",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001587.tgz",
-      "integrity": "sha512-HMFNotUmLXn71BQxg8cijvqxnIAofforZOwGsxyXJ0qugTdspUF4sPSJ2vhgprHCB996tIDzEq1ubumPDV8ULA==",
+      "version": "1.0.30001620",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001620.tgz",
+      "integrity": "sha512-WJvYsOjd1/BYUY6SNGUosK9DUidBPDTnOARHp3fSmFO1ekdxaY6nKRttEVrfMmYi80ctS0kz1wiWmm14fVc3ew==",
       "dev": true,
       "funding": [
         {


### PR DESCRIPTION
▼関連改善事項
https://www.notion.so/growgroup/image-rendering-webkit-optimize-contrast-Safari-CSS-Safari-6468c78484474a4ab96f194e1b75927c


## 起きていた問題
以下のSafariでは効かないでほしかった（Chromeのみで効いてほしい）CSSが、Safariでも効いている

```
@media screen and (-webkit-min-device-pixel-ratio: 0) and (min-resolution: .001dpcm) {
  body {
    image-rendering: -webkit-optimize-contrast;
  }
}
```

## 対応内容
CSSハックを別のものに取り替える応急措置

```
_:lang(x)::-internal-media-controls-overlay-cast-button, body {
    image-rendering: -webkit-optimize-contrast;
}
```

## 確認したこと
SafariとFirefoxでは該当のimage-renderingが効かなくなった