### PR TITLE
editor.scssの &.post-type-post を &.post-type-post .is-root-container に

### DIFF
--- a/app/assets/scss/editor.scss
+++ b/app/assets/scss/editor.scss
@@ -50,8 +50,7 @@
 #growp-editor-wrapper {
   font-family: $font-base-family !important;
 
-  &.post-type-post, //投稿画面
-    //&.post-type-hoge //他投稿タイプ
+  &:is(.post-type-post) .is-root-container //投稿画面
   {
     //max-width: rem-calc(736);
     @include l-post-content;


### PR DESCRIPTION
`.l-post-content > * + *`のスタイルが
そのまま`#growp-editor-wrapper.post-type-post  > * + *` で出力されると
意図通りにはCSS適用されない問題の対応