### PR TITLE
[update] editor.scss

### DIFF
--- a/app/assets/scss/editor.scss
+++ b/app/assets/scss/editor.scss
@@ -50,7 +50,7 @@
 #growp-editor-wrapper {
   font-family: $font-base-family !important;
 
-  &:is(.post-type-post,.growp-post-content) :is(.is-root-container,.mce-content-body), //投稿画面
+  &:is(.post-type-post,.growp-post-content) :is(.is-root-container,.mce-content-body) //投稿画面
   {
     //max-width: rem-calc(736);
     @include l-post-content;

--- a/app/assets/scss/editor.scss
+++ b/app/assets/scss/editor.scss
@@ -50,7 +50,7 @@
 #growp-editor-wrapper {
   font-family: $font-base-family !important;
 
-  &:is(.post-type-post) .is-root-container //投稿画面
+  &:is(.post-type-post,.growp-post-content) :is(.is-root-container,.mce-content-body), //投稿画面
   {
     //max-width: rem-calc(736);
     @include l-post-content;


### PR DESCRIPTION
改善事項
https://www.notion.so/growgroup/editor-scss-is-root-container-mce-content-body-is-post-type-post-growp-post-content-174eef14914a805bb3ddcd33295973ae

## 変更点
`&:is(.post-type-post) .is-root-container` の部分を
`&:is(.post-type-post,.growp-post-content) :is(.is-root-container,.mce-content-body)` に変更しました。

### editor.scss
```
#growp-editor-wrapper {
  font-family: $font-base-family !important;

  &:is(.post-type-post,.growp-post-content) :is(.is-root-container,.mce-content-body) //投稿画面
  {
    //max-width: rem-calc(736);
    @include l-post-content;
  }
```

### こんな風にでます
```
#growp-editor-wrapper:is(.post-type-post,.growp-post-content) :is(.is-root-container,.mce-content-body){display:flow-root}
#growp-editor-wrapper:is(.post-type-post,.growp-post-content) :is(.is-root-container,.mce-content-body)>*+*{margin-top:1em}
など
```