### PR TITLE
swiper : thresholdのパラメーターをデフォルトに追加（スワイプする要素内のリンクがクリックできない場合がある問題の解決）

### DIFF
--- a/app/assets/js/app/swiper.js
+++ b/app/assets/js/app/swiper.js
@@ -108,6 +108,8 @@ export default class SwiperSlider {
 
     const swiper = new Swiper(targetSelector, {
       loop: true,
+      //loopedSlidesLimit:false, //スライドの複製を無制限にする
+      //loopedSlides: 2, //スライドの複製数を指定する
       effect: 'fade',
       autoplay: {
         delay: delayTime, // ４秒後に次の画像へ
@@ -115,6 +117,7 @@ export default class SwiperSlider {
       },
       speed: 2000,
       allowTouchMove: false,
+      threshold: 10, // allowTouchMoveがtrueのとき、スライド内のリンクがクリックできない問題の解決
       pagination: {
         el: pagination, // ページネーションのクラス名を指定
       },
@@ -213,6 +216,8 @@ export default class SwiperSlider {
     return new Swiper(target, {
       spaceBetween: 40,
       loop: true,
+      // loopedSlidesLimit:false, //スライドの複製を無制限にする
+      // loopedSlides: 2, //スライドの複製数を指定する
       navigation: {
         nextEl: next,
         prevEl: prev,
@@ -221,6 +226,7 @@ export default class SwiperSlider {
         el: pagination,
         clickable: false,
       },
+      threshold: 10, // allowTouchMoveがtrueのとき、スライド内のリンクがクリックできない問題の解決
       keyboard: {
         enabled: true,
         onlyInViewport: true,
@@ -304,6 +310,8 @@ export default class SwiperSlider {
 
       const swiper = new Swiper(target, {
         loop: true,
+        //loopedSlidesLimit:false, //スライドの複製を無制限にする
+        //loopedSlides: 2, //スライドの複製数を指定する
         effect: 'slide',
         autoplay: {
           delay: delayTime, // ４秒後に次の画像へ
@@ -311,6 +319,7 @@ export default class SwiperSlider {
         },
         speed: 400,
         allowTouchMove: false,
+        threshold: 10, // allowTouchMoveがtrueのとき、スライド内のリンクがクリックできない問題の解決
         navigation: {
           nextEl: next,
           prevEl: prev,


### PR DESCRIPTION
▼改善事項
https://www.notion.so/growgroup/Swiper-threshold-145eef14914a80efa7a0ed3866c98306

---

# 起きていた問題
マウス（タッチ操作）でのスワイプでスライド切り替えができる仕様の時、
スライド内のリンクをクリックできない場合がある

# 対応したこと
参考情報：https://ruka-tech.xyz/useful-info/make-swiper-more-user-friendly

swiper.js内の各サンプル実装コードに、 `threshold:10,` を追加


# 追加で記述したコメントについて

```
      // loopedSlidesLimit:false, //スライドの複製を無制限にする
      // loopedSlides: 2, //スライドの複製数を指定する
```

こういうデザインのスライドショーで、スライド数が1〜2枚のとき（※1枚のときはスライド発火を切らないパターンのとき）
`loopedSlides` を書いてもスライド切り替え時に「一瞬スライド枚数が足りない」問題が起きがち。

![CleanShot 2024-12-09 at 18 20 07](https://github.com/user-attachments/assets/8b6a7bdc-f34c-4fbc-84b4-002b4da68f7c)


そのとき `loopedSlidesLimit:false`にすると上手くいくのでそのヒントとしてコメントを追加。
