### PR TITLE
breakpoint() で生成するメディアクエリを漏れ無しダブり無しになるよう修正

### DIFF
--- a/app/assets/scss/foundation/_mixin.scss
+++ b/app/assets/scss/foundation/_mixin.scss
@@ -5,181 +5,170 @@
 
 @use "sass:math";
 
+// 数値の単位を削除する関数
 @function strip-unit($number) {
+  // 数値が単位付きの場合
   @if type-of($number) == 'number' and not unitless($number) {
+    // 単位を削除するために1で割る
     @return math.div($number, $number * 0 + 1);
   }
-
+  // 単位が無い場合はそのまま返す
   @return $number;
 }
 
-// rem へ変換
+// 値をremに変換する関数
 @function to-rem($value, $base: null) {
+  // 値が数値でない場合の警告
   @if type-of($value) != 'number' {
     @warn inspect($value) + ' was passed to rem-calc(), which is not a number.';
     @return $value;
   }
-
+  // 値がremでない場合
   @if unit($value) != 'rem' {
     $value: math.div(strip-unit($value), strip-unit($base)) * 1rem;
   }
-
+  // 値が0remの場合
   @if $value == 0rem {
     $value: 0;
   }
+  // 最終的なrem値を返す
   @return $value;
 }
 
-// rem 計算
+// remを計算する関数
 @function rem-calc($values, $base: null) {
+  // 結果を保存するリスト
   $rem-values: ();
+  // 入力された値の長さ
   $count: length($values);
-
+  // 基準値がnullの場合、デフォルトサイズを使用
   @if $base == null {
     $base: $font-html-size;
   }
-
+  // 基準値が%の場合、pxに変換
   @if unit($base) == '%' {
     $base: math.div($base, 100%) * 16px;
   }
-
+  // 入力された値が一つだけの場合
   @if $count == 1 {
     @return to-rem($values, $base);
   }
-
+  // すべての値をremに変換してリストに追加
   @for $i from 1 through $count {
     $rem-values: append($rem-values, to-rem(nth($values, $i), $base));
   }
-
+  // 最終的なrem値のリストを返す
   @return $rem-values;
 }
 
-// em へ変換
+// 値をemに変換する関数
 @function to-em($value) {
+  // 値がpxまたは単位なしの場合、remに変換
   @if unit($value) == 'px' or unitless($value) {
     $value: rem-calc($value, $base: 16px);
   }
+  // 単位を取り除きemを掛ける
   @return strip-unit($value) * 1em;
 }
 
-// ブレイクポイントのテキストを返す
+// ブレイクポイントのメディアクエリ文字列を返し、方向も返す関数
 @function breakpoint($val: small) {
+  $bp: nth($val, 1); // ブレイクポイントの値
+  $bp-max: 0; // 最大値の初期化
+  $dir: if(length($val) > 1, nth($val, 2), up); // 方向の設定
+  $named: false; // Namedフラグの初期化
 
-  $bp: nth($val, 1);
-
-  $bp-max: 0;
-
-  $dir: if(length($val) > 1, nth($val, 2), up);
-
-  $str: '';
-
-  $named: false;
-
-  @if $bp == 'landscape' or $bp == 'portrait' {
-    @return '(orientation: #{$bp})';
-  }
-  @else if $bp == 'retina' {
-    @return '(-webkit-min-device-pixel-ratio: 2), (min-resolution: 192dpi)';
-  }
-
-
+  // ブレイクポイントが文字列の場合
   @if type-of($bp) == 'string' {
+    // ブレイクポイントが設定に存在する場合
     @if map-has-key($breakpoints, $bp) {
+      // 方向が'only'または'down'の場合、最大値を設定
       @if $dir == 'only' or $dir == 'down' {
-        $next-bp: map-next($breakpoints, $bp);
-
+        $next-bp: map-next($breakpoints, $bp); // 次のブレイクポイントを取得
+        // 次のブレイクポイントがない場合の警告
         @if $next-bp == null {
           $bp-max: null;
           @warn 'breakpoint(): the media query "#{$val}" cannot be used because #{$bp} is the largest breakpoint.';
         }
+          // 次のブレイクポイントを最大値に設定
         @else {
           $bp-max: $next-bp;
         }
       }
-
-      $bp: map-get($breakpoints, $bp);
-      $named: true;
+      $bp: map-get($breakpoints, $bp); // 現在のブレイクポイント値を取得
+      $named: true; // Namedフラグをtrueに設定
     }
+      // ブレイクポイントが設定に存在しない場合
     @else {
       $bp: 0;
     }
+  } @else {
+    // ブレイクポイントが数値の場合
+    @if $dir == 'only' or $dir == 'down' {
+      $bp-max: $bp;
+    }
   }
-
-  $bp: to-em($bp);
+  $bp: to-em($bp); // ブレイクポイント値をemに変換
+  // ブレイクポイント最大値がある場合、emに変換して微調整
   @if $bp-max {
-    $bp-max: to-em($bp-max) - math.div(1, 16);
+    $bp-max: to-em($bp-max);
   }
 
-  @if $bp > 0em or $dir == 'only' or $dir == 'down' {
-
-    @if $dir == 'only' {
-      @if $named == true {
-        $str: $str + '(min-width: #{$bp})';
-
-        @if $bp-max != null {
-          $str: $str + ' and (max-width: #{$bp-max})';
-        }
-      }
-      @else {
-        @warn 'Only named media queries can have an `only` range.';
-      }
-    }
-
-    @else if $dir == 'down' {
-      $max: 0;
-
-      @if $named {
-        $max: $bp-max;
-      }
-      @else {
-        $max: $bp;
-      }
-
-      @if $named or $bp > 0em {
-        $str: $str + '(max-width: #{$max})';
-      }
-    }
-    @else if $bp > 0em {
-      $str: $str + '(min-width: #{$bp})';
-    }
-  }
-  @return $str;
+  // 最終的なメディアクエリ文字列と方向をリストで返す
+  @return ($bp, $bp-max, $dir);
 }
 
