### PR TITLE
[update] c-slidebar-button : ×のときの交差点が中心を捉えやすいように変更

### DIFF
--- a/app/assets/scss/object/components/slidebar-button.scss
+++ b/app/assets/scss/object/components/slidebar-button.scss
@@ -3,97 +3,111 @@
 // スマホ時のメニュー。別途 GApp プラグインを呼び出す必要があります。
 // Styleguide 4.5
 
+
 @include breakpoint(large up) {
   .c-slidebar-button {
     display: none;
   }
 }
 
-@include breakpoint(medium down) {
-  // トリガーとなるボタン
-  .c-slidebar-button {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    flex-direction: column;
-    position: fixed;
-    right: 0;
-    top: 0;
-    text-align: center;
-    font-size: rem-calc(12);
-    z-index: 9999;
-    text-decoration: none;
-    background-color: $color-primary;
-    line-height: 1;
-    color: $color-white;
-    width: rem-calc($slidebar-header-height);
-    height: rem-calc($slidebar-header-height);
-    padding-top: rem-calc(6);
-    border: none;
+// トリガーとなるボタン
+.c-slidebar-button {
+  position: fixed;
+  right: 0;
+  top: 0;
+  text-align: center;
+  font-size: rem-calc(12);
+  z-index: 9999;
+  text-decoration: none;
+  background-color: $color-primary;
+  color: $color-white;
+  width: rem-calc($slidebar-header-height);
+  height: rem-calc($slidebar-header-height);
+  border: none;
+  padding: 0;
 
-    &:active,
-    &:hover {
-      opacity: 1;
+  &:active,
+  &:hover {
+    opacity: 1;
+  }
+
+  &__inner {
+    display: grid;
+    position: absolute;
+    inset: 0;
+    place-content: center;
+    padding-top: rem-calc(12);
+  }
+
+  // ボーダー
+  &__line {
+    --color-slidebar-button-line: #{$color-white}; //線の色が開閉で変化しない場合はここで指定
+    position: relative;
+    width: 26px; //線の長さ
+    height: 2px; //線の太さ
+    background-color: var(--color-slidebar-button-line);
+    //background-color: transparent;//線2本の時は、ここは透明に
+    transition: all ease-out .2s;
+
+
+    &::before,
+    &::after {
+      content: "";
+      position: absolute;
+      display: block;
+      width: 100%;
+      height: 100%;
+      background-color: inherit;
+      //background-color: var(--color-slidebar-button-line);//線2本の時は、親は透明にしてこちらで色を指定
+      transition: inherit;
     }
 
-    &__inner{
-      display: block;
+    &::before {
+      top: -7px;
     }
 
-    // ボーダー
-    &__line {
-      height: rem-calc(16);
-      display: block;
-      > span {
-        display: block;
-        width: rem-calc(26);
-        height: rem-calc(2);
-        background: $color-white;
-        margin-left: auto;
-        margin-right: auto;
-        margin-bottom: 5px;
-        transition: all ease .2s;
+    &::after {
+      top: 7px;
+    }
 
-        &:last-child {
-          margin-bottom: 0;
-        }
+    //メニューが開いているとき
+    @at-root .is-slidebar-active & {
+      background-color: transparent;
+
+      &::before,
+      &::after {
+        top: 0;
+        background-color: var(--color-slidebar-button-line);
       }
-    }
 
-    // メニューテキスト
-    &__text {
-      transition: all ease .2s;
-      font-size: 9px;
-      letter-spacing: 0.4px;
-      @include webfont();
-      margin-top: rem-calc(8);
-      display: block;
+      &::before {
+        transform: rotate(45deg);
+      }
 
-      &.is-close {
-        display: none;
+      &::after {
+        transform: rotate(-45deg);
       }
     }
   }
 
-  // 有効時
-  .is-slidebar-active {
-    //cursor: pointer;
+  // メニューテキスト
+  &__text {
+    transition: all ease .2s;
+    font-size: 9px;
+    letter-spacing: 0.4px;
+    @include webfont();
+    margin-top: rem-calc(12);
+    display: block;
 
-    .c-slidebar-button {
-      &__line {
-        > span {
-          &:nth-child(1) {
-            transform: rotate(-45deg) translateY(4px) translateX(-4px);
-          }
+    &.is-close {
+      display: none;
+    }
 
-          &:nth-child(2) {
-            transform: rotate(45deg) translateY(-1px) translateX(-1px);
-          }
+    @at-root .is-slidebar-active & {
+      display: none;
 
-          &:nth-child(3) {
-            display: none;
-          }
-        }
+      &.is-close {
+        display: block;
       }
     }
   }

--- a/app/inc/mixins/_slidebar.pug
+++ b/app/inc/mixins/_slidebar.pug
@@ -4,9 +4,8 @@ mixin c_slidebar
   +c("button").slidebar-button.js-slidebar-button(type="button")
     +e("span").inner
       +e("span").line
-        span
-        span
-        span
+        //- .text が存在するときは.u-visually-hidden要素不要
+        span.u-visually-hidden メニューを開閉する
       +e("span").text.is-open MENU
       +e("span").text.is-close CLOSE
 


### PR DESCRIPTION
▼改善事項
https://www.notion.so/growgroup/c-slidebar-button-HTMLCSS-1bfed8b7a3ab48a18df1a45f9520cbdc


# やりたかったこと
- ×の中心位置が、ズレがちな問題の解決
- 改修時にハンバーガーメニューボタンを出すタイミングの変更がしづらい問題の解決
- （ついでに）ボタン内にテキストがないとき、ラベルのないボタンになる問題を軽減

## ×の中心位置が、ズレがちな問題の解決
線の配置の方法を根本的に変えることで、以下のような現象を防ぐようにしました。

▼現象
![CleanShot 2024-08-01 at 15 28 25](https://github.com/user-attachments/assets/83ad645b-e0a8-4af2-aeac-d1a72ba7594e)

▼参考
https://shibajuku.net/make-hamburger-button/


## 改修時にハンバーガーメニューボタンを出すタイミングの変更がしづらい問題の解決
WP改修案件で、ハンバーガーメニューボタンを出すタイミングを1200pxからに変えたいな〜とおもっても
そもそもボタンのスタイルが950px以下からしか当たっていないので、めちゃくちゃ苦労する問題を改善しました
（ボタンのスタイルはメディアクエリで囲まずに書き、display:noneの設定をlarge upでするようにした）

![CleanShot 2024-08-01 at 15 33 11](https://github.com/user-attachments/assets/f937297a-60b6-46e1-abb6-8d00bfffed1c)

▼該当変更箇所
https://github.com/growgroup/gg-styleguide/pull/151/files#diff-d60a8951cf2d5a04b98cd273debf78d188f5c2da3df1f26f53c8069f992ecf19L12-L14


## （ついでに）ボタン内にテキストがないとき、ラベルのないボタンになる問題を軽減
ハンバーガーメニューボタンのスタイルとして、線しかない場合に、
aria-labelを書かない限り、ラベルのないボタンになる問題を解決するため visually-hiddenでテキストを追加しました。

また、CSS変更のついでに、この部分の[空のパルパブルコンテンツ](https://dskd.jp/archives/112.html)問題も解消しました。

▼該当変更箇所
https://github.com/growgroup/gg-styleguide/pull/151/files#diff-102496db789fab6c3edca82912d8a9f0302b84b6011d98e7ac45e2f329346a99L6-L8