### PR TITLE
[update] :hover to @include hover()

### DIFF
--- a/app/assets/scss/foundation/_mixin.scss
+++ b/app/assets/scss/foundation/_mixin.scss
@@ -259,9 +259,10 @@
 @mixin button_colors($color){
   background: $color;
   border-color: $color;
-  &:hover {
-    background: #fff;
-    color: $color;
+
+  @include hover() {
+    background: $color;
+    color: #fff;
   }
 }
 

--- a/app/assets/scss/layout/footer.scss
+++ b/app/assets/scss/layout/footer.scss
@@ -74,7 +74,8 @@ category: Layout
         padding: rem-calc(14) rem-calc(24);
         display: block;
         background-color: $font-base-color;
-        &:hover {
+
+        @include hover() {
           opacity: 1;
         }
       }

--- a/app/assets/scss/layout/header.scss
+++ b/app/assets/scss/layout/header.scss
@@ -73,6 +73,7 @@ category: Layout
     }
 
     li {
+      //submenu表示用のhoverは hover mixinの利用を避ける
       &:hover {
         .l-header__submenu {
           visibility: visible;
@@ -103,7 +104,8 @@ category: Layout
         }
 
         //*hover
-        &:hover {
+
+        @include hover() {
           opacity: 1;
           color: $color-primary;
 
@@ -194,7 +196,7 @@ category: Layout
       display: block;
     }
 
-    &:hover {
+    @include hover() {
       color: $color-primary;
     }
   }
@@ -267,7 +269,12 @@ category: Layout
       font-size: rem-calc(18);
     }
 
-    &:hover, &.is-active {
+    @include hover() {
+      background: $color-primary;
+      color: $color-white;
+      border-color: $color-primary;
+    }
+    &.is-active {
       background: $color-primary;
       color: $color-white;
       border-color: $color-primary;

--- a/app/assets/scss/layout/searchform.scss
+++ b/app/assets/scss/layout/searchform.scss
@@ -44,9 +44,11 @@
       right: rem-calc(-4);
       top: rem-calc(-48);
     }
-    &:hover {
+
+    @include hover(){
       opacity: 0.5;
     }
+
     &__icon {
       font-size: rem-calc(48);
     }

--- a/app/assets/scss/object/components/banners.scss
+++ b/app/assets/scss/object/components/banners.scss
@@ -34,8 +34,8 @@ category: Banners
       }
     }
 
-    // *hover
-    &:hover {
+
+    @include hover(){
       opacity: 1;
 
       .c-banners__image {
@@ -112,7 +112,7 @@ category: Banners
         display: none;
       }
 
-      &:hover {
+      @include hover() {
         .c-banners__button {
           &::after {
             right: 0;

--- a/app/assets/scss/object/components/block-modal-form.scss
+++ b/app/assets/scss/object/components/block-modal-form.scss
@@ -122,7 +122,7 @@
         @include font-format(12,.08,18,400);
       }
 
-      &:hover {
+      @include hover() {
         opacity: .5;
       }
     }
@@ -179,7 +179,7 @@
       }
     }
 
-    &:hover {
+    @include hover() {
       opacity: 0.5;
     }
   }

--- a/app/assets/scss/object/components/card-download.scss
+++ b/app/assets/scss/object/components/card-download.scss
@@ -48,7 +48,7 @@
       }
     }
 
-    &:hover {
+    @include hover() {
       opacity: 1;
 
       img {

--- a/app/assets/scss/object/components/embed.scss
+++ b/app/assets/scss/object/components/embed.scss
@@ -19,7 +19,8 @@
     display: block;
     color: inherit;
 
-    &:hover {
+
+    @include hover() {
       opacity: 0.7;
 
       .c-embed__image-bg {
@@ -105,9 +106,10 @@
       color: $font-base-color;
       text-decoration: none;
       //color: inherit;
-      &:hover {
+      @include hover() {
         opacity: 0.7;
       }
+
     }
   }
 

--- a/app/assets/scss/object/components/forms-document-detail.scss
+++ b/app/assets/scss/object/components/forms-document-detail.scss
@@ -70,13 +70,14 @@
         margin: 0;
         @include transition();
 
-        &:after {
+        &::after {
           content: "chevron_right";
           @include icon-font();
           color: $color-primary;
         }
 
-        &:hover {
+
+        @include hover() {
           opacity: 0.5;
         }
       }

--- a/app/assets/scss/object/components/gallery-card.scss
+++ b/app/assets/scss/object/components/gallery-card.scss
@@ -68,15 +68,16 @@
         height: rem-calc(48);
       }
 
-      &:after {
+      &::after {
         content: "chevron_right";
         @include icon-font();
         color: $color-primary;
       }
 
-      &:hover {
+      @include hover() {
         opacity: 0.5;
       }
+
     }
 
     .swiper-button-prev {
@@ -86,7 +87,7 @@
         margin-right: rem-calc(12);
       }
 
-      &:after {
+      &::after {
         transform: rotate(-180deg);
       }
     }

--- a/app/assets/scss/object/components/gallery-slider.scss
+++ b/app/assets/scss/object/components/gallery-slider.scss
@@ -186,7 +186,8 @@
         @include transition();
       }
 
-      &:hover {
+
+      @include hover() {
         opacity: 1;
       }
 

--- a/app/assets/scss/object/components/hero-block-line.scss
+++ b/app/assets/scss/object/components/hero-block-line.scss
@@ -1,3 +1,5 @@
+@use "sass:math";
+
 .c-hero-block-line {
   overflow: hidden;
 
@@ -79,7 +81,7 @@
       @include transition(.2s);
     }
 
-    &:hover {
+    @include hover() {
       &::after {
         opacity: 0.3;
       }

--- a/app/assets/scss/object/components/menu-list.scss
+++ b/app/assets/scss/object/components/menu-list.scss
@@ -52,7 +52,17 @@ category: Navigation
       }
 
       //*hover
-      &:hover, &.is-current {
+      @include hover(){
+        opacity: 1;
+        color: $color-primary;
+
+        &::after {
+          width: 100%;
+          opacity: 1;
+        }
+      }
+
+      &.is-current {
         opacity: 1;
         color: $color-primary;
 

--- a/app/assets/scss/object/components/mm.scss
+++ b/app/assets/scss/object/components/mm.scss
@@ -178,7 +178,7 @@ Styles for the Modal component.
       @include icon-font();
     }
 
-    &:hover{
+    @include hover(){
       &:not(:disabled){
         color: $color-primary;
       }

--- a/app/assets/scss/object/components/modaal.scss
+++ b/app/assets/scss/object/components/modaal.scss
@@ -17,8 +17,8 @@
   right: 0;
   transform: translateY(-100%);
 
-  &:hover {
 
+  @include hover(){
     &:before, &:after {
       background: $color-primary;
     }
@@ -49,7 +49,7 @@
     color: $color-white;
   }
 
-  &:hover {
+  @include hover(){
     opacity: 0.5;
   }
 }

--- a/app/assets/scss/object/components/modal-link.scss
+++ b/app/assets/scss/object/components/modal-link.scss
@@ -18,7 +18,7 @@
     color: $color-white;
   }
 
-  &:hover {
+  @include hover() {
     opacity: 0.5;
   }
 }

--- a/app/assets/scss/object/components/news-lg.scss
+++ b/app/assets/scss/object/components/news-lg.scss
@@ -19,7 +19,7 @@ category: News
       padding-top: 0;
     }
 
-    &:any-link:hover {
+    @include hover() {
       background-color: $color-secondary;
     }
   }

--- a/app/assets/scss/object/components/news.scss
+++ b/app/assets/scss/object/components/news.scss
@@ -67,8 +67,8 @@ category: News
       padding-top: 0;
     }
 
-    &:any-link:hover {
-      background-color: $color-secondary;
+    @include hover(){
+        background-color: $color-secondary;
     }
   }
 

--- a/app/assets/scss/object/components/pagetop.scss
+++ b/app/assets/scss/object/components/pagetop.scss
@@ -41,7 +41,8 @@
       @include icon-font();
     }
 
-    &:hover {
+
+    @include hover() {
       color: $font-base-color;
       background: $color-white;
     }

--- a/app/assets/scss/object/components/pagination.scss
+++ b/app/assets/scss/object/components/pagination.scss
@@ -37,7 +37,7 @@ category: Navigation
       height: rem-calc(40);
     }
 
-    &:hover {
+    @include hover(){
       opacity: 1;
       background: $color-primary;
       color: $color-white;

--- a/app/assets/scss/object/components/searchform-bar.scss
+++ b/app/assets/scss/object/components/searchform-bar.scss
@@ -76,7 +76,8 @@
       font-size: rem-calc(12);
     }
 
-    &:hover {
+
+    @include hover() {
       opacity: 0.5;
     }
   }

--- a/app/assets/scss/object/components/slidebar-button.scss
+++ b/app/assets/scss/object/components/slidebar-button.scss
@@ -26,11 +26,6 @@
   border: none;
   padding: 0;
 
-  &:active,
-  &:hover {
-    opacity: 1;
-  }
-
   &__inner {
     display: grid;
     position: absolute;

--- a/app/assets/scss/object/components/slidebar-menu.scss
+++ b/app/assets/scss/object/components/slidebar-menu.scss
@@ -222,10 +222,6 @@
       font-size: rem-calc(18);
       color: $color-primary;
     }
-
-    &:hover,
-    &.is-active {
-    }
   }
 
   &__search-icon {

--- a/app/assets/scss/object/components/tabs.scss
+++ b/app/assets/scss/object/components/tabs.scss
@@ -54,7 +54,7 @@ category: Tabs
       }
 
       // *hover
-      &:hover {
+      @include hover(){
         background-color: color.adjust($color-primary, $lightness: 45%);
         opacity: 1;
       }
@@ -64,7 +64,7 @@ category: Tabs
         background-color: $color-primary;
         color: $color-white;
 
-        &:hover {
+        @include hover(){
           opacity: 1;
         }
       }

--- a/app/assets/scss/object/components/toc.scss
+++ b/app/assets/scss/object/components/toc.scss
@@ -58,7 +58,7 @@ category: PostContent
       color: $font-base-color;
       font-weight: 400;
 
-      &:hover {
+      @include hover(){
         text-decoration: none;
         background: rgba(214, 214, 214, 0.2);
       }

--- a/app/assets/scss/object/utility/text.scss
+++ b/app/assets/scss/object/utility/text.scss
@@ -83,8 +83,11 @@ del,
   }
 }
 
-:where(a):hover,
-.u-text-link:any-link:hover,
+:where(a),.u-text-link{
+  @include hover(){
+    opacity: 0.5;
+  }
+}
 .u-text-link.is-hover {
   opacity: 0.5;
 }


### PR DESCRIPTION
# 内容
ほぼすべての&:hoverを @include hover()に置き換え

# 理由
実案件中で `a:hover{opacity:0.5}`と`@include hover()` を併用したときに、
タッチデバイスで意図せず透けて問題となる事例があったため（タブUIのような、ページ遷移を伴わないaタグにて）

# 結果発生すること
- タッチデバイスで `a:hover{opacity:0.5}` のスタイルが効かなくなる
- そのほかは、普段 `@include hover()` でホバースタイルを書いていれば大きな変化はなし
  - gg-styleguide上に初めから存在するスタイルに関して、CSSの記述順序が変化した都合上スタイルの当たり方が変わっているものがある可能性があります
  （`@media` で囲まれたものが、出力されるCSSの最後にまとまるため、適用されるCSSが変わることがあるかも）

# 例外
l-headerのサブナビ展開用 `:hover` はタッチデバイスでも展開させたい場合があるので、
`:hover`のままとした