### PR TITLE
[add]extensions.json

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,7 @@
+{
+  "recommendations": [
+    "editorconfig.editorconfig",
+    "ms-ceintl.vscode-language-pack-ja",
+    "oderwat.indent-rainbow"
+  ]
+}


### PR DESCRIPTION
【フロントエンド課】
VScodeの推奨拡張機能をプロジェクトメンバーで統一するため
.vscode/extensions.jsonを作成（phpstorm利用者には影響なし）


対象の拡張機能は以下
- Japanese Language Pack for Visual Studio Code（日本語化）
- EditorConfig for VS Code（コードを一貫したスタイルで編集）
- Indent Rainbow（インデントを見やすくするやつ）