-
-// ブレイクポイントを出力
+// ブレイクポイントのメディアクエリを出力するミキシン
 @mixin breakpoint($value) {
-  $str: breakpoint($value);
+  $result: breakpoint($value); // ブレイクポイントの値を取得
+  $bp: nth($result, 1); // サイズを取得
+  $bp-max: nth($result, 2); // サイズを取得2
+  $dir: nth($result, 3); // 方向を取得
 
-  @if $str == '' {
+  // 方向指定なしの場合はそのまま内容を出力
+  @if $dir == '' {
     @content;
   }
-
+    // メディアクエリがある場合、条件付きで内容を出力
   @else {
-    @media screen and #{$str} {
-      @content;
+    @if $dir == 'only' {
+      @media screen and (max-width: #{$bp-max}) {
+        @media not screen and (max-width: #{$bp}) {
+          @content;
+        }
+      }
+    } @else if $dir == 'down' {
+      @media screen and (max-width: #{$bp-max}) {
+        @content;
+      }
+    } @else if $dir == 'up' {
+      @media not screen and (max-width: #{$bp}) {
+        @content;
+      }
     }
   }
 }
 
-
-// map にアクセス
+// mapの次の値を取得する関数
 @function map-next($map, $key) {
-  $values: map-values($map);
-
-  $i: 1;
-  $found: false;
+  $values: map-values($map); // mapの値のリスト
+  $i: 1; // インデックスの初期値
+  $found: false; // 発見フラグの初期化
+  // mapのキーを順に確認
   @each $val in map-keys($map) {
     @if $found == false {
+      // キーが見つかった場合、次のループで値を取得
       @if ($key == $val) {
         $found: true;
       }
       $i: $i + 1;
     }
   }
+  // 最後の値を超えた場合はnullを返す
   @if $i > length($map) {
     @return null;
   }
+    // 次の値を返す
   @else {
     @return nth($values, $i);
   }

--- a/app/assets/scss/foundation/_mixin.scss
+++ b/app/assets/scss/foundation/_mixin.scss
@@ -108,14 +108,34 @@
       $bp-max: $bp;
     }
   }
-  $bp: to-em($bp); // ブレイクポイント値をemに変換
+
+
+  // ブレイクポイント値をemに変換して微調整
+  @if $bp {
+    $bp: to-em($bp) - math.div(1, 16);
+  }
+
   // ブレイクポイント最大値がある場合、emに変換して微調整
   @if $bp-max {
-    $bp-max: to-em($bp-max);
+    $bp-max: to-em($bp-max) - math.div(1, 16);
+  }
+
+  // dir が upで bpが0の場合、dirを''に設定
+  @if $dir == 'up' and $bp <= 0em {
+    $dir: '';
+  }
+
+  // dir が onlyで bpが0の場合、dirをdownに設定
+  @if $dir == 'only' and $bp <= 0em {
+    $dir: 'down';
   }
 
   // 最終的なメディアクエリ文字列と方向をリストで返す
-  @return ($bp, $bp-max, $dir);
+  @return (
+    $bp,
+    $bp-max,
+    $dir
+  );
 }
 
 // ブレイクポイントのメディアクエリを出力するミキシン
