### PR TITLE
slidebar : inert属性値の使い方の修正

### DIFF
--- a/app/assets/js/app/slidebar.js
+++ b/app/assets/js/app/slidebar.js
@@ -115,7 +115,7 @@ export default class Slidebar {
   close() {
     $("body").removeClass('is-slidebar-active');
     this.isActive = false;
-    this.menu.attr("inert", "true");
+    this.menu.attr("inert", "inert");
 
     this.focusToOuterMenu();
   }
@@ -158,7 +158,7 @@ export default class Slidebar {
         if (entry.contentRect.width > this.options.activateWidth) {
           document.body.classList.remove("is-slidebar-active");
           this.isActive = false;
-          this.menu.attr("inert", "true");
+          this.menu.attr("inert", "inert");
         }
       }
     });

--- a/app/inc/mixins/_slidebar.pug
+++ b/app/inc/mixins/_slidebar.pug
@@ -9,7 +9,7 @@ mixin c_slidebar
       +e("span").text.is-open MENU
       +e("span").text.is-close CLOSE
 
-  +c.slidebar-menu.js-slidebar-menu.is-top-to-bottom(inert="true")
+  +c.slidebar-menu.js-slidebar-menu.is-top-to-bottom(inert="inert")
     +ul.list
       +li.parent.js-accordion
         +span.parent-link(data-accordion-title='menu-title') メニュー レベル1


### PR DESCRIPTION
▼改善事項
https://www.notion.so/growgroup/slidebar-inert-inert-true-inert-inert-153eef14914a800f963cfdb8d0622634

---

# やったこと
https://github.com/growgroup/gg-styleguide/pull/101 で追加したinert属性について、
bool属性（`<div inert>`のように値が不要な属性）で値を使う場合は `属性名="属性名"` の方が正確だったので
以下のように修正。

```
+c.slidebar-menu.js-slidebar-menu.is-top-to-bottom(inert="inert")
```

その上で、JSの処理も同様に修正。