### PR TITLE
[update]slidebar-menuの背景色とテキストカラーの変数設定、scss記述整理

### DIFF
--- a/app/assets/scss/foundation/_settings.scss
+++ b/app/assets/scss/foundation/_settings.scss
@@ -102,6 +102,7 @@ $header-height-sp: 55 !default; // スクロール位置をずらす計算にも
 
 // スライドバー（スマホメニュー）
 $slidebar-menu-bg: $color-primary !default;
+$slidebar-menu-text-color: $color-white !default;
 $slidebar-menu-width: 100% !default;
 $slidebar-container-bg: rgba(0, 0, 0, 0.8) !default;
 $slidebar-header-height: $header-height-sp !default; // スマホ時のヘッダーの高さ

--- a/app/assets/scss/object/components/slidebar-menu.scss
+++ b/app/assets/scss/object/components/slidebar-menu.scss
@@ -34,7 +34,6 @@
   // メニュー要素（一番外・全体で共通する設定）
   &__list {
     width: 100%;
-    background: $color-primary;
     font-size: rem-calc(14);
     font-weight: 700;
 
@@ -62,8 +61,8 @@
   }
 
   &__parent { //親li
-    color: $color-white;
-    border-bottom: solid 1px rgba(255, 255, 255, 0.4);
+    color: $slidebar-menu-text-color;
+    border-bottom: solid 1px rgba($slidebar-menu-text-color, 0.4);
 
     &.is-open {
       //background: $color-white;


### PR DESCRIPTION
# 概要
slidebar-menu.scss内にて、&__linkにbackgroundが設定されていため、$slidebar-menu-bg変数の値を変更しても、一発でslidebarの背景色が変わらなかった。
文字色の設定、ボーダー色の設定も、_settings.scss内の変数で一括指定できるように変更。

## 変更内容
- _settings.scssに新規で$slidebar-menu-text-color変数を設定
- slidebar-menu.scss内
  - &__listのbackground削除
  - &__parentのcolor, border-bottomのカラー設定を変数に置き換え