### PR TITLE
過去の修正にまつわる小さなCSS調整

### DIFF
--- a/app/assets/scss/foundation/_normalize.scss
+++ b/app/assets/scss/foundation/_normalize.scss
@@ -40,7 +40,7 @@ html {
 
 body {
   color: $font-base-color;
-  margin: rem-calc(80) 0 0;
+  margin: var(--header-height) 0 0;
   line-height: $font-base-line-height;
   //letter-spacing: $font-base-letter-spacing;
   font-size: $font-base-size;
@@ -49,10 +49,6 @@ body {
 
   &.is-slidebar-active {
     overflow: hidden;
-  }
-
-  @include breakpoint(medium down) {
-    margin-top: rem-calc(55);
   }
 
   @include breakpoint(small only) {

--- a/app/assets/scss/object/components/toc.scss
+++ b/app/assets/scss/object/components/toc.scss
@@ -8,7 +8,7 @@ category: PostContent
 
 #toc_container {
   margin: rem-calc(32) 0;
-  width: 100%;
+  width: 100% !important; //WPプラグインでインラインスタイルが指定されているため!importantを使用
   background: $color-secondary;
   border-radius: 0;
   padding: rem-calc(16) rem-calc(40) rem-calc(40);


### PR DESCRIPTION
▼関連改善事項
https://www.notion.so/growgroup/toc_container-width-100-important-45a98cd720a24760aafff4f04e789aaa
https://www.notion.so/growgroup/normalize-body-291513458dde431bbd1cb024e5c48285

## 対応内容
- https://github.com/growgroup/gg-styleguide/pull/144 で
作成した変数がbodyの上方向marginに適用されていなかった問題の解決
- https://github.com/growgroup/gg-styleguide/pull/136/ で
削除した!importantのうち、WPプラグイン都合で必要なものがあったので復活