### PR TITLE
:any-link:hover の追加（主にお知らせ一覧）と @mixin hoverの調整、@mixin group-hoverの追加

### DIFF
--- a/app/assets/scss/foundation/_mixin.scss
+++ b/app/assets/scss/foundation/_mixin.scss
@@ -513,6 +513,14 @@
   }
 }
 
+@mixin group-hover {
+  @media (hover: hover) {
+    &:is(:where(:any-link, :enabled, summary):hover *) {
+      @content;
+    }
+  }
+}
+
 @mixin icon-font-style {
   font-weight: normal;
   font-style: normal;

--- a/app/assets/scss/foundation/_mixin.scss
+++ b/app/assets/scss/foundation/_mixin.scss
@@ -504,9 +504,10 @@
   left: 0;
 }
 
+//https://zenn.dev/kagan/articles/css-hover-style
 @mixin hover {
   @media (hover: hover) {
-    &:hover {
+    &:where(:any-link, :enabled, summary):hover {
       @content;
     }
   }

--- a/app/assets/scss/object/components/news-lg.scss
+++ b/app/assets/scss/object/components/news-lg.scss
@@ -18,6 +18,10 @@ category: News
     &:first-child {
       padding-top: 0;
     }
+
+    &:any-link:hover {
+      background-color: $color-secondary;
+    }
   }
 
   &__sup {

--- a/app/assets/scss/object/components/news.scss
+++ b/app/assets/scss/object/components/news.scss
@@ -66,6 +66,10 @@ category: News
     &:first-child {
       padding-top: 0;
     }
+
+    &:any-link:hover {
+      background-color: $color-secondary;
+    }
   }
 
   &__inner {
@@ -112,6 +116,7 @@ category: News
     }
 
     .c-news__date {
+      flex-shrink: 0;
       margin-top: rem-calc(6);
       @include breakpoint(small only) {
         margin-top: 0;
@@ -119,6 +124,7 @@ category: News
     }
 
     .c-news__title {
+      flex-grow: 1;
       text-align: center;
       margin-bottom: rem-calc(40);
       @include breakpoint(small only) {

--- a/app/assets/scss/object/utility/text.scss
+++ b/app/assets/scss/object/utility/text.scss
@@ -54,8 +54,8 @@ a,
   text-decoration: underline;
   cursor: pointer;
 }
-a{
 
+.u-text-link {
   &.is-pdf {
 
     &:after {
@@ -84,15 +84,19 @@ a{
 }
 
 a:hover,
-.u-text-link:hover,
+.u-text-link:any-link:hover,
 .u-text-link.is-hover {
   opacity: 0.8;
 }
 
-a:active,
+a:any-link:active,
 .u-text-link:active,
 .u-text-link.is-active {
   // color: darken($color-primary, 10);
+}
+
+.u-hover-disabled, .u-pointer-events-none {
+  pointer-events: none;
 }
 
 // p a:visited {
@@ -112,3 +116,4 @@ a:active,
 .u-text-success {
   color: $color-state-info;
 }
+

--- a/app/news/index.pug
+++ b/app/news/index.pug
@@ -21,6 +21,12 @@ block body
         +c.news.is-onecolumn
           h2.c-news__title.c-heading.is-md.is-line-under.is-color-primary すべて
           +e.content
+            +e.block
+              +e.date 2022.01.01
+              +e.label.c-label.is-white カテゴリ
+              +e.inner
+                +e.text リンク無し記事のテスト
+                +e.excerpt リンク無し記事のテスト
             +loop(3)
               +c_news__block("news")
         +c_pagination()


### PR DESCRIPTION
▼関連改善事項
https://www.notion.so/growgroup/news-CSS-235e3adbc9a042c989f544b74d0d1ac2


# やりたいこと
## 前提
WordPress実装時に「お知らせ」系の投稿機能では、
必ず同じclass名に対してリンクのありverと、なしverが存在する
```
<a class="c-news__block" href="#">リンクあり</a>
<div class="c-news__block">リンクなし</div>
```

## やりたいこと
リンク無しverのときは、hoverの反応をあらかじめ切っておきたい。

# 対応したこと
- .c-news__blockにあらかじめ `:any-link:hover` を設定しておく
- @mixin hover に :any-linkを仕込んでおく（ついでにmixin group-hoverも作っておく）
- .u-hover-disabled を作っておく

## .c-news__blockにあらかじめ `:any-link:hover` を設定しておく
```
&__block{
    &:any-link:hover {
      background-color: $color-secondary;
    }
}
```

### 理由
▼妥当な指定方法の研究
https://codepen.io/miral_kashiwagi/pen/zYQQoxr

上記より、aタグのみにhoverを設定するより、:any-link:hoverとする方が
- 動作的に妥当
- 日常的に書くのが楽


## @mixin hover に :any-linkを仕込んでおく（ついでにmixin group-hoverも作っておく）
※ただしmedia queryのソートの都合で期待値とCSSの効き方が違うので、いったん標準とはしていない

```
@mixin hover {
  @media (hover: hover) {
    &:where(:any-link, :enabled, summary):hover {
      @content;
    }
  }
}

@mixin group-hover {
  @media (hover: hover) {
    &:is(:where(:any-link, :enabled, summary):hover *) {
      @content;
    }
  }
```

### 使い方

```
&__block{
    @include hover {
      background-color: $color-secondary;
    }
}
```

▼参考
https://zenn.dev/kagan/articles/css-hover-style

## .u-hover-disabled を作っておく
※いったん.u-pointer-events-noneも併記してあります

```
.u-hover-disabled, .u-pointer-events-none {
  pointer-events: none;
}
```

### 理由
- どうしても後から急にリンクを無効にしたいときがあるので、その対応したい
- `all:inherit` のような形だと、hoverどころか元のコンポーネントのスタイルも全部消滅するのでユーティリティでできる範囲はpointer-eventsしかない

