### PR TITLE
[update] l-header, l-footer

### DIFF
--- a/app/inc/layout/_footer.pug
+++ b/app/inc/layout/_footer.pug
@@ -2,9 +2,10 @@
 //- description: フッター
 -
   var className = "l-footer"
+  var isSimplePages = ["contact", "confirm", "complete"]
 
-  if (current.id === "contact" || current.id === "confirm" || current.id === "complete") {
-    className = "l-footer is-simple"
+  if (isSimplePages.includes(current.id)) {
+    className += " is-simple"
   }
 
 footer(class=className)

--- a/app/inc/layout/_header.pug
+++ b/app/inc/layout/_header.pug
@@ -1,13 +1,18 @@
 -
-  var className = "l-header js-fixedheader is-normal"
+  var className = "l-header"
+  var isSimplePages = ["contact", "confirm", "complete"]
 
-  if (current.id === "contact" || current.id === "confirm" || current.id === "complete") {
-    className = "l-header is-simple"
+  if (isSimplePages.includes(current.id)) {
+    //isSimplePagesにcurrent.idが含まれている場合
+    className += " is-simple"
+  } else {
+    //それ以外のとき
+    className += " js-fixedheader"
+  }
+  if (current.id === "home") {
+    className += " is-home"
   }
 
-  else if (current.id === "home") {
-    className = "l-header js-fixedheader"
-  }
 
 
 header(class=className)


### PR DESCRIPTION
▼関連改善事項
https://www.notion.so/growgroup/layout-222ab7221f5f45b89e0594fbbea68442

# やりたいこと
以下のように`current.id === "contact"` を `||` でつないでいくのはページ数が多いときに大変なので

```
  if (current.id === "contact" || current.id === "confirm" || current.id === "complete") {
    className = "l-header is-simple"
  }
```

以下のように配列に追加するだけでよくしたい

```
var currentList = ["main-store","contact-wood","contact-machine","contact-forest","entry" , "confirm" ,"complete"]
```

# やったこと
isSimplePages配列に追加すると、 is-simpleが追加されるようになりました。

```
-
  var className = "l-header"
  var isSimplePages = ["contact", "confirm", "complete"]

  if (isSimplePages.includes(current.id)) {
    //isSimplePagesにcurrent.idが含まれている場合
    className += " is-simple"
  } else {
    //それ以外のとき
    className += " js-fixedheader"
  }
  if (current.id === "home") {
    className += " is-home"
  }
```