### PR TITLE
[update] normalize : 改行系

### DIFF
--- a/app/assets/scss/foundation/_mixin-post-content.scss
+++ b/app/assets/scss/foundation/_mixin-post-content.scss
@@ -8,7 +8,7 @@
 //l-post-content内のスタイルはすべてここに記述すること ※@extend使わない
 @mixin l-post-content {
   display: flow-root;
-  word-break: break-all;
+  //word-break: break-all;
 
   > * + * { //投稿内の各ブロックの間に1emのマージンを設定
     margin-top: 1em;

--- a/app/assets/scss/foundation/_normalize.scss
+++ b/app/assets/scss/foundation/_normalize.scss
@@ -46,6 +46,9 @@ body {
   font-size: $font-base-size;
   font-feature-settings: 'liga';
   -webkit-font-smoothing: antialiased;
+  overflow-wrap: anywhere; /* 収まらない場合に折り返す */
+  word-break: normal; /* 単語の分割はデフォルトに依存 */
+  line-break: strict; /* 禁則処理を厳格に適用 */
 
   &.is-slidebar-active {
     overflow: hidden;


### PR DESCRIPTION
▼改善事項
https://www.notion.so/growgroup/CSS-dd31f6f1f989431784853c4b6eeeb40a

## やったこと
https://ics.media/entry/240411/ のおすすめ設定を反映し、
l-post-contentにある `word-break: break-all;` を削除

## 理由：以下の問題を解決するため
- word-break: break-all;では英語の場合に単語の途中で改行されてしまい、文章の意味が分からなくなる
- word-break無しだとURLが改行せず、コンテンツをぶち抜いてしまう問題がある

## 結果
▼サンプル（このテキストはGit内には反映していません）
- URLは自動改行する
- 英単語内での改行は起きない

![CleanShot 2024-08-27 at 10 43 12@2x](https://github.com/user-attachments/assets/62457c2b-0851-4bc1-a7e4-80baac9bb7ef)
