### PR TITLE
[update] searchform.pug : spanのaria-labelをvisually-hiddenに変更

### DIFF
--- a/app/assets/scss/object/utility/_index.scss
+++ b/app/assets/scss/object/utility/_index.scss
@@ -1,3 +1,4 @@
+@import "a11y";
 @import "align";
 @import "margin";
 @import "responsive";

--- a/app/assets/scss/object/utility/a11y.scss
+++ b/app/assets/scss/object/utility/a11y.scss
@@ -1,0 +1,11 @@
+.u-visually-hidden {
+  border: 0 !important;
+  clip: rect(0, 0, 0, 0) !important;
+  height: 1px !important;
+  margin: -1px !important;
+  overflow: hidden !important;
+  padding: 0 !important;
+  position: absolute !important;
+  white-space: nowrap !important;
+  width: 1px !important;
+}

--- a/app/inc/mixins/_searchform.pug
+++ b/app/inc/mixins/_searchform.pug
@@ -8,6 +8,7 @@ mixin l_searchform
           span.c-icon-font.l-searchform__close__icon close
         form.l-searchform__form.js-header-searchform-content
           label.l-searchform__form__label(for="searchform")
-            span.l-searchform__form__icon(aria-label="キーワードから検索") search
+            span.u-visually-hidden キーワードから検索
+            span.l-searchform__form__icon(aria-hidden="true") search
           input(type="text", placeholder="キーワードから検索")#searchform
           button 検索する


### PR DESCRIPTION
▼関連改善事項
https://www.notion.so/growgroup/WAI-ARIA-1-2-span-aria-label-visually-hidden-08cc365b58c94fea8ebeba00a16c8848

## やったこと
WAI-ARIA1.2からspanにaria-labelを付けるのがNGになったので、visually-hiddenに変更。
（WAI-ARIA 1.1まではつけてもよかった）

## 参考
デジタル庁 https://www.digital.go.jp/ のCSSにある
.u-visually-hidden