### PR TITLE
[update] download/page/ : モーダル発火用のJS変更が反映できていなかったのを修正

### DIFF
--- a/app/download/page/index.pug
+++ b/app/download/page/index.pug
@@ -28,7 +28,7 @@ block body
             +e.images
               +e.image: .is-no NO IMAGE
               +loop(5)
-                +ae("/assets/images/img-card-01.jpg").image.js-modal-image
+                +ae("/assets/images/img-card-01.jpg").image.c-modal-link.js-modal(data-modal-type="image")
                   +img("img-card-01.jpg")
             +e.slider.js-document-slider.swiper
               +e.slider-wrapper.swiper-wrapper


### PR DESCRIPTION
▼改善事項
https://www.notion.so/growgroup/download-page-format-micromodal-121eef14914a807587e6da72a15adcff

## 内容
https://github.com/growgroup/gg-styleguide/pull/156 のときの変更が、
/download/page/で漏れていたため、その反映。

`+ae("/assets/images/img-card-01.jpg").image.js-modal-image`

↓↓

`+ae("/assets/images/img-card-01.jpg").image.c-modal-link.js-modal(data-modal-type="image")`