### PR TITLE
remove rel='shortcut icon'

### DIFF
--- a/app/inc/foundation/_head.pug
+++ b/app/inc/foundation/_head.pug
@@ -46,7 +46,6 @@ html(lang="ja")
     //- リンクファイル
     block link
       +link("/assets/images/favicon.ico")(rel='icon')
-      +link("/assets/images/favicon.ico")(rel='shortcut icon')
       +link("/assets/images/web-clipicon.png")(rel='apple-touch-icon')
 
     //- スタイルシート


### PR DESCRIPTION
▼改善事項
https://www.notion.so/growgroup/favicon-165eef14914a80baa4c7ce0b23c9601c

# 対応したこと
` +link("/assets/images/favicon.ico")(rel='shortcut icon')` を削除しました。

## 参考
https://developer.mozilla.org/ja/docs/Web/HTML/Attributes/rel#values:~:text=shortcut
> shortcut リンク種別が icon の前に見られることが良くありますが、このリンク種別は適合するものではなく、無視されるので使用しないでください。