### PR TITLE
[update] _head.pug : サイトの説明文のデフォルト設定と上書き設定

### DIFF
--- a/app/archive-twocolumns/category/index.pug
+++ b/app/archive-twocolumns/category/index.pug
@@ -2,7 +2,7 @@ extends /inc/foundation/_base-twocolumn.pug
 block append config
   - current.id = "category" // ページのID
   - current.title = "カテゴリ" // タイトル
-  - current.description = `これは${current.title}についての説明文です` // 説明文
+  //- - current.description = `これは${current.title}についての説明文です` // ページごとに説明文を設定する場合のみ
   - current.bodyClass = `${current.id}` // body に付与するクラス
   - current.path = `/archive-twocolumns/${current.id}/` // ページのpath
   - current.depth = 3 // ページの階層

--- a/app/archive-twocolumns/category/page/index.pug
+++ b/app/archive-twocolumns/category/page/index.pug
@@ -2,7 +2,7 @@ extends /inc/foundation/_base-twocolumn.pug
 block append config
   - current.id = "post" // ページのID
   - current.title = "ここに記事のタイトルが入ります。" // タイトル
-  - current.description = `これは${current.title}についての説明文です` // 説明文
+  //- - current.description = `これは${current.title}についての説明文です` // ページごとに説明文を設定する場合のみ
   - current.bodyClass = `single-${current.id}` // body に付与するクラス
   - current.path = "/archive-twocolumns/category/page/" // ページのpath
   - current.depth = 4 // ページの階層

--- a/app/archive-twocolumns/index.pug
+++ b/app/archive-twocolumns/index.pug
@@ -2,7 +2,7 @@ extends /inc/foundation/_base-twocolumn.pug
 block append config
   - current.id = "archive-twocolumns" // ページのID
   - current.title = "アーカイブ_2カラム" // タイトル
-  - current.description = `これは${current.title}についての説明文です` // 説明文
+  //- - current.description = `これは${current.title}についての説明文です` // ページごとに説明文を設定する場合のみ
   - current.bodyClass = `${current.id}` // body に付与するクラス
   - current.path = `/${current.id}/` // ページのpath
   - current.depth = 2 // ページの階層

--- a/app/blocks/index.pug
+++ b/app/blocks/index.pug
@@ -2,7 +2,7 @@ extends /inc/foundation/_base.pug
 block append config
   - current.id = "blocks" // ページのID
   - current.title = "ブロック編集ページ" // タイトル
-  - current.description = "これはブロック編集ページの説明文です" // 説明文
+  //- - current.description = `これは${current.title}についての説明文です` // ページごとに説明文を設定する場合のみ
   - current.bodyClass = "blocks" // body に付与するクラス
   - current.path = "/blocks/" // ページのpath
   - current.depth = 2 // ページの階層

--- a/app/contact/complete/index.pug
+++ b/app/contact/complete/index.pug
@@ -2,7 +2,7 @@ extends /inc/foundation/_base.pug
 block append config
   - current.id = "complete" // ページのID
   - current.title = "お問い合わせ - 送信完了ページ" // タイトル
-  - current.description = `これは${current.title}についての説明文です` // 説明文
+  //- - current.description = `これは${current.title}についての説明文です` // ページごとに説明文を設定する場合のみ
   - current.bodyClass = `${current.id}` // body に付与するクラス
   - current.path = `/contact/${current.id}/` // ページのpath
   - current.depth = 3 // ページの階層

--- a/app/contact/confirm/index.pug
+++ b/app/contact/confirm/index.pug
@@ -2,7 +2,7 @@ extends /inc/foundation/_base.pug
 block append config
   - current.id = "confirm" // ページのID
   - current.title = "お問い合わせ - 確認ページ" // タイトル
-  - current.description = `これは${current.title}についての説明文です` // 説明文
+  //- - current.description = `これは${current.title}についての説明文です` // ページごとに説明文を設定する場合のみ
   - current.bodyClass = `${current.id}` // body に付与するクラス
   - current.path = `/contact/${current.id}/` // ページのpath
   - current.depth = 3 // ページの階層

--- a/app/contact/index.pug
+++ b/app/contact/index.pug
@@ -2,7 +2,7 @@ extends /inc/foundation/_base.pug
 block append config
   - current.id = "contact" // ページのID
   - current.title = "お問い合わせフォーム" // タイトル
-  - current.description = `これは${current.title}についての説明文です` // 説明文
+  //- - current.description = `これは${current.title}についての説明文です` // ページごとに説明文を設定する場合のみ
   - current.bodyClass = `${current.id}` // body に付与するクラス
   - current.path = `/${current.id}/` // ページのpath
   - current.depth = 2 // ページの階層

