### PR TITLE
#159 以降ででるSass系のDepracated のWarningが出ないように微調整する

### DIFF
--- a/app/assets/scss/foundation/_form-controls.scss
+++ b/app/assets/scss/foundation/_form-controls.scss
@@ -33,8 +33,8 @@ $form-controls-active-border-color: #0097D8;
 
 //input, textareaの共通スタイル
 @mixin form-controls-input-style {
-  @include form-controls-common-style;
   padding: rem-calc(10) rem-calc(16);
+  @include form-controls-common-style;
 
   @include breakpoint(small down) {
     padding: rem-calc(9) rem-calc(12);
@@ -138,17 +138,16 @@ input[type="radio"] {
 //
 // Styleguide 1.6.5
 select {
-  @include form-controls-common-style();
   display: block;
   height: rem-calc(44);
   padding: rem-calc(10) rem-calc(16);
   text-transform: none;
-
   appearance: none;
   background-image: url('data:image/svg+xml;utf8,<svg width="9" height="6" viewBox="0 0 9 6" fill="none" xmlns="http://www.w3.org/2000/svg"> <path d="M7.945 2.38419e-05L9 1.05402L4.5 5.55402L0 1.05402L1.055 -0.000976562L4.5 3.44502L7.945 2.38419e-05Z" fill="%23222222"/></svg>');
   background-repeat: no-repeat;
   background-position: calc(100% - 16px) center;
   background-size: 9px 5px;
+  @include form-controls-common-style();
 
   @include breakpoint(small down) {
     padding: rem-calc(9) rem-calc(12);

--- a/app/assets/scss/foundation/_mixin-post-content.scss
+++ b/app/assets/scss/foundation/_mixin-post-content.scss
@@ -104,10 +104,10 @@
   }
 
   table {
-    @include c-table;
     width: 100%;
+    @include c-table;
   }
-
+  
   ol, ul {
     @include c-list;
   }

--- a/app/assets/scss/object/components/buttons.scss
+++ b/app/assets/scss/object/components/buttons.scss
@@ -4,6 +4,8 @@ name: ボタン_カラー別
 category: Buttons
 ---
 */
+@use "sass:color";
+
 .c-button {
   position: relative;
   display: inline-flex;
@@ -49,9 +51,9 @@ category: Buttons
 
   // -> セカンダリカラー
   &.is-secondary {
-    background-color: lighten($color-primary, 40);
+    background-color: color.adjust($color-primary, $lightness:40%);
     color: $color-primary;
-    border-color: lighten($color-primary, 40);
+    border-color: color.adjust($color-primary, $lightness:40%);
 
     @include hover {
       background-color: $color-white;

--- a/app/assets/scss/object/components/tabs.scss
+++ b/app/assets/scss/object/components/tabs.scss
@@ -4,6 +4,8 @@ name: タブ
 category: Tabs
 ---
 */
+@use "sass:color";
+
 .c-tabs {
   // タブ
   &__navs {
@@ -53,7 +55,7 @@ category: Tabs
 
       // *hover
       &:hover {
-        background-color: lighten($color-primary, 45);
+        background-color: color.adjust($color-primary, $lightness: 45%);
         opacity: 1;
       }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -56,7 +56,7 @@
         "pug-cli": "git+https://github.com/pugjs/pug-cli.git",
         "rimraf": "^6.0.1",
         "sass": "^1.78.0",
-        "sass-loader": "^12.6.0",
+        "sass-loader": "^16.0.2",
         "style-loader": "^4.0.0",
         "webpack": "^5.94.0",
         "webpack-cli": "^5.1.4",
@@ -6886,15 +6886,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/klona": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/klona/-/klona-2.0.6.tgz",
-      "integrity": "sha512-dhG34DXATL5hSxJbIexCft8FChFXtmskoZYnoPWjXQuebWYCNkVeV3KkGegCK9CP1oswI/vQibS2GY7Em/sJJA==",
-      "dev": true,
-      "engines": {
-        "node": ">= 8"
-      }
-    },
     "node_modules/lazy-cache": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
@@ -9324,30 +9315,29 @@
       }
     },
     "node_modules/sass-loader": {
-      "version": "12.6.0",
-      "resolved": "https://registry.npmjs.org/sass-loader/-/sass-loader-12.6.0.tgz",
-      "integrity": "sha512-oLTaH0YCtX4cfnJZxKSLAyglED0naiYfNG1iXfU5w1LNZ+ukoA5DtyDIN5zmKVZwYNJP4KRc5Y3hkWga+7tYfA==",
+      "version": "16.0.2",
+      "resolved": "https://registry.npmjs.org/sass-loader/-/sass-loader-16.0.2.tgz",
+      "integrity": "sha512-Ll6iXZ1EYwYT19SqW4mSBb76vSSi8JgzElmzIerhEGgzB5hRjDQIWsPmuk1UrAXkR16KJHqVY0eH+5/uw9Tmfw==",
       "dev": true,
       "dependencies": {
-        "klona": "^2.0.4",
         "neo-async": "^2.6.2"
       },
       "engines": {
-        "node": ">= 12.13.0"
+        "node": ">= 18.12.0"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/webpack"
       },
       "peerDependencies": {
-        "fibers": ">= 3.1.0",
-        "node-sass": "^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0",
+        "@rspack/core": "0.x || 1.x",
+        "node-sass": "^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0 || ^9.0.0",
         "sass": "^1.3.0",
         "sass-embedded": "*",
         "webpack": "^5.0.0"
       },
       "peerDependenciesMeta": {
-        "fibers": {
+        "@rspack/core": {
           "optional": true
         },
         "node-sass": {
@@ -9357,6 +9347,9 @@
           "optional": true
         },
         "sass-embedded": {
+          "optional": true
+        },
+        "webpack": {
           "optional": true
         }
       }

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "pug-cli": "git+https://github.com/pugjs/pug-cli.git",
     "rimraf": "^6.0.1",
     "sass": "^1.78.0",
-    "sass-loader": "^12.6.0",
+    "sass-loader": "^16.0.2",
     "style-loader": "^4.0.0",
     "webpack": "^5.94.0",
     "webpack-cli": "^5.1.4",

--- a/webpack.config.babel.js
+++ b/webpack.config.babel.js
@@ -3,7 +3,6 @@ const webpack = require('webpack');
 const path = require('path');
 const MiniCssExtractPlugin = require('mini-css-extract-plugin');
 const CopyPlugin = require("copy-webpack-plugin");
-const globImporter = require('node-sass-glob-importer');
 
 
 const BASE_DIR = "../../"
@@ -72,7 +71,6 @@ module.exports = (env, argv) => {
               loader: 'sass-loader',
               options: {
                 sassOptions: {
-                  importer: globImporter()
                 },
 
               }


### PR DESCRIPTION
▼改善事項
https://www.notion.so/growgroup/node-sass-deprecated-warning-10eeef14914a8075ad60ff5c7222d51c

https://github.com/growgroup/gg-styleguide/pull/159 でsassのバージョンを上げたため
いくつかの Depracated がでているので、できるだけ出ないようにしました。

```
LOG from ../node_modules/sass-loader/dist/cjs.js sass-loader ../node_modules/css-loader/dist/cjs.js??ruleSet[1].rules[0].use[1]!../node_modules/postcss-loader/dist/cjs.js??ruleSet[1].rules[0].use[2]!../node_modules/sass-loader/dist/cjs.js!./assets/scss/style.scss
<w> Deprecation The legacy JS API is deprecated and will be removed in Dart Sass 2.0.0.
<w> 
<w> More info: https://sass-lang.com/d/legacy-js-api
<w> 
<w> null
<w> Deprecation Sass's behavior for declarations that appear after nested
<w> rules will be changing to match the behavior specified by CSS in an upcoming
<w> version. To keep the existing behavior, move the declaration above the nested
<w> rule. To opt into the new behavior, wrap the declaration in `& {}`.
<w> 
<w> More info: https://sass-lang.com/d/mixed-decls
<w> 
<w> app/assets/scss/foundation/_form-controls.scss 37:3  form-controls-input-style()
<w> app/assets/scss/foundation/_form-controls.scss 64:3  @import
<w> app/assets/scss/style.scss 30:9                      root stylesheet
<w> 
<w> Deprecation Sass's behavior for declarations that appear after nested
<w> rules will be changing to match the behavior specified by CSS in an upcoming
<w> version. To keep the existing behavior, move the declaration above the nested
<w> rule. To opt into the new behavior, wrap the declaration in `& {}`.
<w> 
<w> More info: https://sass-lang.com/d/mixed-decls
<w> 
<w> app/assets/scss/foundation/_form-controls.scss 142:3  @import
<w> app/assets/scss/style.scss 30:9                       root stylesheet
<w> 
<w> Deprecation Sass's behavior for declarations that appear after nested
<w> rules will be changing to match the behavior specified by CSS in an upcoming
<w> version. To keep the existing behavior, move the declaration above the nested
<w> rule. To opt into the new behavior, wrap the declaration in `& {}`.
<w> 
<w> More info: https://sass-lang.com/d/mixed-decls
<w> 
<w> app/assets/scss/foundation/_form-controls.scss 143:3  @import
<w> app/assets/scss/style.scss 30:9                       root stylesheet
<w> 
<w> Deprecation Sass's behavior for declarations that appear after nested
<w> rules will be changing to match the behavior specified by CSS in an upcoming
<w> version. To keep the existing behavior, move the declaration above the nested
<w> rule. To opt into the new behavior, wrap the declaration in `& {}`.
<w> 
<w> More info: https://sass-lang.com/d/mixed-decls
<w> 
<w> app/assets/scss/foundation/_form-controls.scss 144:3  @import
<w> app/assets/scss/style.scss 30:9                       root stylesheet
<w> 
<w> Deprecation Sass's behavior for declarations that appear after nested
<w> rules will be changing to match the behavior specified by CSS in an upcoming
<w> version. To keep the existing behavior, move the declaration above the nested
<w> rule. To opt into the new behavior, wrap the declaration in `& {}`.
<w> 
<w> More info: https://sass-lang.com/d/mixed-decls
<w> 
<w> app/assets/scss/foundation/_form-controls.scss 145:3  @import
<w> app/assets/scss/style.scss 30:9                       root stylesheet
<w> 
<w> Deprecation lighten() is deprecated. Suggestions:
<w> 
<w> color.scale($color, $lightness: 74.7252747253%)
<w> color.adjust($color, $lightness: 40%)
<w> 
<w> More info: https://sass-lang.com/d/color-functions
<w> 
<w> app/assets/scss/object/components/buttons.scss 52:23  @import
<w> app/assets/scss/object/components/_index.scss 17:9    @import
<w> app/assets/scss/style.scss 39:9                       root stylesheet
<w> 
<w> Deprecation lighten() is deprecated. Suggestions:
<w> 
<w> color.scale($color, $lightness: 74.7252747253%)
<w> color.adjust($color, $lightness: 40%)
<w> 
<w> More info: https://sass-lang.com/d/color-functions
<w> 
<w> app/assets/scss/object/components/buttons.scss 54:19  @import
<w> app/assets/scss/object/components/_index.scss 17:9    @import
<w> app/assets/scss/style.scss 39:9                       root stylesheet
<w> 
<w> Deprecation lighten() is deprecated. Suggestions:
<w> 
<w> color.scale($color, $lightness: 84.0659340659%)
<w> color.adjust($color, $lightness: 45%)
<w> 
<w> More info: https://sass-lang.com/d/color-functions
<w> 
<w> app/assets/scss/object/components/tabs.scss 56:27   @import
<w> app/assets/scss/object/components/_index.scss 64:9  @import
<w> app/assets/scss/style.scss 39:9                     root stylesheet
<w> 
<w> 8 repetitive deprecation warnings omitted.
<w> 
<w> null

LOG from ../node_modules/sass-loader/dist/cjs.js sass-loader ../node_modules/css-loader/dist/cjs.js??ruleSet[1].rules[0].use[1]!../node_modules/postcss-loader/dist/cjs.js??ruleSet[1].rules[0].use[2]!../node_modules/sass-loader/dist/cjs.js!./assets/scss/editor.scss
<w> Deprecation The legacy JS API is deprecated and will be removed in Dart Sass 2.0.0.
<w> 
<w> More info: https://sass-lang.com/d/legacy-js-api
<w> 
<w> null
<w> Deprecation Sass's behavior for declarations that appear after nested
<w> rules will be changing to match the behavior specified by CSS in an upcoming
<w> version. To keep the existing behavior, move the declaration above the nested
<w> rule. To opt into the new behavior, wrap the declaration in `& {}`.
<w> 
<w> More info: https://sass-lang.com/d/mixed-decls
<w> 
<w> app/assets/scss/foundation/_mixin-post-content.scss 108:5  l-post-content()
<w> app/assets/scss/editor.scss 29:5                           root stylesheet
<w> 
<w> Deprecation Sass's behavior for declarations that appear after nested
<w> rules will be changing to match the behavior specified by CSS in an upcoming
<w> version. To keep the existing behavior, move the declaration above the nested
<w> rule. To opt into the new behavior, wrap the declaration in `& {}`.
<w> 
<w> More info: https://sass-lang.com/d/mixed-decls
<w> 
<w> app/assets/scss/foundation/_mixin-post-content.scss 108:5  l-post-content()
<w> app/assets/scss/editor.scss 29:5                           root stylesheet
<w> 
<w> Deprecation Sass's behavior for declarations that appear after nested
<w> rules will be changing to match the behavior specified by CSS in an upcoming
<w> version. To keep the existing behavior, move the declaration above the nested
<w> rule. To opt into the new behavior, wrap the declaration in `& {}`.
<w> 
<w> More info: https://sass-lang.com/d/mixed-decls
<w> 
<w> app/assets/scss/foundation/_mixin-post-content.scss 108:5  l-post-content()
<w> app/assets/scss/editor.scss 56:5                           root stylesheet
<w> 
<w> Deprecation Sass's behavior for declarations that appear after nested
<w> rules will be changing to match the behavior specified by CSS in an upcoming
<w> version. To keep the existing behavior, move the declaration above the nested
<w> rule. To opt into the new behavior, wrap the declaration in `& {}`.
<w> 
<w> More info: https://sass-lang.com/d/mixed-decls
<w> 
<w> app/assets/scss/foundation/_mixin-post-content.scss 108:5  l-post-content()
<w> app/assets/scss/editor.scss 56:5                           root stylesheet
<w> 
```