### PR TITLE
[update] .gitignore : base/ の削除

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -76,7 +76,6 @@ bower_components
 ### App ###
 dist/
 styleguide/
-base/
 tests/results/
 
 ### basic ###


### PR DESCRIPTION
▼改善事項
https://www.notion.so/growgroup/gitignore-base-ignore-131eef14914a8059a60bef5dcf6f9d6a

## やったこと
.gitignore から base/ を削除