--- a/app/download/index.pug
+++ b/app/download/index.pug
@@ -2,7 +2,7 @@ extends /inc/foundation/_base.pug
 block append config
   - current.id = "download" // ページのID
   - current.title = "資料ダウンロード" // タイトル
-  - current.description = `これは${current.title}についての説明文です` // 説明文
+  //- - current.description = `これは${current.title}についての説明文です` // ページごとに説明文を設定する場合のみ
   - current.bodyClass = `${current.id}` // body に付与するクラス
   - current.path = `/${current.id}/` // ページのpath
   - current.depth = 2 // ページの階層

--- a/app/download/page/index.pug
+++ b/app/download/page/index.pug
@@ -2,7 +2,7 @@ extends /inc/foundation/_base.pug
 block append config
   - current.id = "download-page" // ページのID
   - current.title = "資料ダウンロードサンプル詳細" // タイトル
-  - current.description = `これは${current.title}についての説明文です` // 説明文
+  //- - current.description = `これは${current.title}についての説明文です` // ページごとに説明文を設定する場合のみ
   - current.bodyClass = `${current.id}` // body に付与するクラス
   - current.path = `/${current.id}/` // ページのpath
   - current.depth = 3 // ページの階層
@@ -38,7 +38,7 @@ block body
               +e.slider-nav.swiper-nav
                 +e.slider-prev.swiper-prev.js-document-slider-prev.swiper-button-prev
                 +e.slider-next.swiper-next.js-document-slider-next.swiper-button-next
-                
+
         .c-block-document__form
           +c.forms
             .c-heading.is-xs.is-mg-level-4 ダウンロードフォーム

--- a/app/format/index.pug
+++ b/app/format/index.pug
@@ -2,7 +2,7 @@ extends /inc/foundation/_base.pug
 block append config
   - current.id = "format" // ページのID
   - current.title = "フォーマット" // タイトル
-  - current.description = `これは${current.title}についての説明文です` // 説明文
+  //- - current.description = `ページごとに説明文を設定する場合の動作サンプルです` // ページごとに説明文を設定する場合のみ
   - current.bodyClass = `${current.id}` // body に付与するクラス
   - current.path = `/${current.id}/` // ページのpath
   - current.depth = 2 // ページの階層

