### PR TITLE
[update] swiper :コード整理

### DIFF
--- a/app/assets/js/app.js
+++ b/app/assets/js/app.js
@@ -2,11 +2,12 @@
 import "../scss/font.scss";
 
 
+
 import Utils from './app/utils.js';
 import Accordion from './app/accordion.js';
 import Anchor from './app/anchor.js';
 import FixedHeader from './app/fixedheader.js';
-import HeightLine from './app/heightline.js';
+// import HeightLine from './app/heightline.js';
 import CopyRight from './app/copyright.js';
 import ResponsiveTable from './app/responsive-table.js';
 import Slidebar from './app/slidebar.js';
@@ -35,7 +36,7 @@ class App {
     this.FixedHeader = new FixedHeader();
     this.modal = new modal();
     this.CopyRight = new CopyRight();
-    this.HeightLine = new HeightLine();
+    // this.HeightLine = new HeightLine();
     this.ResponsiveTable = new ResponsiveTable();
     this.Slidebar = new Slidebar();
     this.ScrollSpy = new ScrollSpy();

--- a/app/assets/js/app/swiper.js
+++ b/app/assets/js/app/swiper.js
@@ -135,6 +135,7 @@ export default class SwiperSlider {
 
 
   //スライド枚数が著しく少ない場合、事前にスライドを複製してスライダーを初期化するサンプル
+  //動作の安定性に疑問があるため、不具合があれば別の実装方法を検討する
   LogoSlider(selector, reverse = false) {
     const minSlides = 2;
     const targetSelector = selector;
@@ -155,12 +156,6 @@ export default class SwiperSlider {
 
     // スライドの数が8未満の場合、スライドを複製して8枚以上になるまで追加する
     if (targetSlides.length < 8) {
-      // targetSlidesを複製
-      for (let i = 0; i < targetSlides.length; i++) {
-        const cloneSlide = targetSlides[i].cloneNode(true);
-        target.querySelector(".swiper-wrapper").appendChild(cloneSlide);
-      }
-      // 8枚以上になるまで複製
       while (target.querySelectorAll(targetSlideSelector).length < 8) {
         for (let i = 0; i < targetSlides.length; i++) {
           const cloneSlide = targetSlides[i].cloneNode(true);

--- a/app/assets/js/app/swiper.js
+++ b/app/assets/js/app/swiper.js
@@ -1,14 +1,42 @@
 // core version + navigation, pagination modules:
-import Swiper, {Navigation, Pagination, Autoplay,Controller, EffectCreative,Keyboard,EffectFade,Scrollbar} from 'swiper';
-Swiper.use([Pagination, Navigation,Autoplay,Controller, EffectCreative,Keyboard,EffectFade,Scrollbar]);
+import Swiper, {
+  Navigation,
+  Pagination,
+  Autoplay,
+  Controller,
+  Keyboard,
+  EffectFade,
+  // EffectCreative,
+  // Scrollbar,
+  // Thumbs,
+} from 'swiper';
+
+Swiper.use([
+  Pagination,
+  Navigation,
+  Autoplay,
+  Controller,
+  Keyboard,
+  EffectFade,
+  // EffectCreative,
+  // Scrollbar,
+  // Thumbs
+]);
 // import Swiper and modules styles
 import 'swiper/css';
 import 'swiper/css/autoplay';
 import 'swiper/css/navigation';
 import 'swiper/css/pagination';
-import 'swiper/css/scrollbar';
 import 'swiper/css/effect-fade';
+// import 'swiper/css/effect-creative';
+// import 'swiper/css/scrollbar';
+// import 'swiper/css/thumbs';
 
+
+import imagesLoaded from "imagesloaded";
+import Utils from "./utils";
+
+const utils = new Utils();
 
 
 let defaultOptions = {
@@ -21,7 +49,7 @@ export default class SwiperSlider {
    * @param options
    */
   constructor(options) {
-    this.options = $.extend(defaultOptions, options);
+    this.options = Object.assign(defaultOptions, options);
     this.init();
   }
 
@@ -30,7 +58,7 @@ export default class SwiperSlider {
    */
   init() {
     // ターゲットを取得する
-    this.targetAll = $(this.options.selector);
+    this.targetAll = document.querySelectorAll(this.options.selector);
 
     // ターゲットが存在しない場合は実行しない
     if (!this.targetAll.length) {
@@ -45,162 +73,284 @@ export default class SwiperSlider {
    * 実行する
    */
   run() {
-    //->スライダー
-    this.targetAll.imagesLoaded(function () {
+    imagesLoaded(this.targetAll, () => {
+      this.MainVisualSlider(); //->メインビジュアル
+      this.LogoSlider(".js-logo-slider:nth-child(odd of .js-logo-slider)"); //->ロゴスライダー
+      this.LogoSlider(".js-logo-slider:nth-child(even of .js-logo-slider)", true); //->ロゴスライダー
+      this.runCardSlider(); //->カードスライダー
+      this.documentSlider(); //->ドキュメントスライダー
+      this.textLoopSlider(); //->テキストループ
+    });
+  }
 
-      if ($('.c-main-visual .swiper').length <= 0) {
+  MainVisualSlider() {
+    const minSlides = 2;
+    const targetSelector = '.js-main-visual';
+    const targetSlideSelector = `${targetSelector} .swiper-slide`;
+    const target = document.querySelector(targetSelector);
+    const targetSlides = document.querySelectorAll(targetSlideSelector);
+
+    // ターゲット要素が存在しない場合、処理を終了する
+    if (!target) {
+      return;
+    }
+
+    // スライドの数が最低限必要な数（minSlides）より少ない場合、スライダーを初期化せずに処理を終了する
+    if (targetSlides.length < minSlides) {
+      return;
+    }
+
+    // const prev = document.querySelector(targetSelector + '-prev');
+    // const next = document.querySelector(targetSelector + '-next');
+    const pagination = document.querySelector(targetSelector + '-pagination');
+    const bar = document.querySelector(targetSelector + '-bar span');
+    const delayTime = 4000;
+
+    const swiper = new Swiper(targetSelector, {
+      loop: true,
+      effect: 'fade',
+      autoplay: {
+        delay: delayTime, // ４秒後に次の画像へ
+        disableOnInteraction: false, // ユーザー操作後に自動再生を再開する
+      },
+      speed: 2000,
+      allowTouchMove: false,
+      pagination: {
+        el: pagination, // ページネーションのクラス名を指定
+      },
+      on: {
+        //スライド（次または前）へのアニメーションの開始後にイベント発生
+        slideChangeTransitionStart: function (result) {
+          bar.style.transitionDuration = '0ms';
+          bar.style.transform = 'scaleY(0)'
+        },
+        //スライド（次または前）へのアニメーションの開始後にイベント発生
+        slideChangeTransitionEnd: function (result) {
+          bar.style.transitionDuration = delayTime + 'ms';
+          bar.style.transform = 'scaleY(1)'
+        },
+      },
+    });
+  }
+
+
+  //スライド枚数が著しく少ない場合、事前にスライドを複製してスライダーを初期化するサンプル
+  LogoSlider(selector, reverse = false) {
+    const minSlides = 2;
+    const targetSelector = selector;
+    const target = document.querySelector(targetSelector);
+
+    // ターゲット要素が存在しない場合、処理を終了する
+    if (!target) {
+      return;
+    }
+
+    const targetSlideSelector = `${targetSelector} .swiper-slide`;
+    const targetSlides = target.querySelectorAll(targetSlideSelector);
+
+    // スライドの数が最低限必要な数（minSlides）より少ない場合、スライダーを初期化せずに処理を終了する
+    if (targetSlides.length < minSlides) {
+      return;
+    }
+
+    // スライドの数が8未満の場合、スライドを複製して8枚以上になるまで追加する
+    if (targetSlides.length < 8) {
+      // targetSlidesを複製
+      for (let i = 0; i < targetSlides.length; i++) {
+        const cloneSlide = targetSlides[i].cloneNode(true);
+        target.querySelector(".swiper-wrapper").appendChild(cloneSlide);
+      }
+      // 8枚以上になるまで複製
+      while (target.querySelectorAll(targetSlideSelector).length < 8) {
+        for (let i = 0; i < targetSlides.length; i++) {
+          const cloneSlide = targetSlides[i].cloneNode(true);
+          target.querySelector(".swiper-wrapper").appendChild(cloneSlide);
+        }
+      }
+    }
+
+    let options = {
+      loop: true,
+      speed: 4000,
+      loopedSlides: targetSlides.length + 2,
+      slidesPerView: "auto",
+      allowTouchMove: false,
+      autoplay: {
+        delay: 0,
+        disableOnInteraction: false,
+        reverseDirection: reverse,
+      },
+      breakpoints: {
+        0: {
+          spaceBetween: 16,
+        },
+        950: {
+          spaceBetween: 32,
+        },
+      },
+    }
+
+    return new Swiper(targetSelector,
+      options
+    );
+
+  }
+
+
+  // スマホとPCで最低限必要なスライド数が異なる場合のサンプル
+  //initとrunを分ける（init側は、スライダーの初期化のみを行う）
+  initCardSlider(target, minSlides) {
+    // ターゲット要素が存在しない場合、nullを返して処理を終了する
+    if (!target) {
+      return null;
+    }
+
+    const targetSlides = target.querySelectorAll('.swiper-slide');
+    const prev = target.querySelector('.js-card-slider-prev');
+    const next = target.querySelector('.js-card-slider-next');
+    const pagination = target.querySelector('.js-card-slider-pagination');
+
+    // スライドの数が最低限必要な数（minSlides）より少ない場合、nullを返して処理を終了する
+    if (targetSlides.length < minSlides) {
+      return null;
+    }
+
+    return new Swiper(target, {
+      spaceBetween: 40,
+      loop: true,
+      navigation: {
+        nextEl: next,
+        prevEl: prev,
+      },
+      pagination: {
+        el: pagination,
+        clickable: false,
+      },
+      keyboard: {
+        enabled: true,
+        onlyInViewport: true,
+      },
+      breakpoints: {
+        0: {
+          slidesPerView: 1.25,
+          centeredSlides: true,
+          spaceBetween: 16,
+        },
+        950: {
+          spaceBetween: 40,
+          slidesPerView: 3,
+          loopAdditionalSlides: 3,
+        }
+      },
+    });
+  }
+
+  // スマホとPCで最低限必要なスライド数が異なる場合のサンプル
+  //initとrunを分ける(run側でレスポンシブ対応を行う)
+  runCardSlider() {
+    const targetSelector = '.js-card-slider';
+    const sliders = document.querySelectorAll(targetSelector);
+
+    sliders.forEach(slider => {
+      let swiper = null;
+
+      utils.responsiveMatch(
+        // SP (mobile) の場合の処理
+        () => {
+          if (swiper) {
+            swiper.destroy();
+          }
+          swiper = this.initCardSlider(slider, 2);
+          // ナビゲーション表示非表示方法参考
+          //  &__slider-nav {
+          //     display: none;
+          //     // swiper が初期化された後に表示する
+          //     @at-root .swiper-initialized & {
+          //       display: block;
+          //     }
+          //   }
+        },
+        // PC の場合の処理
+        () => {
+          if (swiper) {
+            swiper.destroy();
+          }
+          swiper = this.initCardSlider(slider, 4);
+        }
+      );
+    });
+  }
+
+  // 同じスライダーを複数設置する場合のサンプル
+  documentSlider() {
+    const targetSelector = '.js-document-slider';
+    const targetSlideSelector = `${targetSelector} .swiper-slide`;
+    const minSlides = 2;
+    const targets = document.querySelectorAll(targetSelector);
+
+    // スライダーのターゲット要素が存在しない場合、処理を終了する
+    if (!targets.length) {
+      return;
+    }
+
+    targets.forEach(target => {
+
+      const targetSlides = target.querySelectorAll(targetSlideSelector);
+
+      // スライドの数が最低限必要な数（minSlides）より少ない場合、処理を終了する
+      if (targetSlides.length < minSlides) {
         return;
       }
 
-      let bar = document.querySelector('.c-main-visual__bar span');
-      let pagination = document.querySelector('.c-main-visual__pagination');
-      let delayTime = 3500;
+      const prev = target.querySelector(targetSelector + '-prev');
+      const next = target.querySelector(targetSelector + '-next');
+      // const pagination = target.querySelector(targetSelector + '-pagination');
+      const delayTime = 4000;
 
-      const mainVisualSwiper = new Swiper(".c-main-visual .swiper", {
+      const swiper = new Swiper(target, {
         loop: true,
-        effect: 'fade',
+        effect: 'slide',
         autoplay: {
           delay: delayTime, // ４秒後に次の画像へ
           disableOnInteraction: false, // ユーザー操作後に自動再生を再開する
         },
-        speed: 2000,
+        speed: 400,
         allowTouchMove: false,
-        pagination: {
-          el: pagination, // ページネーションのクラス名を指定
-        },
-        on: {
-          //スライド（次または前）へのアニメーションの開始後にイベント発生
-          slideChangeTransitionStart: function (result) {
-            bar.style.transitionDuration = '0ms';
-            bar.style.transform = 'scaleY(0)'
-          },
-          //スライド（次または前）へのアニメーションの開始後にイベント発生
-          slideChangeTransitionEnd: function (result) {
-            bar.style.transitionDuration = delayTime + 'ms';
-            bar.style.transform = 'scaleY(1)'
-          },
-        },
-      });
-    });
-
-    this.targetAll.imagesLoaded(function () {
-
-      if ($('.js-float-swiper.swiper').length <= 0) {
-        return;
-      }
-
-      const textLoopInstagramSwiper = new Swiper(".js-float-swiper.swiper", {
-        loop: true,
-        speed: 20000,
-        slidesPerView: "auto",
-        allowTouchMove: false,
-        autoplay: {
-          delay: 0,
-          disableOnInteraction: false,
-        },
-        breakpoints: {
-          0: {
-            spaceBetween: 32,
-          },
-          950: {
-            spaceBetween: 54,
-          },
-        },
-      });
-    });
-
-    this.targetAll.imagesLoaded(function () {
-
-      if ($('.c-gallery-logo__slider.swiper').length <= 0) {
-        return;
-      }
-
-      const infiniteSwiperEven = new Swiper(".c-gallery-logo__slider.swiper:nth-child(even)", {
-        loop: true,
-        speed: 4000,
-        slidesPerView: "auto",
-        allowTouchMove: false,
-        autoplay: {
-          delay: 0,
-        },
-        breakpoints: {
-          0: {
-            spaceBetween: 32,
-          },
-          950: {
-            spaceBetween: 90,
-          },
-        },
-      });
-
-      const infiniteSwiperOdd = new Swiper(".c-gallery-logo__slider.swiper:nth-child(odd)", {
-        loop: true,
-        speed: 4000,
-        slidesPerView: "auto",
-        allowTouchMove: false,
-        autoplay: {
-          delay: 0,
-          reverseDirection: true,
-        },
-        breakpoints: {
-          0: {
-            spaceBetween: 32,
-          },
-          950: {
-            spaceBetween: 90,
-          },
-        },
-      });
-    });
-
-    this.targetAll.imagesLoaded(function () {
-
-      if ($('.c-gallery-card.swiper').length <= 0) {
-        return;
-      }
-
-      let bar = document.querySelector('.swiper-scrollbar');
-
-      const cultureGallerySwiper = new Swiper(".c-gallery-card.swiper", {
-        loop: true,
-        speed: 500,
-        slidesPerView: "auto",
-        slideToClickedSlide: true,
-        centeredSlides: true,
-        autoplay: {
-          delay: 3000,
-        },
         navigation: {
-          prevEl: ".swiper-button-prev",
-          nextEl: ".swiper-button-next",
-        },
-        pagination: {
-          el: bar,
-          type: 'progressbar',
-          draggable: true,
-        },
-      });
-    });
-
-    this.targetAll.imagesLoaded(function () {
-
-      if ($('.c-block-document__slider.swiper').length <= 0) {
-        return;
-      }
-
-      let delayTime = 3500;
-
-      const downloadSwiper = new Swiper(".c-block-document__slider.swiper", {
-        loop: true,
-        speed: 500,
-        autoplay: {
-          delay: delayTime,
-        },
-        navigation: {
-          prevEl: ".swiper-button-prev",
-          nextEl: ".swiper-button-next",
+          nextEl: next,
+          prevEl: prev,
         },
       });
     });
   }
+
+
+  textLoopSlider() {
+    const targetSelector = '.js-text-loop';
+
+    // ターゲット要素が存在しない場合、処理を終了する
+    if (!document.querySelector(targetSelector)) {
+      return;
+    }
+
+    const swiper = new Swiper(targetSelector, {
+      loop: true,
+      speed: 20000,
+      slidesPerView: "auto",
+      allowTouchMove: false,
+      autoplay: {
+        delay: 0,
+        disableOnInteraction: false,
+      },
+      breakpoints: {
+        0: {
+          spaceBetween: 32,
+        },
+        950: {
+          spaceBetween: 54,
+        },
+      },
+    });
+  }
+
 }

--- a/app/assets/js/app/utils.js
+++ b/app/assets/js/app/utils.js
@@ -213,6 +213,15 @@ export default class Utils {
         return requestAnimFrame;
     }
 
+
+  debounce(func) {
+    var timer;
+    return function (event) {
+      if (timer) clearTimeout(timer);
+      timer = setTimeout(func, 300, event);
+    };
+  }
+
   /**
    * matchMediaを使ったレスポンシブ対応を便利にする
    *

--- a/app/assets/scss/object/components/card.scss
+++ b/app/assets/scss/object/components/card.scss
@@ -5,25 +5,36 @@ category: Components
 ---
 */
 .c-card {
-  &__block {
-    width: 100%;
+
+  &__list {
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    gap: rem-calc(36);
+  }
+
+  &__card {
     display: block;
     text-decoration: none;
     color: $font-base-color;
     font-weight: 400;
 
-    span,
-    small {
-      display: block;
+    @include hover() {
+      opacity: 1;
+      color: $color-primary;
+
+      .c-card__image img {
+        transform: scale(1.05);
+      }
     }
   }
 
   &__image {
-    transition: all .2s;
+    aspect-ratio: 16 / 9;
+    overflow: hidden;
 
     img {
-      width: 100%;
-      height: auto;
+      @include img-option();
+      transition: transform .2s;
     }
   }
 
@@ -48,6 +59,36 @@ category: Components
       margin-top: rem-calc(6);
     }
   }
+
+
+  // スライドショーサンプル
+  &__slider {
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    gap: rem-calc(36);
+
+    @at-root .swiper-initialized & {
+      display: flex;
+      gap: 0;
+    }
+  }
+
+
+  &__slider-nav {
+    display: none;
+    @at-root .swiper-initialized & {
+      display: block;
+    }
+  }
+
+  &__slider-pagination {
+    display: none;
+    @at-root .swiper-initialized & {
+      display: block;
+    }
+  }
+
+
 }
 
 /*

--- a/app/assets/scss/object/components/gallery-logo.scss
+++ b/app/assets/scss/object/components/gallery-logo.scss
@@ -13,11 +13,11 @@
 
   &__image {
     position: relative;
-    width: 100%;
-    max-width: rem-calc(160);
+    width: rem-calc(240);
+    max-width: 100%;
 
     @include breakpoint(small down) {
-      max-width: rem-calc(120);
+      width: rem-calc(120);
     }
 
     img {
@@ -26,7 +26,14 @@
     }
   }
 
-  .swiper-wrapper {
+  &__images {
     transition-timing-function: linear;
+    display: flex;
+    gap: rem-calc(32);
+
+    @at-root .swiper-initialized & {
+      display: flex;
+      gap: 0;
+    }
   }
 }

--- a/app/download/page/index.pug
+++ b/app/download/page/index.pug
@@ -30,14 +30,15 @@ block body
               +loop(5)
                 +ae("/assets/images/img-card-01.jpg").image.js-modal-image
                   +img("img-card-01.jpg")
-            +e.slider.swiper
-              .swiper-wrapper
+            +e.slider.js-document-slider.swiper
+              +e.slider-wrapper.swiper-wrapper
                 +e.image.swiper-slide: .is-no NO IMAGE
                 +loop(3)
                   +e.image.swiper-slide: +img("img-card-01.jpg")
-              .swiper-nav
-                .swiper-button-prev
-                .swiper-button-next
+              +e.slider-nav.swiper-nav
+                +e.slider-prev.swiper-prev.js-document-slider-prev.swiper-button-prev
+                +e.slider-next.swiper-next.js-document-slider-next.swiper-button-next
+                
         .c-block-document__form
           +c.forms
             .c-heading.is-xs.is-mg-level-4 ダウンロードフォーム

--- a/app/format/components/_other.pug
+++ b/app/format/components/_other.pug
@@ -16,39 +16,65 @@ div.u-mbs.is-bottom
         +e.content(data-accordion-content="accordion--text")
           +e.icon.is-color-accent A
           +e.text ここにテキストが入ります。ここにテキストが入ります。ここにテキストが入ります。ここにテキストが入ります。ここにテキストが入ります。ここにテキストが入ります。ここにテキストが入ります。ここにテキストが入ります。ここにテキストが入ります。ここにテキストが入ります。ここにテキストが入ります。ここにテキストが入ります。ここにテキストが入ります。ここにテキストが入ります。ここにテキストが入ります。ここにテキストが入ります。
-div.u-mbs.is-bottom
-  +c.gallery-text.js-float-swiper.swiper
-    ul.swiper-wrapper
-      +loop(2)
-        li.swiper-slide: span TEXTGALLERY
 
+h3 カードスライダー
 div.u-mbs.is-bottom
-  +c.gallery-logo
-    .l-container
-      +h2.head.c-heading.is-md.is-center.is-mg-level-2 ロゴギャラリー
-    +loop(2)
-      +e.slider.swiper
+  +c.card.js-card-slider.swiper
+    +e.slider.swiper-wrapper
+      +e.block.swiper-slide
+        +e.image: +img("img-card-01.jpg","",712,420)
+        +e.content
+          h3.c-card__title スマホでスライダーになるサンプル
+          p.c-card__text ここにテキストが入ります。ここにテキストが入ります。ここにテキストが入ります。ここにテキストが入ります。ここにテキストが入ります。
+      +e.block.swiper-slide
+        +e.image: +img("img-card-01.jpg","",712,420)
+        +e.content
+          h3.c-card__title スマホでスライダーになるサンプル
+          p.c-card__text ここにテキストが入ります。ここにテキストが入ります。ここにテキストが入ります。ここにテキストが入ります。ここにテキストが入ります。
+
+    +e.slider-nav
+      +button.button-prev.js-card-slider-prev < 前へ
+      +button.button-next.js-card-slider-next > 次へ
+    +e.slider-pagination.js-card-slider-pagination
+div.u-mbs.is-bottom
+  +c.card.js-card-slider.swiper
+    +e.slider.swiper-wrapper
+      +e.block.swiper-slide
+        +e.image: +img("img-card-01.jpg","",712,420)
+        +e.content
+          h3.c-card__title スマホでスライダーになるサンプル
+          p.c-card__text ここにテキストが入ります。ここにテキストが入ります。ここにテキストが入ります。ここにテキストが入ります。ここにテキストが入ります。
+      +e.block.swiper-slide
+        +e.image: +img("img-card-01.jpg","",712,420)
+        +e.content
+          h3.c-card__title スマホでスライダーになるサンプル
+          p.c-card__text ここにテキストが入ります。ここにテキストが入ります。ここにテキストが入ります。ここにテキストが入ります。ここにテキストが入ります。
+
+    +e.slider-nav
+      +button.button-prev.js-card-slider-prev < 前へ
+      +button.button-next.js-card-slider-next > 次へ
+    +e.slider-pagination.js-card-slider-pagination
+
+  h3 横に流れ続けるスライダー
+  div.u-mbs.is-bottom
+    +c.gallery-text.js-text-loop.swiper
+      ul.swiper-wrapper
+        +loop(2)
+          li.swiper-slide: span TEXTGALLERY
+
+  div.u-mbs.is-bottom
+    +c.gallery-logo
+      .l-container
+        +h2.head.c-heading.is-md.is-center.is-mg-level-2 ロゴギャラリー
+
+      +e.slider.js-logo-slider.swiper
         +e.images.swiper-wrapper
-          +loop(10)
-            +e.image.swiper-slide: +img("logo.png")
+          for num in [1,2]
+            - var img = "https://placehold.jp/3d4070/ffffff/300x80.png?text=" + num + ".png"
+            +e.image.swiper-slide: +img(img)
 
-div.u-mbs.is-bottom
-  +c.gallery-card.swiper
-    .l-container
-      +h2.head.c-heading.is-md.is-center.is-mg-level-2 会社紹介ギャラリー
-    +e.cards.swiper-wrapper
-      +e.card.swiper-slide
-        +e.image: +img("img-sample.jpg","",803, 451)
-        +e.text テキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキスト
-      +e.card.swiper-slide
-        +e.image: +img("img-sample.jpg","",803, 451)
-        +e.text テキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキスト
-      +e.card.swiper-slide
-        +e.image: +img("img-sample.jpg","",803, 451)
-        +e.text テキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキスト
-    .l-container
-      .swiper-content
-        .swiper-scrollbar
-        .swiper-nav
-          .swiper-button-prev
-          .swiper-button-next
+      +e.slider.js-logo-slider.swiper
+        +e.images.swiper-wrapper
+          for num in [1,2,3,4,5,6]
+            - var img = "https://placehold.jp/3d4070/ffffff/300x80.png?text=" + num + ".png"
+            +e.image.swiper-slide: +img(img)

--- a/app/inc/mixins/_main-visual.pug
+++ b/app/inc/mixins/_main-visual.pug
@@ -1,14 +1,14 @@
 //- メインビジュアル
 mixin c_main-visual
   +c.main-visual
-    +e.wrapper.swiper
+    +e.wrapper.js-main-visual.swiper
       +e.slider.swiper-wrapper
         +loop(3)
           +e.image.swiper-slide
             +picture("img-main-visual-01.jpg", "img-sample.jpg","", 1600, 620, 803, 451)
       +e.animation
-        +e.bar: span
-        +e.pagination
+        +e.bar.js-main-visual-bar: span
+        +e.pagination.js-main-visual-pagination
       +e.inner
         .l-container
           +e.title: +img("img-main-visual-text.png","キャッチコピーが入ります",1048,118)

--- a/app/index.pug
+++ b/app/index.pug
@@ -21,25 +21,22 @@ block body
       +heading-xlg("私たちについて", "ABOUT").is-bottom
       p.u-text-center テキストテキストテキストテキストテキストテキストテキストテキストテキスト<br>テキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキスト
       +c.card.u-mbs.is-top.is-lg
-        .row.slide
-          .large-4.small-12
-            +e.block
-              +e.image: +img("img-card-01.jpg","",712,420)
-              +e.content
-                h3.c-card__title コンセプトタイトル
-                p.c-card__text ここにテキストが入ります。ここにテキストが入ります。ここにテキストが入ります。ここにテキストが入ります。ここにテキストが入ります。
-          .large-4.small-12
-            +e.block
-              +e.image: +img("img-card-01.jpg","",712,420)
-              +e.content
-                h3.c-card__title コンセプトタイトル
-                p.c-card__text ここにテキストが入ります。ここにテキストが入ります。ここにテキストが入ります。ここにテキストが入ります。ここにテキストが入ります。
-          .large-4.small-12
-            +e.block
-              +e.image: +img("img-card-01.jpg","",712,420)
-              +e.content
-                h3.c-card__title コンセプトタイトル
-                p.c-card__text ここにテキストが入ります。ここにテキストが入ります。ここにテキストが入ります。ここにテキストが入ります。ここにテキストが入ります。
+        +e.list
+          +ae("#").card
+            +e.image: +img("img-card-01.jpg","",712,420)
+            +e.content
+              +h3.title コンセプトタイトル
+              +p.text ここにテキストが入ります。ここにテキストが入ります。ここにテキストが入ります。ここにテキストが入ります。ここにテキストが入ります。
+          +e.card
+            +e.image: +img("img-card-01.jpg","",712,420)
+            +e.content
+              +h3.title コンセプトタイトル
+              +p.text ここにテキストが入ります。ここにテキストが入ります。ここにテキストが入ります。ここにテキストが入ります。ここにテキストが入ります。
+          +e.card
+            +e.image: +img("img-card-01.jpg","",712,420)
+            +e.content
+              +h3.title コンセプトタイトル
+              +p.text ここにテキストが入ります。ここにテキストが入ります。ここにテキストが入ります。ここにテキストが入ります。ここにテキストが入ります。
   section.l-section.is-lg.is-top
     .l-container
       +heading-xlg("事業内容", "SERVICE").is-bottom


### PR DESCRIPTION
▼改善事項
https://www.notion.so/growgroup/gg-styleguide-swiper-5b61aae658b3490e908cde35a2661a28

## 動画
https://capture.dropbox.com/QUrg0wshbYTDVpos
※会社紹介ギャラリー として設置してあったサンプルは、
　カードスライダー（スマホとPCで発火最小枚数をが異なる）のサンプルに置き換わりました。

## 対応したこと
### 全体的なコードの書き方の整理
- メソッドを分けてコードの見通しをよくする
- jQuery非依存の書き方でいったん統一（追加するときはjQueryでも可）
- imagesLoadedのimport処理を heightline.jsに依存しないようにする
- コーディング規約に基づき、js発火用classとスタイリング用classを分ける（jsでCSSセレクタを使う場合 `js-` にする）


### スライド枚数によって処理を調整する系サンプルコードの追加

※サンプルの各HTML（pug）は TOP、 /format/ 、/download/page/ 上にあります。

#### たんにスライド枚数によって発火するかしないか切り替える
https://github.com/growgroup/gg-styleguide/blob/eec6932a150c5f5f74d4cfe47e8b45f6a1611714/app/assets/js/app/swiper.js#L98-L102

#### ロゴループスライダーなど、スライド枚数が不足していたらswiper外で複製する
※そもそもロゴループスライダーの動作が不安定なのだがそれはいったん考えないものとする
https://github.com/growgroup/gg-styleguide/blob/9a270ab1b171ff333ac136e4686b77e5117c9769/app/assets/js/app/swiper.js#L152-L166

#### PCとSPで発火するかしないかの切り替え判断スライド枚数が異なる
https://github.com/growgroup/gg-styleguide/blob/eec6932a150c5f5f74d4cfe47e8b45f6a1611714/app/assets/js/app/swiper.js#L248-L282

#### スライドが発火しているかしていないかで当てるCSSを変える
https://github.com/growgroup/gg-styleguide/blob/eec6932a150c5f5f74d4cfe47e8b45f6a1611714/app/assets/scss/object/components/card.scss#L64-L89

