### PR TITLE
[update] c_breadcrumb : 再帰的なmixinに変更して階層が深いサイトに対応する

### DIFF
--- a/app/archive-twocolumns/category/index.pug
+++ b/app/archive-twocolumns/category/index.pug
@@ -14,7 +14,11 @@ block page_header
     title: "お知らせ",
     subtitle: "news"
   })
-  +c_breadcrumb()
+  +c_breadcrumb({
+    paths: [
+      {url: "news", text: "お知らせ"},
+    ]
+  })
 
 block body
   +c.news

--- a/app/archive-twocolumns/category/page/index.pug
+++ b/app/archive-twocolumns/category/page/index.pug
@@ -13,7 +13,13 @@ block page_header
     title: "お知らせ",
     subtitle: "news"
   })
-  +c_breadcrumb("お知らせ","news","カテゴリ","category")
+  +c_breadcrumb({
+      paths: [
+        {url: "news", text: "お知らせ"},
+        {url: "category", text: "カテゴリ"},
+      ]
+    })
+
 
 block body
   +c.news-header

--- a/app/format/index.pug
+++ b/app/format/index.pug
@@ -14,7 +14,7 @@ block page_header
     title: "量産ページ",
     subtitle: "parent"
   })
-  +c_breadcrumb()
+  +c_breadcrumb().is-bg-color
 
 block body
   section.l-section.is-lg

--- a/app/inc/mixins/_breadcrumb.pug
+++ b/app/inc/mixins/_breadcrumb.pug
@@ -1,26 +1,48 @@
 //- パンくずリスト
-mixin c_breadcrumb(parent,parentURL,parent2,parentURL2)
-  +c.breadcrumb
-    .l-container
-      +e.inner
-        span
+mixin c_breadcrumb(props, cache)
+
+  if cache && cache.count === props.paths.length
+    //- パンくずリストの最後の要素の場合（現在のページタイトルを表示）
+    span=current.title
+
+  else if cache && cache.count
+    //- パンくずリストの途中の要素の場合
+    //- 現在のリンクパスを次の要素のURLで更新
+    - var linkedPath = cache.linkedPath + props.paths[cache.count].url + "/"
+    span
+      +a(linkedPath)=props.paths[cache.count].text
+      span.is-arrow
+        span.c-icon-font
+          | chevron_right
+      //- 次のパンくずリスト要素を再帰的に処理
+      +c_breadcrumb({paths: props.paths}, {count: cache.count + 1, linkedPath: linkedPath})
+
+  else
+    //- パンくずリストの最初の要素の場合
+    //- クラス名を&attributesを用いて設定
+    .c-breadcrumb&attributes(attributes)
+      .l-container
+        .c-breadcrumb__inner
           span
-            +a("/") TOP
-            span.is-arrow <span class="c-icon-font">chevron_right</span>
-            if !parent
-              //- parent設定がないとき
-              span !{current.title}
-            else
-              //- parent設定があるとき
-              span
-                +a('/' + parentURL + '/')=parent
-                span.is-arrow <span class="c-icon-font">chevron_right</span>
-                if !parent2
-                  //- parent2設定がないとき
-                  span !{current.title}
-                else
-                  //- parent2設定があるとき
-                  span
-                    +a('/' + parentURL + '/' + parentURL2 + '/')=parent2
-                    span.is-arrow <span class="c-icon-font">chevron_right</span>
-                    span !{current.title}
+            span
+              //- トップへのリンク（最初の要素）
+              +a("/") TOP
+              span.is-arrow
+                span.c-icon-font
+                  | chevron_right
+
+              if props === undefined ||props.paths === undefined ||!props.paths[0]
+                //- パスが存在しない場合は現在のページタイトルを表示
+                span=current.title
+
+              else
+                //- パスが存在する場合は最初のパンくず要素を表示
+                span
+                  +a(`/${props.paths[0].url}/`)=props.paths[0].text
+                  span.is-arrow
+                    span.c-icon-font
+                      | chevron_right
+                  //- 最初のリンクパスを設定
+                  - var linkedPath = `/${props.paths[0].url}/`
+                  //- 次のパンくずリスト要素を再帰的に処理
+                  +c_breadcrumb({paths: props.paths}, {count: 1, linkedPath: linkedPath})

--- a/app/news/category/index.pug
+++ b/app/news/category/index.pug
@@ -13,7 +13,11 @@ block page_header
     title: "カテゴリ",
     subtitle: "news"
   })
-  +c_breadcrumb("お知らせ","news")
+  +c_breadcrumb({
+    paths: [
+      {url: "news", text: "お知らせ"},
+    ]
+  })
 
 block body
   section.l-section.is-lg

--- a/app/news/category/page/index.pug
+++ b/app/news/category/page/index.pug
@@ -13,7 +13,12 @@ block page_header
     title: "お知らせ",
     subtitle: "news"
   })
-  +c_breadcrumb("お知らせ","news","カテゴリ","category")
+  +c_breadcrumb({
+    paths: [
+      {url: "news", text: "お知らせ"},
+      {url: "category", text: "カテゴリ"},
+    ]
+  })
 
 block body
   section.l-section.is-lg


### PR DESCRIPTION
▼改善事項
https://www.notion.so/growgroup/Mixin-2a02c566afab46bbb526bcbc396a89fe#150e1e20a3d041fbab6ac2ea26fa678f

# やったこと
- c_breadcrumbのmixinを再帰的なmixinに変更
- class名などの属性を `&attributes(attributes)` で付けられるようにする

# 使用上の変更点
1. 階層が深いページのときのパンくずの書き方が変わりました。
2. 階層が大変深いサイトのときc_breadcrumbのmixinを修正する必要が無くなりました。

### 旧
```
+c_breadcrumb("お知らせ","news","カテゴリ","category")
```

### 新
```
 +c_breadcrumb({
   paths: [
     {url: "news", text: "お知らせ"},
     {url: "category", text: "カテゴリ"},
   ]
 })
```