### PR TITLE
[update]scss繰り返し処理の簡易化

### DIFF
--- a/app/assets/scss/layout/section.scss
+++ b/app/assets/scss/layout/section.scss
@@ -7,59 +7,47 @@
 //
 // Styleguide 5.3.0
 
-$xlg: 120;
-$lg: 100;
-$md: 80;
-$sm: 64;
-$xs: 32;
+// サイズ定義 (必ずPC用, SP用の2つの値を指定)
+$sizes: (
+  xlg: (120, 60),
+  lg: (100, 50),
+  md: (80, 40),
+  sm: (64, 32),
+  xs: (32, 16),
+);
+
 
 .l-section {
+
   // サイズ設定
+  @each $key, $value in $sizes {
+    $pc-value: nth($value, 1); // PC用
+    $sp-value: nth($value, 2); // SP用
 
+    &.is-#{$key} {
+      padding-top: rem-calc($pc-value);
+      padding-bottom: rem-calc($pc-value);
+      @include breakpoint(small down) {
+        padding-top: rem-calc($sp-value);
+        padding-bottom: rem-calc($sp-value);
+      }
 
-  &.is-xlg {
-    padding-top: rem-calc($xlg);
-    padding-bottom: rem-calc($xlg);
-    @include breakpoint(small only) {
-      padding-top: rem-calc($xlg) * 0.5;
-      padding-bottom: rem-calc($xlg) * 0.5;
+      &-top {
+        padding-top: rem-calc($pc-value);
+        @include breakpoint(small down) {
+          padding-top: rem-calc($sp-value);
+        }
+      }
+
+      &-bottom {
+        padding-bottom: rem-calc($pc-value);
+        @include breakpoint(small down) {
+          padding-bottom: rem-calc($sp-value);
+        }
+      }
     }
   }
 
-  &.is-lg {
-    padding-top: rem-calc($lg);
-    padding-bottom: rem-calc($lg);
-    @include breakpoint(small only) {
-      padding-top: rem-calc($lg) * 0.5;
-      padding-bottom: rem-calc($lg) * 0.5;
-    }
-  }
-
-  &.is-md {
-    padding-top: rem-calc($md);
-    padding-bottom: rem-calc($md);
-    @include breakpoint(small only) {
-      padding-top: rem-calc($md) * 0.5;
-      padding-bottom: rem-calc($md) * 0.5;
-    }
-  }
-
-  &.is-sm {
-    padding-top: rem-calc($sm);
-    padding-bottom: rem-calc($sm);
-    @include breakpoint(small only) {
-      padding-top: rem-calc($sm) * 0.5;
-      padding-bottom: rem-calc($sm) * 0.5;
-    }
-  }
-  &.is-xs {
-    padding-top: rem-calc($xs);
-    padding-bottom: rem-calc($xs);
-    @include breakpoint(small only) {
-      padding-top: rem-calc($xs) * 0.5;
-      padding-bottom: rem-calc($xs) * 0.5;
-    }
-  }
 
   // カラー設定
   //->プライマリー

--- a/app/assets/scss/object/utility/margin.scss
+++ b/app/assets/scss/object/utility/margin.scss
@@ -2,61 +2,33 @@
 // margin size
 
 $default: 56;
-$xlg: 120;
-$lg: 100;
-$md: 64;
-$sm: 42;
-$xs: 24;
+$sizes: (
+  xlg: 120,
+  lg: 100,
+  md: 64,
+  sm: 42,
+  xs: 24,
+);
+
 
 .u-mbs {
   margin-top: rem-calc($default);
   margin-bottom: rem-calc($default);
-  @include breakpoint(small only) {
+  @include breakpoint(small down) {
     margin-top: rem-calc($default) * 0.5;
     margin-bottom: rem-calc($default) * 0.5;
   }
 
-  &.is-xlg {
-    margin-top: rem-calc($xlg);
-    margin-bottom: rem-calc($xlg);
-    @include breakpoint(small only) {
-      margin-top: rem-calc($xlg) * 0.5;
-      margin-bottom: rem-calc($xlg) * 0.5;
+  @each $key, $value in $sizes {
+    &.is-#{$key} {
+      margin-top: rem-calc($value);
+      margin-bottom: rem-calc($value);
+      @include breakpoint(small down) {
+        margin-top: rem-calc($value) * 0.5;
+        margin-bottom: rem-calc($value) * 0.5;
+      }
     }
   }
-  &.is-lg {
-    margin-top: rem-calc($lg);
-    margin-bottom: rem-calc($lg);
-    @include breakpoint(small only) {
-      margin-top: rem-calc($lg) * 0.5;
-      margin-bottom: rem-calc($lg) * 0.5;
-    }
-  }
-  &.is-md {
-    margin-top: rem-calc($md);
-    margin-bottom: rem-calc($md);
-    @include breakpoint(small only) {
-      margin-top: rem-calc($md) * 0.5;
-      margin-bottom: rem-calc($md) * 0.5;
-    }
-  }
-  &.is-sm {
-    margin-top: rem-calc($sm);
-    margin-bottom: rem-calc($sm);
-    @include breakpoint(small only) {
-      margin-top: rem-calc($sm) * 0.5;
-      margin-bottom: rem-calc($sm) * 0.5;
-    }
-  }
-  &.is-xs {
-    margin-top: rem-calc($xs);
-    margin-bottom: rem-calc($xs);
-    @include breakpoint(small only) {
-      margin-top: rem-calc($xs) * 0.5;
-      margin-bottom: rem-calc($xs) * 0.5;
-    }
-  }
-
 
   &.is-top {
     margin-bottom: 0 !important;
@@ -65,5 +37,4 @@ $xs: 24;
   &.is-bottom {
     margin-top: 0 !important;
   }
-
 }

--- a/app/assets/scss/object/utility/margin.scss
+++ b/app/assets/scss/object/utility/margin.scss
@@ -3,15 +3,15 @@
 
 $default: 56;
 $sizes: (
-  xlg: 120,
-  lg: 100,
-  md: 64,
-  sm: 42,
-  xs: 24,
+  xlg: (120, 60),
+  lg: (100, 50),
+  md: (64, 32),
+  sm: (42, 20),
+  xs: (24, 12),
 );
 
-
 .u-mbs {
+
   margin-top: rem-calc($default);
   margin-bottom: rem-calc($default);
   @include breakpoint(small down) {
@@ -19,13 +19,17 @@ $sizes: (
     margin-bottom: rem-calc($default) * 0.5;
   }
 
+  // サイズ設定
   @each $key, $value in $sizes {
+    $pc-value: nth($value, 1); // PC用
+    $sp-value: nth($value, 2); // SP用
+
     &.is-#{$key} {
-      margin-top: rem-calc($value);
-      margin-bottom: rem-calc($value);
+      margin-top: rem-calc($pc-value);
+      margin-bottom: rem-calc($pc-value);
       @include breakpoint(small down) {
-        margin-top: rem-calc($value) * 0.5;
-        margin-bottom: rem-calc($value) * 0.5;
+        margin-top: rem-calc($sp-value);
+        margin-bottom: rem-calc($sp-value);
       }
     }
   }


### PR DESCRIPTION
.l-section、u-mbsの繰り返し処理の簡易化

例
旧記述方法
```
.l-section {
  &.is-xlg {
    padding-top: rem-calc($xlg);
    padding-bottom: rem-calc($xlg);
    @include breakpoint(small only) {
      padding-top: rem-calc($xlg) * 0.5;
      padding-bottom: rem-calc($xlg) * 0.5;
    }
  }

  &.is-lg {
    padding-top: rem-calc($lg);
    padding-bottom: rem-calc($lg);
    @include breakpoint(small only) {
      padding-top: rem-calc($lg) * 0.5;
      padding-bottom: rem-calc($lg) * 0.5;
    }
  }
}
```

新記述方法
```
$sizes: (
  xlg: (120, 60),
  lg: (100, 50),
  md: (80, ),
  sm: (64, 28),
  xs: (32, 20),
);

.l-section {
  @each $key, $value in $sizes {
    &.is-#{$key} {
      margin-top: rem-calc($value);
      margin-bottom: rem-calc($value);
      @include breakpoint(small down) {
        margin-top: rem-calc($value) * 0.5;
        margin-bottom: rem-calc($value) * 0.5;
      }
    }
  }
}
```