--- a/app/inc/_settings.pug
+++ b/app/inc/_settings.pug
@@ -41,7 +41,7 @@
     site: {
       title: "株式会社 サンプル",
       titleSeparator: " | ",
-      description: "説明文",
+      description: "このサイト共通の説明文です。",
       keywords: "キーワード",
       viewport: "width=device-width,initial-scale=1",
       favicon: "",

--- a/app/inc/foundation/_head.pug
+++ b/app/inc/foundation/_head.pug
@@ -16,10 +16,15 @@ html(lang="ja")
     block meta
       -
         var desc = false
+        if (current.id === "home")
+          //- TOPページ＝サイトの説明文
+          desc = config.site.description
+        else
+          //- それ以外＝ サイト名 + ページタイトル + サイトの説明文
+          desc = config.site.title+'の'+current.title + 'のページです。' + config.site.description
+          //- 説明文が設定されている場合は上書き
         if (current.description)
           desc = current.description
-        else
-          desc = config.site.description
       meta(name='description', content=desc)
       meta(name="viewport", content=config.site.viewport)
       meta(name="format-detection" , content="telephone=no")

--- a/app/index.pug
+++ b/app/index.pug
@@ -4,8 +4,8 @@
 extends /inc/foundation/_base.pug
 block append config
   - current.id = "home" // ページのID
-  - current.title = "トップページ" // タイトルあ
-  - current.description = "これはトップページの説明文です" // 説明文
+  - current.title = "トップページ" // タイトル
+  //- - current.description = "これはトップページの説明文です" // ページごとに説明文を設定する場合のみ
   - current.bodyClass = "home" // body に付与するクラス
   - current.path = "/" // ページのpath
   - current.depth = 1 // ページの階層

--- a/app/news/category/index.pug
+++ b/app/news/category/index.pug
@@ -2,7 +2,7 @@ extends /inc/foundation/_base.pug
 block append config
   - current.id = "category" // ページのID
   - current.title = "カテゴリ" // タイトル
-  - current.description = `これは${current.title}についての説明文です` // 説明文
+  //- - current.description = `これは${current.title}についての説明文です` // ページごとに説明文を設定する場合のみ
   - current.bodyClass = `${current.id}` // body に付与するクラス
   - current.path = `/news/${current.id}/` // ページのpath
   - current.depth = 3 // ページの階層

--- a/app/news/category/page/index.pug
+++ b/app/news/category/page/index.pug
@@ -2,7 +2,7 @@ extends /inc/foundation/_base.pug
 block append config
   - current.id = "post" // ページのID
   - current.title = "ここに記事のタイトルが入ります。" // タイトル
-  - current.description = `これは${current.title}についての説明文です` // 説明文
+  //- - current.description = `これは${current.title}についての説明文です` // ページごとに説明文を設定する場合のみ
   - current.bodyClass = `single-${current.id}` // body に付与するクラス
   - current.path = "/news/category/page/" // ページのpath
   - current.depth = 4 // ページの階層

--- a/app/news/index.pug
+++ b/app/news/index.pug
@@ -2,7 +2,7 @@ extends /inc/foundation/_base.pug
 block append config
   - current.id = "news" // ページのID
   - current.title = "お知らせ" // タイトル
-  - current.description = `これは${current.title}についての説明文です` // 説明文
+  //- - current.description = `これは${current.title}についての説明文です` // ページごとに説明文を設定する場合のみ
   - current.bodyClass = `${current.id}` // body に付与するクラス
   - current.path = `/${current.id}/` // ページのpath
   - current.depth = 2 // ページの階層

--- a/app/page/index.pug
+++ b/app/page/index.pug
@@ -2,7 +2,7 @@ extends /inc/foundation/_base.pug
 block append config
   - current.id = "format" // ページのID
   - current.title = "量産ページ" // タイトル
-  - current.description = `これは${current.title}についての説明文です` // 説明文
+  //- - current.description = `これは${current.title}についての説明文です` // ページごとに説明文を設定する場合のみ
   - current.bodyClass = `${current.id}` // body に付与するクラス
   - current.path = `/${current.id}/` // ページのpath
   - current.depth = 2 // ページの階層

--- a/app/result/index.pug
+++ b/app/result/index.pug
@@ -2,7 +2,7 @@ extends /inc/foundation/_base.pug
 block append config
   - current.id = "result" // ページのID
   - current.title = "サイト内検索" // タイトル
-  - current.description = `これは${current.title}についての説明文です` // 説明文
+  //- - current.description = `これは${current.title}についての説明文です` // ページごとに説明文を設定する場合のみ
   - current.bodyClass = `${current.id}` // body に付与するクラス
   - current.path = `/${current.id}/` // ページのpath
   - current.depth = 2 // ページの階層

--- a/app/sitemap/index.pug
+++ b/app/sitemap/index.pug
@@ -2,7 +2,7 @@ extends /inc/foundation/_base.pug
 block append config
   - current.id = "format" // ページのID
   - current.title = "量産ページ" // タイトル
-  - current.description = `これは${current.title}についての説明文です` // 説明文
+  //- - current.description = `これは${current.title}についての説明文です` // ページごとに説明文を設定する場合のみ
   - current.bodyClass = `${current.id}` // body に付与するクラス
   - current.path = `/${current.id}/` // ページのpath
   - current.depth = 2 // ページの階層

--- a/app/twocolumns/index.pug
+++ b/app/twocolumns/index.pug
@@ -2,7 +2,7 @@ extends /inc/foundation/_base-twocolumn.pug
 block append config
   - current.id = "twocolumns" // ページのID
   - current.title = "ページ_2カラム" // タイトル
-  - current.description = `これは${current.title}についての説明文です` // 説明文
+  //- - current.description = `これは${current.title}についての説明文です` // ページごとに説明文を設定する場合のみ
   - current.bodyClass = `${current.id}` // body に付与するクラス
   - current.path = `/${current.id}/` // ページのpath
   - current.depth = 2 // ページの階層


### PR DESCRIPTION
▼改善事項
https://www.notion.so/growgroup/description-description-114eef14914a800693b7c122e9a40a12

# やったこと
基本的にページのdescriptionについて、ページごと完全に個別のものを入れることがないので
ページタイトル+サイト全体のdescription＝ページのdescriptionをデフォルト値にして、
ページのpug側で上書きできる構造に変える

# 使い方（主に一次公開時）
1. app/inc/_settings.pug にTOPページ用の説明文を入れる
2. app/inc/foundation/_head.pugの `desc = config.site.title+'の'+current.title + 'のページです。' + config.site.description` を必要に応じて調整
3. ページごとに全く異なる説明文を入れるときは、各ページのpugから設定
