### PR TITLE
[update] c-list.is-icon

### DIFF
--- a/app/assets/scss/foundation/_mixin-post-content.scss
+++ b/app/assets/scss/foundation/_mixin-post-content.scss
@@ -107,7 +107,7 @@
     width: 100%;
     @include c-table;
   }
-  
+
   ol, ul {
     @include c-list;
   }
@@ -226,19 +226,20 @@
 @mixin c-list-ul {
   > li { //l-post-content 用に > が必要
     padding-left: rem-calc(16);
+    position: relative;
 
     &::before {
-      font-family: $font-icon-family;
-      @include icon-font-style();
-      content: "circle";
-      font-size: rem-calc(10);
-      color: $color-primary;
-      width: rem-calc(16);
-      height: calc(rem-calc(16) * $font-base-line-height); //1行分の高さ（liのフォントサイズ * line-height）
+      --_icon-size: #{rem-calc(4)};
 
-      @include breakpoint(small only) {
-        height: calc(rem-calc(13) * $font-base-line-height); //1行分の高さ（liのフォントサイズ * line-height）
-      }
+      content: "";
+      width: var(--_icon-size);
+      height: var(--_icon-size);
+      background: $color-primary;
+      border-radius: 50%;
+      top: calc(1em * #{$font-base-line-height} / 2 - var(--_icon-size) / 2);
+      left: 0.25em;
+      position: absolute;
+
     }
   }
 
@@ -247,17 +248,16 @@
     padding-left: rem-calc(16);
 
     &::before {
-      font-family: $font-icon-family;
-      @include icon-font-style();
-      content: "・";
-      color: $color-primary;
-      font-size: rem-calc(10);
-      width: rem-calc(16);
-      height: calc(rem-calc(16) * $font-base-line-height); //1行分の高さ（liのフォントサイズ * line-height）
+      --_icon-size: #{rem-calc(2)};
 
-      @include breakpoint(small only) {
-        height: calc(rem-calc(13) * $font-base-line-height); //1行分の高さ（liのフォントサイズ * line-height）
-      }
+      content: "";
+      width: var(--_icon-size);
+      height: var(--_icon-size);
+      background: $color-primary;
+      border-radius: 50%;
+      top: calc(1em * #{$font-base-line-height} / 2 - var(--_icon-size) / 2);
+      left: 0.5em;
+      position: absolute;
     }
   }
 }


### PR DESCRIPTION
▼改善事項
https://www.notion.so/growgroup/gg-styleguide-c-list-material-icon-01d55fdeb04445f79d837df00583f59d

# やったこと
.c-list.is-iconのデフォルトのアイコンを、material iconsの○ではなく
以下のような感じで作るやつに変更。
```
      width: rem-calc(4);
      height: rem-calc(4);
      border-radius: 50%;
      background: $font-base-color;
```

# 使い方
ただの●なら `--_icon-size: #{rem-calc(4)};` を変更するとサイズ変更可能。
必要に応じて全体的に書き換えてOK

```
    &::before {
      --_icon-size: #{rem-calc(4)};

      content: "";
      width: var(--_icon-size);
      height: var(--_icon-size);
      background: $color-primary;
      border-radius: 50%;
      top: calc(1em * #{$font-base-line-height} / 2 - var(--_icon-size) / 2);
      left: 0.25em;
      position: absolute;
    }
```
