### PR TITLE
anchor.jsのズラし量計算を、scroll-padding-topとscroll-margin-topに依存させる

### DIFF
--- a/app/assets/js/app/anchor.js
+++ b/app/assets/js/app/anchor.js
@@ -23,7 +23,6 @@ var defaultOptions = {
   dataSelector: 'anchor-target',
   scrollSpeed: 300,
   easing: 'linear',
-  headerElement:'.l-header' // ヘッダーの高さ分ずらしたいとき '.l-header' のように
 };
 export default class Anchor {
   constructor(options) {
@@ -40,7 +39,6 @@ export default class Anchor {
   init() {
     this.target = $(this.options.selector);
     this.onClick();
-    this.run();
   }
 
   /**
@@ -51,7 +49,7 @@ export default class Anchor {
     var self = this;
 
     this.target.on('click', function(e) {
-      e.preventDefault();
+      // e.preventDefault();
 
       // スクロール先のターゲットを指定
       var anchorTargetSelector = $(this).data(self.options.dataSelector);
@@ -65,6 +63,7 @@ export default class Anchor {
           return false;
         }
         anchorTargetSelector = anchorTargetSelector[0];
+
       }
 
       var anchorTarget = $(anchorTargetSelector);
@@ -73,13 +72,13 @@ export default class Anchor {
         throw new Error('ターゲットとなる要素を取得できませんでした。');
         return false;
       }
-      var top = anchorTarget.offset().top;
 
-      //headerElementの指定があればheaderの高さを測って top の値をずらす
-      var headerHeight;
-      if (self.options.headerElement) {
-        headerHeight = $(self.options.headerElement).outerHeight();
-        top = top - headerHeight
+      let top = anchorTarget.offset().top;
+
+      // scroll-margin-topの値を取得して、スクロール位置を調整
+      let scrollMarginTop = parseInt(window.getComputedStyle(anchorTarget[0]).scrollMarginTop);
+      if (!isNaN(scrollMarginTop)) {
+        top -= scrollMarginTop;
       }
 
       // スクロールさせる
@@ -107,30 +106,4 @@ export default class Anchor {
 
     });
   }
-
-
-  /**
-   * ページロード時に実行
-   */
-  run() {
-    var self = this;
-    //headerElementの指定があればheaderの高さを測って表示位置をずらす
-    var headerHeight;
-    var url = $(location).attr('href');
-    if (url.indexOf("#") !== -1) {
-      if (self.options.headerElement) {
-        window.addEventListener("load", function () {
-          headerHeight = $(self.options.headerElement).outerHeight();
-          var id = url.split("#");
-          var $target = $('#' + id[id.length - 1]);
-          if ($target.length) {
-            var pos = $target.offset().top - headerHeight;
-            $("html, body").animate({scrollTop: pos}, 10);
-          }
-        });
-      }
-    }
-  }
 }
-
-

--- a/app/assets/js/app/anchor.js
+++ b/app/assets/js/app/anchor.js
@@ -38,6 +38,7 @@ export default class Anchor {
    */
   init() {
     this.target = $(this.options.selector);
+    this.scrollPaddingTopObj = $(this.options.scrollPaddingTopObj);
     this.onClick();
   }
 
@@ -49,7 +50,7 @@ export default class Anchor {
     var self = this;
 
     this.target.on('click', function(e) {
-      // e.preventDefault();
+      e.preventDefault();
 
       // スクロール先のターゲットを指定
       var anchorTargetSelector = $(this).data(self.options.dataSelector);
@@ -75,11 +76,20 @@ export default class Anchor {
 
       let top = anchorTarget.offset().top;
 
-      // scroll-margin-topの値を取得して、スクロール位置を調整
-      let scrollMarginTop = parseInt(window.getComputedStyle(anchorTarget[0]).scrollMarginTop);
-      if (!isNaN(scrollMarginTop)) {
-        top -= scrollMarginTop;
+
+      // ヘッダーの高さを取得
+      // target に指定された要素の scroll-margin-top を取得
+      let rootHeaderHeight = $('html').css('scroll-padding-top');
+      let headerHeight = anchorTarget.css('scroll-margin-top');
+      rootHeaderHeight = parseInt(rootHeaderHeight);
+      headerHeight = parseInt(headerHeight);
+      if (!isNaN(headerHeight)) {
+        top -= headerHeight;
       }
+      if (!isNaN(rootHeaderHeight)) {
+        top -= rootHeaderHeight;
+      }
+      console.log(headerHeight)
 
       // スクロールさせる
       $('body,html').animate({

--- a/app/assets/js/app/anchor.js
+++ b/app/assets/js/app/anchor.js
@@ -47,18 +47,18 @@ export default class Anchor {
    */
   onClick() {
 
-    var self = this;
+    let self = this;
 
     this.target.on('click', function(e) {
       e.preventDefault();
 
       // スクロール先のターゲットを指定
-      var anchorTargetSelector = $(this).data(self.options.dataSelector);
+      let anchorTargetSelector = $(this).data(self.options.dataSelector);
 
 
       if (typeof anchorTargetSelector === 'undefined') {
         var href = $(this).attr('href');
-        var anchorTargetSelector = href.match(/#(\S*)/g);
+        anchorTargetSelector = href.match(/#(\S*)/g);
         if (typeof anchorTargetSelector[0] === 'undefined') {
           throw new Error('ターゲットとなる要素を取得できませんでした。');
           return false;
@@ -67,7 +67,7 @@ export default class Anchor {
 
       }
 
-      var anchorTarget = $(anchorTargetSelector);
+      let anchorTarget = $(anchorTargetSelector);
 
       if (anchorTarget.length === 0) {
         throw new Error('ターゲットとなる要素を取得できませんでした。');
@@ -77,19 +77,20 @@ export default class Anchor {
       let top = anchorTarget.offset().top;
 
 
-      // ヘッダーの高さを取得
-      // target に指定された要素の scroll-margin-top を取得
+      // 基本的なスクロール位置調整値としてhtml要素のscroll-padding-topを取得
       let rootHeaderHeight = $('html').css('scroll-padding-top');
+      // 個別のスクロール位置調整値としてターゲット要素のscroll-margin-topを取得
       let headerHeight = anchorTarget.css('scroll-margin-top');
       rootHeaderHeight = parseInt(rootHeaderHeight);
       headerHeight = parseInt(headerHeight);
+
+      // スクロール位置調整値が数値であれば、スクロール位置から引く（個別の調整値は追加で引く）
       if (!isNaN(headerHeight)) {
         top -= headerHeight;
       }
       if (!isNaN(rootHeaderHeight)) {
         top -= rootHeaderHeight;
       }
-      console.log(headerHeight)
 
       // スクロールさせる
       $('body,html').animate({

--- a/app/assets/scss/foundation/_normalize.scss
+++ b/app/assets/scss/foundation/_normalize.scss
@@ -23,6 +23,7 @@ html {
   -webkit-text-size-adjust: 100%; /* 2 */
   text-autospace: no-autospace; /* スクリプト間スペースの自動挿入防止 */
   text-spacing-trim: space-all; /* Chrome122以前のデフォルト値 */
+  scroll-padding-top: var(--header-height); //スクロール位置の調整
 }
 
 * {
@@ -438,9 +439,4 @@ a {
   overflow: hidden;
   white-space: nowrap;
   text-overflow: ellipsis;
-}
-
-//アンカーリンクの対象にscroll-margin-topの付与（https://example.com/#hoge のときに #hogeに自動付与）
-:target {
-  scroll-margin-top: var(--header-height);
 }

--- a/app/assets/scss/foundation/_normalize.scss
+++ b/app/assets/scss/foundation/_normalize.scss
@@ -23,7 +23,7 @@ html {
   -webkit-text-size-adjust: 100%; /* 2 */
   text-autospace: no-autospace; /* スクリプト間スペースの自動挿入防止 */
   text-spacing-trim: space-all; /* Chrome122以前のデフォルト値 */
-  scroll-padding-top: var(--header-height); //スクロール位置の調整
+  scroll-padding-top: var(--header-height); //スクロール位置の調整が不要な場合は 0 にする
 }
 
 * {

--- a/app/assets/scss/foundation/_normalize.scss
+++ b/app/assets/scss/foundation/_normalize.scss
@@ -3,9 +3,11 @@
 // # CSS 変数の定義
 :root {
   --letter-spacing: #{$font-base-letter-spacing};
+  --header-height: #{rem-calc($header-height)};
 
   //スマホのとき値を変更したい場合は以下に
-  @include breakpoint(small down) {
+  @include breakpoint(medium down) {
+    --header-height: #{rem-calc($header-height-sp)};
   }
 }
 
@@ -436,4 +438,9 @@ a {
   overflow: hidden;
   white-space: nowrap;
   text-overflow: ellipsis;
+}
+
+//アンカーリンクの対象にscroll-margin-topの付与（https://example.com/#hoge のときに #hogeに自動付与）
+:target {
+  scroll-margin-top: var(--header-height);
 }

--- a/app/assets/scss/foundation/_settings.scss
+++ b/app/assets/scss/foundation/_settings.scss
@@ -96,13 +96,16 @@ $breakpoints: (
 // ==============================
 // # 5. Layout
 // ==============================
+// ヘッダーの高さ
+$header-height: 100 !default;
+$header-height-sp: 55 !default;
 
 // スライドバー（スマホメニュー）
 $slidebar-menu-bg: $color-primary !default;
 $slidebar-menu-width: 100% !default;
 $slidebar-menu-eaasing: all ease-in-out .2s !default;
 $slidebar-container-bg: rgba(0, 0, 0, 0.8) !default;
-$slidebar-header-height: 55 !default; // スマホ時のヘッダーの高さ
+$slidebar-header-height: $header-height-sp !default; // スマホ時のヘッダーの高さ
 
 // # Grid
 $grid-row-width: 1140px !default; // グリッドの幅

--- a/app/assets/scss/foundation/_settings.scss
+++ b/app/assets/scss/foundation/_settings.scss
@@ -97,8 +97,8 @@ $breakpoints: (
 // # 5. Layout
 // ==============================
 // ヘッダーの高さ
-$header-height: 100 !default;
-$header-height-sp: 55 !default;
+$header-height: 100 !default; // スクロール位置をずらす計算にも使います
+$header-height-sp: 55 !default; // スクロール位置をずらす計算にも使います
 
 // スライドバー（スマホメニュー）
 $slidebar-menu-bg: $color-primary !default;

--- a/app/assets/scss/layout/header.scss
+++ b/app/assets/scss/layout/header.scss
@@ -30,11 +30,11 @@ category: Layout
     display: flex;
     align-items: center;
     padding: rem-calc(16) rem-calc(32) rem-calc(24);
-    height: rem-calc(80);
+    height: rem-calc($header-height);
 
     @include breakpoint(medium down) {
       padding: rem-calc(3) rem-calc(64) rem-calc(3) rem-calc(16);
-      height: rem-calc(55);
+      height: rem-calc($header-height-sp);
     }
   }
 

--- a/app/assets/scss/layout/section.scss
+++ b/app/assets/scss/layout/section.scss
@@ -84,3 +84,11 @@ $xs: 32;
     background: $color-background;
   }
 }
+
+
+.l-section.is-scroll-margin-responsive {
+  scroll-margin-top: rem-calc(200);
+  @include breakpoint(small only) {
+    scroll-margin-top: 0;
+  }
+}

--- a/app/format/components/_tab.pug
+++ b/app/format/components/_tab.pug
@@ -14,15 +14,15 @@ div.u-mbs.is-bottom
           li: +a("#")(data-tab-target="3") タブ4
           li: +a("#")(data-tab-target="4") タブ5
         .c-tabs__content.is-active.js-tabs-content(data-tab-name="0")
-          h3 タブ1
+          h3.u-text-center タブ1
         .c-tabs__content.js-tabs-content(data-tab-name="1")
-          h3 タブ2
+          h3.u-text-center タブ2
         .c-tabs__content.js-tabs-content(data-tab-name="2")
-          h3 タブ3
+          h3.u-text-center タブ3
         .c-tabs__content.js-tabs-content(data-tab-name="3")
-          h3 タブ4
+          h3.u-text-center タブ4
         .c-tabs__content.js-tabs-content(data-tab-name="4")
-          h3 タブ5
+          h3.u-text-center タブ5
     .c-tabs__content.js-tabs-content(data-tab-name="1")
       +c.tabs.is-index.js-tabs
         ul.c-tabs__navs.js-tabs-nav

--- a/app/format/index.pug
+++ b/app/format/index.pug
@@ -19,23 +19,52 @@ block page_header
 block body
   section.l-section.is-lg
     .l-container
-        
+      +c_anchor-nav("u-mbs is-bottom",{
+        link: "#text",
+        title: "テキスト",
+      },{
+        link: "#button",
+        title: "ボタン",
+      },{
+        link: "#other",
+        title: "その他",
+      },{
+        link: "#tab",
+        title: "タブ",
+      },{
+        link: "#anchor-demo",
+        title: "アンカーのデモ",
+      })
 
-      .c-tabs.js-tabs
-        ul.c-tabs__navs.js-tabs-nav
-          li: +a("#").is-active(data-tab-target="0") テキスト
-          li: +a("#")(data-tab-target="1") ボタン
-          li: +a("#")(data-tab-target="2") その他
-          li: +a("#")(data-tab-target="3") タブ
 
-        .c-tabs__content.is-active.js-tabs-content(data-tab-name="0")
-          include /format/components/_text.pug
-        .c-tabs__content.js-tabs-content(data-tab-name="1")
-          include /format/components/_buttons.pug
-        .c-tabs__content.js-tabs-content(data-tab-name="2")
-          include /format/components/_other.pug
-        .c-tabs__content.js-tabs-content(data-tab-name="3")
-          include /format/components/_tab.pug
+      h1#text テキスト
+      include /format/components/_text.pug
+
+      //-スペース空ける
+      .u-mbs.is-lg
+
+
+      h1#button ボタン
+      include /format/components/_buttons.pug
+
+      //-スペース空ける
+      .u-mbs.is-lg
+
+      h1#other その他
+      include /format/components/_other.pug
+
+
+      //-スペース空ける
+      .u-mbs.is-lg
+
+      h1#tab タブ
+      include /format/components/_tab.pug
+
+      h1#anchor-demo(style="scroll-margin-top:100px") アンカーのデモ
+      p アンカー位置を上方向に追加でズラしたデモ（style属性で書いていますが普通にCSSファイル側で指定でOK）
+      p html要素のscroll-padding-top = 標準のズラし量
+      p 個別要素のscroll-margin-top = 追加のズラし量
+      p 標準のズラし量 + 追加のズラし量 = 実際のズラし量
 
 
 block before_footer

--- a/app/index.pug
+++ b/app/index.pug
@@ -16,6 +16,10 @@ block before_main
 
 block body
   +c_main-visual()
+
+  +a('#hoge1').js-anchor テスト1
+  +a('#hoge2').js-anchor テスト2
+
   section.l-section.is-lg.is-color-secondary
     .l-container
       +heading-xlg("私たちについて", "ABOUT").is-bottom
@@ -60,7 +64,7 @@ block body
               h3.c-heading.is-sm.is-bottom タイトルがここに入ります。
               p テキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキスト
               +e.button: +a("#").c-button.is-sm ボタンテキスト
-      +e.block
+      +e.block#hoge1
         +e.image: +img("img-hero-block-01.jpg","",700,400)
         .l-container
           +e.content
@@ -68,7 +72,7 @@ block body
               h3.c-heading.is-sm.is-bottom タイトルがここに入ります。
               p テキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキスト
               +e.button: +a("#").c-button.is-sm ボタンテキスト
-  section.l-section.is-lg
+  section.l-section.is-lg#hoge2(style="scroll-margin-top: 150px;")
     .l-container
       +c.news
         +e.columns

--- a/app/index.pug
+++ b/app/index.pug
@@ -16,24 +16,6 @@ block before_main
 
 block body
   +c_main-visual()
-
-  p
-    +a("#test01").js-anchor テスト01:.js-anchorの通常動作
-  p
-    +a("#test01") テスト02:.js-anchorなしでもスクロール位置自体は問題なくなる
-  p
-    +a("#test02").js-anchor テスト03: 敢えてヘッダーにめり込ませる
-  p
-    +a("#test02") テスト04:.js-anchorなしの敢えてヘッダーにめり込ませる
-  p
-    +a("#test03").js-anchor テスト05: ヘッダーの高さよりも大きい値を指定
-  p
-    +a("#test03") テスト06:.js-anchorなしのヘッダーの高さよりも大きい値を指定
-  p
-    +a("#test04").js-anchor  テスト07:レスポンシブ対応
-  p
-    +a("#test04") テスト08:.js-anchorなしのレスポンシブ対応
-
   section.l-section.is-lg.is-color-secondary
     .l-container
       +heading-xlg("私たちについて", "ABOUT").is-bottom
@@ -86,20 +68,6 @@ block body
               h3.c-heading.is-sm.is-bottom タイトルがここに入ります。
               p テキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキスト
               +e.button: +a("#").c-button.is-sm ボタンテキスト
-  section.l-section.is-bg-color#test01
-    .l-container
-      p 標準動作:html要素のscroll-padding-top依存の動作
-
-  section.l-section#test02(style="scroll-margin-top: -50px;")
-    .l-container
-      p scroll-margin-top: -50px;//html要素のscroll-padding-top + -50px
-  section.l-section.is-bg-color#test03(style="scroll-margin-top: 300px;")
-    .l-container
-      p scroll-margin-top: 300px;//html要素のscroll-padding-top + 300px
-  section.l-section.is-color-secondary.is-scroll-margin-responsive#test04
-    .l-container
-      p PCだとscroll-margin-top: rem-calc(200);//html要素のscroll-padding-top + 200px
-      p SPだとscroll-margin-top: 0px;//html要素のscroll-padding-topのみ
   section.l-section.is-lg
     .l-container
       +c.news

--- a/app/index.pug
+++ b/app/index.pug
@@ -17,8 +17,22 @@ block before_main
 block body
   +c_main-visual()
 
-  +a('#hoge1').js-anchor テスト1
-  +a('#hoge2').js-anchor テスト2
+  p
+    +a("#test01").js-anchor テスト01:.js-anchorの通常動作
+  p
+    +a("#test01") テスト02:.js-anchorなしでもスクロール位置自体は問題なくなる
+  p
+    +a("#test02").js-anchor テスト03: 敢えてヘッダーにめり込ませる
+  p
+    +a("#test02") テスト04:.js-anchorなしの敢えてヘッダーにめり込ませる
+  p
+    +a("#test03").js-anchor テスト05: ヘッダーの高さよりも大きい値を指定
+  p
+    +a("#test03") テスト06:.js-anchorなしのヘッダーの高さよりも大きい値を指定
+  p
+    +a("#test04").js-anchor  テスト07:レスポンシブ対応
+  p
+    +a("#test04") テスト08:.js-anchorなしのレスポンシブ対応
 
   section.l-section.is-lg.is-color-secondary
     .l-container
@@ -64,7 +78,7 @@ block body
               h3.c-heading.is-sm.is-bottom タイトルがここに入ります。
               p テキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキスト
               +e.button: +a("#").c-button.is-sm ボタンテキスト
-      +e.block#hoge1
+      +e.block
         +e.image: +img("img-hero-block-01.jpg","",700,400)
         .l-container
           +e.content
@@ -72,7 +86,21 @@ block body
               h3.c-heading.is-sm.is-bottom タイトルがここに入ります。
               p テキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキスト
               +e.button: +a("#").c-button.is-sm ボタンテキスト
-  section.l-section.is-lg#hoge2(style="scroll-margin-top: 150px;")
+  section.l-section.is-bg-color#test01
+    .l-container
+      p 標準動作:html要素のscroll-padding-top依存の動作
+
+  section.l-section#test02(style="scroll-margin-top: -50px;")
+    .l-container
+      p scroll-margin-top: -50px;//html要素のscroll-padding-top + -50px
+  section.l-section.is-bg-color#test03(style="scroll-margin-top: 300px;")
+    .l-container
+      p scroll-margin-top: 300px;//html要素のscroll-padding-top + 300px
+  section.l-section.is-color-secondary.is-scroll-margin-responsive#test04
+    .l-container
+      p PCだとscroll-margin-top: rem-calc(200);//html要素のscroll-padding-top + 200px
+      p SPだとscroll-margin-top: 0px;//html要素のscroll-padding-topのみ
+  section.l-section.is-lg
     .l-container
       +c.news
         +e.columns


### PR DESCRIPTION
▼関連改善事項
https://www.notion.so/growgroup/anchor-margin-top-6b60dd228e124fa0bcda3dd4debef252

▼デモ
npm start 後、 localhost:3000/format/


# やりたいこと
## その1
marginが付いている要素の時に、paddingが付いている要素と見かけ上同じ位置にアンカーが来るようにしたい場合がある
![CleanShot 2024-06-28 at 17 33 53@2x](https://github.com/growgroup/gg-styleguide/assets/97862690/3394ec22-5ddc-454e-bf02-ba1001600a2c)

## その2
別ページから /hoge/#hoge へリンクしたときの動作を改善したい。
最近の案件だと、ページを開く→ロードが終わってからスクロール位置を計算し直すのでガタつく
![CleanShot 2024-06-28 at 17 40 26@2x](https://github.com/growgroup/gg-styleguide/assets/97862690/e7ad653f-4c2b-421c-be83-e781f0e93660)

# 解決方法
scroll-padding-top と scroll-margin-topによる計算方法の導入。
参考 https://note.com/eightbe/n/n9eac9c7b3cb0

## 使い方詳しく

### settings.scss
PCとSPの基本のヘッダー高さを設定

```
// ==============================
// # 5. Layout
// ==============================
// ヘッダーの高さ
$header-height: 100 !default; // スクロール位置をずらす計算にも使います
$header-height-sp: 55 !default; // スクロール位置をずらす計算にも使います

```

### normalize.scss
上記scss変数は最終的にhtml要素のscroll-padding-topに入る。

```
html {
<略>
  scroll-padding-top: var(--header-height); //スクロール位置の調整が不要な場合は 0 にする
}
```

### 個別のズラし値を指定したい要素
```
.c-hoge{
  scroll-margin-top: rem-calc(100); //$header-height + 100pxをズラし値にします。
}

```

## 仕組み詳しく
- scroll-padding-topとscroll-margin-topはアンカーリンク先の位置をずらすCSSの標準機能
- JavaScriptでscrollさせると上記が正しく機能しないので、上記のCSS標準挙動に合致するようにスクロール先を計算し直している