### PR TITLE
[update]anchorJSで別ページリンクと共存させる

### DIFF
--- a/app/assets/js/app/anchor.js
+++ b/app/assets/js/app/anchor.js
@@ -50,6 +50,17 @@ export default class Anchor {
     let self = this;
 
     this.target.on('click', function(e) {
+
+      // アンカーが同一ページか判定
+      const targetUrl = e.target.href;
+      const targetPage = targetUrl.split('#')[0];
+      const currentPage = window.location.href.split('#')[0];
+
+      // 異なるページであればそのままリンクさせて以降処理しない
+      if(targetPage !== currentPage) {
+        return;
+      }
+
       e.preventDefault();
 
       // スクロール先のターゲットを指定

--- a/app/assets/js/app/anchor.js
+++ b/app/assets/js/app/anchor.js
@@ -51,15 +51,18 @@ export default class Anchor {
 
     this.target.on('click', function(e) {
 
-      // アンカーが同一ページか判定
-      const targetUrl = e.target.href;
-      const targetPage = targetUrl.split('#')[0];
-      const currentPage = window.location.href.split('#')[0];
+      // 現在のページのパスとリンクのパスを比較
+      let currentPath = window.location.pathname;
+      let linkPath = $(this).attr('href').split('#')[0];
 
-      // 異なるページであればそのままリンクさせて以降処理しない
-      if(targetPage !== currentPage) {
-        return;
-      }
+      // 同一パスかつ同一階層かチェック
+      let currentPathArray = currentPath.split('/');
+      let linkPathArray = linkPath.split('/');
+      let flag = (linkPath !== '' && currentPathArray.slice(-linkPathArray.length).join('/') !== linkPath);
+
+      // パスや階層が異なる場合は何もせずに通常のリンク遷移を行う
+      if (flag) return;
+
 
       e.preventDefault();
 

--- a/app/assets/js/app/anchor.js
+++ b/app/assets/js/app/anchor.js
@@ -51,18 +51,15 @@ export default class Anchor {
 
     this.target.on('click', function(e) {
 
-      // 現在のページのパスとリンクのパスを比較
-      let currentPath = window.location.pathname;
-      let linkPath = $(this).attr('href').split('#')[0];
+      // リンク先のパスと現在のページのパスを比較
+      let linkHref = $(this).attr('href').split('#')[0]; // hrefのパス部分を取得
+      let currentPath = window.location.pathname; // 現在のページのパス
 
-      // 同一パスかつ同一階層かチェック
-      let currentPathArray = currentPath.split('/');
-      let linkPathArray = linkPath.split('/');
-      let flag = (linkPath !== '' && currentPathArray.slice(-linkPathArray.length).join('/') !== linkPath);
+      // linkHrefが空の場合（#はじまりのリンク）は同一ページと判定
+      let isSamePage = !linkHref || new URL(linkHref, window.location.origin).pathname === currentPath;
 
-      // パスや階層が異なる場合は何もせずに通常のリンク遷移を行う
-      if (flag) return;
-
+      // 他ページの場合は何もせずに通常のリンク遷移を行う
+      if (!isSamePage) return;
 
       e.preventDefault();
 


### PR DESCRIPTION
以下の２つのリンク機能があった時に共存させる
A：ページAではページ内アンカーとして利用
B：ページA以外ではページAの指定場所への直接リンクとして利用

例
```
+a("/pageA/#block01").js-anchor block01
+a("/pageA/#block02").js-anchor block02
+a("/pageA/#block03").js-anchor block03
```


実装コードは以下changed fileを参照