### PR TITLE
目次（toc）の見た目の調整

### DIFF
--- a/app/assets/scss/object/components/toc.scss
+++ b/app/assets/scss/object/components/toc.scss
@@ -17,6 +17,10 @@ category: PostContent
     padding: rem-calc(16) rem-calc(24) rem-calc(24);
   }
 
+  &.contracted .toc_title{
+    margin-bottom: 0;
+  }
+
   .toc_title {
     text-align: center;
     font-size: 1.125rem;
@@ -34,6 +38,8 @@ category: PostContent
     padding-left: 0;
   }
   .toc_list li {
+    padding-left: 0;
+
     &::before {
       display: none;
     }


### PR DESCRIPTION
▼改善事項
https://www.notion.so/growgroup/166eef14914a803dbf4df8574c883581

# 対応内容
- 目次を閉じる操作をしたとき（WP組み込み後）に、下側余白が広すぎる問題の解決
- （ついでに）リストの左側余白が l-post-content のCSSの影響で余分についていた問題の解決

## 目次を閉じる操作をしたときの余白調整の詳細
以下を追加しました。

```
#toc_container.contracted .toc_title {
    margin-bottom: 0;
}
```
![CleanShot 2024-12-26 at 09 22 46](https://github.com/user-attachments/assets/d4a88f14-97d4-49ea-9e96-86a8769dcb6f)
