### PR TITLE
[update] mixin icon-font

### DIFF
--- a/app/assets/scss/foundation/_mixin.scss
+++ b/app/assets/scss/foundation/_mixin.scss
@@ -570,6 +570,7 @@
 
 @mixin icon-font-size-control{
   display: inline-block;
+  flex-shrink: 0;
   width: 1em;
   height: 1em;
 }

--- a/app/assets/scss/object/components/breadcrumb.scss
+++ b/app/assets/scss/object/components/breadcrumb.scss
@@ -8,28 +8,26 @@
 
   &__inner {
     //三点リーダーの色を変更したい場合はここにcolorを入れる
+    font-size: rem-calc(12);
+    line-height: 1.5;
 
     @include breakpoint(small only) {
       @include line-clamp(1);
     }
 
     span {
-      @include font-format-light(12,19);
-
       &.is-arrow {
         margin:0 rem-calc(8);
-        align-items: center;
-
+        font-size: rem-calc(10);
+        line-height: 1;
+        vertical-align: middle;
         span {
-          font-size: rem-calc(12);
-          vertical-align: middle;
           display:inline-flex;
         }
       }
 
       a {
         display: inline-flex; //iOS17でパンくずがクリックできない問題の対応
-        @include font-format-light(12,19);
       }
     }
   }

--- a/app/assets/scss/object/components/icon-font.scss
+++ b/app/assets/scss/object/components/icon-font.scss
@@ -2,8 +2,7 @@
 // span.c-icon-font close
 
 .c-icon-font {
-  font-family: $font-icon-family;
-  @include icon-font-style();
+  @include icon-font();
 
   //アイコンを複数混在させる必要がある場合
   //&.is-outlined{


### PR DESCRIPTION
▼改善事項
https://www.notion.so/growgroup/mixin-icon-font-flex-shrink-0-137eef14914a8045945bf4d939fb8d2f

## やったこと
- `mixin icon-font()` に `flex-shrink: 0;` の追加。
- .c-icon-font にincludeするCSSが `mixin icon-font-size-control()` のものを含むように変更
- 上記に伴いc-breadcrumbが崩れるので崩れないように調整

## 結果

```
.c-icon-font {
    font-family: "Material Icons";
    font-weight: normal;
    font-style: normal;
    line-height: 1;
    letter-spacing: 0;
    text-transform: none;
    overflow: hidden;
    display: inline-block;
    flex-shrink: 0;
    width: 1em;
    height: 1em;
}
```

## よいこと
- display:flex でアイコンと文字を横に並べたとき、アイコンの表示が消えたり意図しないものに変化するのを防ぎます
- `.c-icon-font` で設置したアイコンについて、ロード時に文字が見えて横に伸びるのを防ぐと共に、上記の効果を付与します。