### PR TITLE
slidebar.js内の画面幅指定箇所をdefaultOptions＆ページ内リンク用の記述のコメントアウトを外す＆slidebar-menu.scssの調整

### DIFF
--- a/app/assets/js/app/slidebar.js
+++ b/app/assets/js/app/slidebar.js
@@ -33,6 +33,7 @@ var defaultOptions = {
   containerSelector: '.js-slidebar-container',
   buttonSelector: '.js-slidebar-button',
   menuSelector: '.js-slidebar-menu',
+  activateWidth: 950,//950px未満の場合のみ有効化。PCでもslidebarを利用する場合はnullを設定
   slideSpeed: 500
 }
 
@@ -45,7 +46,10 @@ export default class Slidebar {
     this.isActive = false;
 
     this.init();
-    this.setupResizeObserver(); // ResizeObserverをセットアップ
+
+    if (this.options.activateWidth !== null) {
+      this.setupResizeObserver(); // ResizeObserverをセットアップ
+    }
   }
 
   /**
@@ -75,9 +79,9 @@ export default class Slidebar {
     });
 
     // ページ内リンク時の挙動
-    // $(".c-slidebar-menu a[href*=\"#\"]").on('click', function (e) {
-    //   self.close();
-    // });
+    this.menu.find("a[href*='#']").on('click', function (e) {
+      self.close();
+    });
   }
 
   /**
@@ -151,7 +155,7 @@ export default class Slidebar {
   setupResizeObserver() {
     const resizeObserver = new ResizeObserver(entries => {
       for (const entry of entries) {
-        if (entry.contentRect.width >= 950) {
+        if (entry.contentRect.width > this.options.activateWidth) {
           document.body.classList.remove("is-slidebar-active");
           this.isActive = false;
           this.menu.attr("inert", "true");

--- a/app/assets/scss/object/components/slidebar-menu.scss
+++ b/app/assets/scss/object/components/slidebar-menu.scss
@@ -4,241 +4,244 @@
   }
 }
 
-@include breakpoint(medium down) {
 
-  .c-slidebar-menu {
-    height: calc(100vh - #{$slidebar-header-height}px);
-    padding: 0 0 rem-calc(104);
-    position: fixed;
-    background-color: $slidebar-menu-bg;
-    z-index: 9980;
-    width: $slidebar-menu-width;
-    transform: translate3d(100%, 0px, 0px);
-    right: 0;
-    transition: $slidebar-menu-eaasing;
-    overflow-x: scroll;
-    top: 0;
-    -webkit-overflow-scrolling: touch;
+.c-slidebar-menu {
+  height: calc(100vh - #{$slidebar-header-height}px);
+  padding: 0 0 rem-calc(104);
+  position: fixed;
+  background-color: $slidebar-menu-bg;
+  z-index: 9980;
+  width: $slidebar-menu-width;
+  transform: translate3d(100%, 0px, 0px);
+  right: 0;
+  transition: $slidebar-menu-eaasing;
+  overflow-x: scroll;
+  top: 0;
+  -webkit-overflow-scrolling: touch;
 
-    &.is-active {
-      height: calc(100% - 60px);
-    }
+  &.is-active {
+    height: calc(100% - 60px);
+  }
 
-    // 上から下へ
-    &.is-top-to-bottom {
-      transform: translate3d(0px, -100%, 0px);
-      //transform: translate3d(0, 0, 0); // 表示デバッグ時
-      width: 100%;
-      opacity: 0; // 表示デバッグ時は1
-    }
+  // 上から下へ
+  &.is-top-to-bottom {
+    transform: translate3d(0px, -100%, 0px);
+    //transform: translate3d(0, 0, 0); // 表示デバッグ時
+    width: 100%;
+    opacity: 0; // 表示デバッグ時は1
+  }
 
-    // メニュー要素（一番外・全体で共通する設定）
-    &__list {
-      width: 100%;
-      background: $color-primary;
-      font-size: rem-calc(14);
-      font-weight: 700;
+  // メニュー要素（一番外・全体で共通する設定）
+  &__list {
+    width: 100%;
+    background: $color-primary;
+    font-size: rem-calc(14);
+    font-weight: 700;
 
-      a, span {
-        display: flex;
-        align-items: center;
-        justify-content: space-between;
-        color: inherit;
-        font-weight: inherit;
-        text-decoration: none;
-        position: relative;
-
-        &::after {
-          content: "navigate_next";
-          @include icon-font();
-        }
-      }
-
-      [data-accordion-title] {
-
-        &::after {
-          content: "add";
-        }
-      }
-    }
-
-    &__parent { //親li
-      color: $color-white;
-      border-bottom: solid 1px rgba(255,255,255,0.4);
-      &.is-open{
-        //background: $color-white;
-        //color: $color-primary;
-        & > [data-accordion-title]{
-
-          &::after {
-            content: "remove";
-          }
-        }
-      }
-    }
-
-    &__parent-link { //親a, span
-      cursor: pointer;
-      padding:rem-calc(18) rem-calc(46) rem-calc(18) rem-calc(20);
-    }
-
-    // メニュー要素（子）
-    &__children {
-      font-size: rem-calc(13);
-      width: 100%;
-      padding-left: rem-calc(20);
-      padding-bottom: rem-calc(20);
-      display: none;
-    }
-
-    &__child { //子li
-      //color: $color-white;
-      background: rgba(0,0,0,0.2);
-      margin-bottom: rem-calc(4);
-
-      &.is-open{
-        //color: $color-primary;
-        & > [data-accordion-title]{
-
-          &::after {
-            content: "remove";
-          }
-        }
-      }
-    }
-
-    &__child-link { //子a, span
-      padding:rem-calc(13) rem-calc(48) rem-calc(13) rem-calc(20);
-    }
-
-    // メニュー要素（孫）
-    &__grandchildren {
-      font-size: rem-calc(12);
-      font-weight: 400;
-      width: 100%;
-      display: none;
-      border-top: solid 1px $border-base-color;
-      padding-left: rem-calc(26);
-    }
-
-    &__grandchild { //孫li
-      //color: $color-white;
-      border-top: solid 1px $border-base-color;
-      &:first-child{
-        border-top: 0;
-      }
-    }
-
-    &__grandchild-link { //孫a, span
-      padding:rem-calc(12) rem-calc(40) rem-calc(12) rem-calc(0);
-    }
-
-    //大きいボタン（お問い合わせなど）
-    &__buttons{
-      margin-top: rem-calc(20);
-      padding:0 rem-calc(20);
-    }
-    &__button + &__button{
-      margin-top: rem-calc(8);
-    }
-    &__button {
-      max-width: 100%;
-      font-weight: bold;
-      font-size: rem-calc(18);
-      color: $color-primary;
-      background-color: $color-white;
-      padding:rem-calc(24);
-      text-align: center;
-
-      &::after {
-        content: none;
-      }
-      &__icon {
-        display: inline;
-        vertical-align: rem-calc(-6);
-        line-height: 1;
-        font-size: rem-calc(24);
-        margin-right: rem-calc(8);
-      }
-    }
-
-    //SNSボタンなど小さいボタン
-    &__sns-btns {
-      max-width: 100%;
-      margin-top: rem-calc(24);
-      display: flex;
-      justify-content: center;
-      line-height: 1;
-    }
-
-    &__sns-btn {
-      background: $color-white;
-      color: $color-primary;
-      text-decoration: none;
-      //font-size: rem-calc(24);
-      margin: 0 rem-calc(8);
-      width: rem-calc(44);
-      height: rem-calc(44);
-      border-radius: rem-calc(44);
+    a, span {
       display: flex;
       align-items: center;
-      justify-content: center;
-    }
-
-    &__search {
-      //border: 1px solid $border-base-color;
-      //color: $font-base-color;
+      justify-content: space-between;
+      color: inherit;
+      font-weight: inherit;
+      text-decoration: none;
       position: relative;
-      display: block;
-      margin-bottom: rem-calc(22);
-      max-width: 100%;
-      width: 100%;
-      border: 1px solid $color-primary;
-      color: $color-gray;
-      background: $color-white;
-      border-radius: rem-calc(23);
-      font-size: rem-calc(16);
-      letter-spacing: 0.1em;
-      line-height: 1.5;
-      font-weight: 400;
-      height: rem-calc(46);
-      transition: all 0.2s ease-out;
 
-      &:before {
-        position: absolute;
-        left: rem-calc(18);
-        top: 50%;
-        transform: translateY(-50%);
-        line-height: 1;
-        background-repeat: no-repeat;
-        background-position: center center;
-        background-size: cover;
+      &::after {
+        content: "navigate_next";
         @include icon-font();
-        content: "search";
-        font-size: rem-calc(18);
-        color: $color-primary;
-      }
-
-      &:hover,
-      &.is-active {
       }
     }
 
-    &__search-icon {
-      display: none;
+    [data-accordion-title] {
+
+      &::after {
+        content: "add";
+      }
     }
   }
 
-  // 有効時
-  .is-slidebar-active {
+  &__parent { //親li
+    color: $color-white;
+    border-bottom: solid 1px rgba(255, 255, 255, 0.4);
 
-    .c-slidebar-menu {
-      transform: translate3d(0, 0, 0);
+    &.is-open {
+      //background: $color-white;
+      //color: $color-primary;
+      & > [data-accordion-title] {
 
-      &.is-top-to-bottom {
-        transform: translate3d(0, #{$slidebar-header-height}px, 0);
-        opacity: 1;
+        &::after {
+          content: "remove";
+        }
       }
+    }
+  }
+
+  &__parent-link { //親a, span
+    cursor: pointer;
+    padding: rem-calc(18) rem-calc(46) rem-calc(18) rem-calc(20);
+  }
+
+  // メニュー要素（子）
+  &__children {
+    font-size: rem-calc(13);
+    width: 100%;
+    padding-left: rem-calc(20);
+    padding-bottom: rem-calc(20);
+    display: none;
+  }
+
+  &__child { //子li
+    //color: $color-white;
+    background: rgba(0, 0, 0, 0.2);
+    margin-bottom: rem-calc(4);
+
+    &.is-open {
+      //color: $color-primary;
+      & > [data-accordion-title] {
+
+        &::after {
+          content: "remove";
+        }
+      }
+    }
+  }
+
+  &__child-link { //子a, span
+    padding: rem-calc(13) rem-calc(48) rem-calc(13) rem-calc(20);
+  }
+
+  // メニュー要素（孫）
+  &__grandchildren {
+    font-size: rem-calc(12);
+    font-weight: 400;
+    width: 100%;
+    display: none;
+    border-top: solid 1px $border-base-color;
+    padding-left: rem-calc(26);
+  }
+
+  &__grandchild { //孫li
+    //color: $color-white;
+    border-top: solid 1px $border-base-color;
+
+    &:first-child {
+      border-top: 0;
+    }
+  }
+
+  &__grandchild-link { //孫a, span
+    padding: rem-calc(12) rem-calc(40) rem-calc(12) rem-calc(0);
+  }
+
+  //大きいボタン（お問い合わせなど）
+  &__buttons {
+    margin-top: rem-calc(20);
+    padding: 0 rem-calc(20);
+  }
+
+  &__button + &__button {
+    margin-top: rem-calc(8);
+  }
+
+  &__button {
+    max-width: 100%;
+    font-weight: bold;
+    font-size: rem-calc(18);
+    color: $color-primary;
+    background-color: $color-white;
+    padding: rem-calc(24);
+    text-align: center;
+
+    &::after {
+      content: none;
+    }
+
+    &__icon {
+      display: inline;
+      vertical-align: rem-calc(-6);
+      line-height: 1;
+      font-size: rem-calc(24);
+      margin-right: rem-calc(8);
+    }
+  }
+
+  //SNSボタンなど小さいボタン
+  &__sns-btns {
+    max-width: 100%;
+    margin-top: rem-calc(24);
+    display: flex;
+    justify-content: center;
+    line-height: 1;
+  }
+
+  &__sns-btn {
+    background: $color-white;
+    color: $color-primary;
+    text-decoration: none;
+    //font-size: rem-calc(24);
+    margin: 0 rem-calc(8);
+    width: rem-calc(44);
+    height: rem-calc(44);
+    border-radius: rem-calc(44);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+  }
+
+  &__search {
+    //border: 1px solid $border-base-color;
+    //color: $font-base-color;
+    position: relative;
+    display: block;
+    margin-bottom: rem-calc(22);
+    max-width: 100%;
+    width: 100%;
+    border: 1px solid $color-primary;
+    color: $color-gray;
+    background: $color-white;
+    border-radius: rem-calc(23);
+    font-size: rem-calc(16);
+    letter-spacing: 0.1em;
+    line-height: 1.5;
+    font-weight: 400;
+    height: rem-calc(46);
+    transition: all 0.2s ease-out;
+
+    &:before {
+      position: absolute;
+      left: rem-calc(18);
+      top: 50%;
+      transform: translateY(-50%);
+      line-height: 1;
+      background-repeat: no-repeat;
+      background-position: center center;
+      background-size: cover;
+      @include icon-font();
+      content: "search";
+      font-size: rem-calc(18);
+      color: $color-primary;
+    }
+
+    &:hover,
+    &.is-active {
+    }
+  }
+
+  &__search-icon {
+    display: none;
+  }
+}
+
+// 有効時
+.is-slidebar-active {
+
+  .c-slidebar-menu {
+    transform: translate3d(0, 0, 0);
+
+    &.is-top-to-bottom {
+      transform: translate3d(0, #{$slidebar-header-height}px, 0);
+      opacity: 1;
     }
   }
 }


### PR DESCRIPTION
▼改善事項
https://www.notion.so/growgroup/slidebar-js-ResizeObserver-defaultOptions-10ceef14914a807896fad7cf84bc8eb3
https://www.notion.so/growgroup/slidebar-js-ce0fba7f2d3348039c1c0ee227ea4e31
https://www.notion.so/growgroup/js-c-block-document__slider-js-b754a08f9b154c138948e464a0abb24c

# 行ったこと
slidebar.jsおよび slidebar-menu.scssの以下の変更

- https://github.com/growgroup/gg-styleguide/pull/111 の、画面サイズの指定について数値を defaultOptionsに設定することで、外部JavaScriptから数値を書き換え可能にする（WP改修用）
- ページ内リンク時の挙動のコメントアウトを外し、セレクタを `c-slidebar-menu` から `this.options.menuSelector` を参照するように変更
- ついでに https://github.com/growgroup/gg-styleguide/pull/151 でslidebar-button はメインのスタイルをメディアクエリの外に出したのに、-menuの方は行っていなかったので実施