@@ -128,9 +148,8 @@
   // 方向指定なしの場合はそのまま内容を出力
   @if $dir == '' {
     @content;
-  }
+  } @else {
     // メディアクエリがある場合、条件付きで内容を出力
-  @else {
     @if $dir == 'only' {
       @media screen and (max-width: #{$bp-max}) {
         @media not screen and (max-width: #{$bp}) {

--- a/webpack.style.config.babel.js
+++ b/webpack.style.config.babel.js
@@ -55,7 +55,8 @@ module.exports = (env, argv) => {
                       [
                         'postcss-sort-media-queries',
                         {
-                          sort: 'desktop-first'
+                          sort: 'desktop-first',
+                          onlyTopLevel: true,
                         }
                       ],
                     ],


### PR DESCRIPTION
▼関連改善事項
https://www.notion.so/growgroup/CSS-105eef14914a80a28fe6ffeeb3fb435d

# 修正前後の変化のイメージ
![CleanShot 2024-09-18 at 22 20 44@2x](https://github.com/user-attachments/assets/257715e6-5dcd-4010-b128-87285ac486c6)

# なぜ修正が必要か
参考：「幅変更でスタイル消失!?「メディアクエリ設定」の落とし穴」 https://liginc.co.jp/421566
ブラウザまたは表示スケール（windows）が100%以外の値になっているとき、
小数を持つ表示領域幅が発生する可能性がある。

.l-headerのナビを消し.c-slidebar-button を表示させるときのように
min-width(750px)とmax-width(749px)を使うと、749.5pxのときはどちらのCSSも当たっていない状態になるため
※メディアクエリは実際にはem値

# 修正方法
- downのときは max-widthを従来通り使う
- upのときは min-widthではなく notでdownのときのメディアクエリを否定する
- onlyのときはメディアクエリの入れ子を使う

## Range Syntaxを使わない理由
- Range SyntaxはiOS16.4から対応であり2024年9月時点だとまだ利用に慎重になる必要があるため

# 検証1 postcss-sort-media-queriesによるソートで問題が起きていないか
もっともよく使う以下のスタイルの上書きで確認

### SCSS
```
.c-hoge {
  color: green;
  @include breakpoint(medium down){
    color:blue;
  }
  @include breakpoint(small only){
    color:red;
  }
```
### CSS出力順

```
.c-hoge {
  color: green;
}
@media screen and (max-width: 59.3125em) {
    .c-hoge {
        color: blue;
    }
}
@media screen and (max-width: 46.8125em) {
    .c-hoge {
        color: red;
    }
}
```

→ desktop first の順で出力できている

# 検証2 各メディアクエリはどう変更されたか
## 1200 up

### 旧(1200px以上)
```
@media screen and (min-width: 75em) {

}
```

### 新（1199pxを超える）
```
@media not screen and (max-width: 74.9375em) {

}
```


## 1200 down

### 旧（1200px以下）
```
@media screen and (max-width: 75em) {

}
```


### 新（1199px以下）
```
@media screen and (max-width: 74.9375em) {

}
```


## large up
### 旧（950px以上）
```
@media screen and (min-width: 59.375em) {

}
```

### 新（949pxを超える）
```
@media not screen and (max-width: 59.3125em) {

}
```


## large down
### 旧も新も同じ（1139px以下）
```
@media screen and (max-width: 71.1875em) {

}
```

## large only

### 旧（950px以上かつ1139px以下）
```
@media screen and (min-width: 59.375em) and (max-width: 71.1875em) {

}
```

### 新（949pxを超えるかつ1139px以下）
```
@media screen and (max-width: 71.1875em) {
    @media not screen and (max-width: 59.3125em) {
    
    }
}
```

## medium up

### 旧（750px以上）
```
@media screen and (min-width: 46.875em) {

}
```

### 新（749pxを超える）
```
@media not screen and (max-width: 46.8125em) {

}
```

## medium down

### 旧も新も同じ（949px以下）
```
@media screen and (max-width: 59.3125em) {

}
```

##medium only

### 旧（750px以上かつ949px以下）
```
@media screen and (min-width: 46.875em) and (max-width: 59.3125em) {

}
```

### 新（749pxを超えるかつ949px以下）
```
@media screen and (max-width: 59.3125em) {
    @media not screen and (max-width: 46.8125em) {
    }
}
```


## small down

### 旧も新も同じ（749px以下）
```
@media screen and (max-width: 46.8125em) {

}
```


## small up(意味ない)

### 旧
メディアクエリの出力無し

### 新
メディアクエリの出力無し


## small only

### 旧（0px以上かつ749px以下）
```
@media screen and (min-width: 0em) and (max-width: 46.8125em) {

}
```

### 新（749px以下　※新しいsmall downと同じ）
```
@media screen and (max-width: 46.8125em) {

}
```

→直接数値指定のものを除けば、downの時の値には変更なし