### PR TITLE
c-tableのスタイルをtbodyのみ→theadのth, tdにもスタイルが当たるように変更

### DIFF
--- a/app/assets/scss/foundation/_mixin-post-content.scss
+++ b/app/assets/scss/foundation/_mixin-post-content.scss
@@ -154,27 +154,50 @@
   width: 100%;
   border-top: 1px solid $border-base-color;
 
-  tbody {
-    th,
-    td {
-      text-align: left;
-      border-bottom: 1px solid $border-base-color;
-      padding: rem-calc(24);
-      vertical-align: top;
-      @include breakpoint(small only) {
-        padding: rem-calc(12);
-      }
-    }
+  //▼WordPressのスタイルをリセットするためのCSS
+  thead {
+    border: 0;
+  }
+  th, td {
+    border: 0;
+  }
+  //▲ここまでWordPressのスタイルをリセットするためのCSS
 
+
+  //thead tbody共通スタイル
+  th, td {
+    text-align: left;
+    border-bottom: 1px solid $border-base-color;
+    padding: rem-calc(24);
+    vertical-align: top;
+    @include breakpoint(small only) {
+      padding: rem-calc(12);
+    }
+  }
+
+  th {
+    color: $color-primary;
+    border-bottom: 1px solid $color-primary;
+  }
+
+
+  //thead専用スタイル
+  thead {
+
+  }
+
+  //tbody専用スタイル
+  tbody {
     th {
-      color: $color-primary;
       width: rem-calc(196);
-      border-bottom: 1px solid $color-primary;
       @include breakpoint(small only) {
         width: rem-calc(96);
       }
     }
   }
+
+  //table自体にmodifierをつける場合は、 components/table.scssに記載する
+
 }
 
 

--- a/app/format/components/_text.pug
+++ b/app/format/components/_text.pug
@@ -112,6 +112,10 @@ div.u-mbs.is-bottom
 // テーブル
 div.u-mbs.is-bottom
   table.c-table
+    thead
+      tr
+        th thテキスト(thead)
+        th thテキスト(thead)
     tbody
       tr
         th thテキスト


### PR DESCRIPTION
▼改善事項
https://www.notion.so/growgroup/l-post-content-table-thead-CSS-be914716374b4324ba8e777fccc60481

---

# 行ったこと
- tbodyのth,tdのみにスタイルを付ける設定になっていたものについて、tbodyのみの縛りを外す
- WordPressのコアブロックのスタイルの影響を考慮したデフォルトのスタイル設定を追加

## before
![CleanShot 2024-09-24 at 09 03 57@2x](https://github.com/user-attachments/assets/f5fbe768-0254-44b5-9939-a87bc4ecaeb9)

## after 
![CleanShot 2024-09-24 at 09 04 19@2x](https://github.com/user-attachments/assets/e55b9c6e-9dcd-435a-9fc1-088374f58628)
