### PR TITLE
[add] scss functions : vw-calc, cqw-calc, min-vw, clamp-vw

### DIFF
--- a/app/assets/scss/foundation/_mixin.scss
+++ b/app/assets/scss/foundation/_mixin.scss
@@ -78,7 +78,7 @@
 }
 
 // 値をcqwに変換する関数
-// container-size:inline で指定したコンテナのデザイン上の幅を第2引数に指定すること
+// container-type を指定したコンテナのデザイン上の幅を第2引数に指定すること
 @function cqw-calc($value, $container-width: 1400) {
   @return strip-unit($value) / strip-unit($container-width) * 100cqw;
 }
@@ -102,14 +102,14 @@
 }
 
 // レスポンシブな値を生成するためのclamp関数
-// @param {Number} $values... - 設定値（順番に基準値、ビューポート幅、最小値、最大ビューポート幅）
+// @param {Number} $values... - 設定値（順番に基準値、最小値、最大ビューポート幅、ビューポート幅）
 // @return {String} - clamp関数を使用したレスポンシブな値
 // @example
 //   .element {
 //     font-size: clamp-vw(16);             // 基準値のみ
-//     padding: clamp-vw(20, 1400);         // 基準値, ビューポート幅
-//     margin: clamp-vw(24, 1400, 12);      // 基準値, ビューポート幅, 最小値
-//     width: clamp-vw(100, 1400, 16, 2560);// 基準値, ビューポート幅, 最小値, 最大ビューポート幅
+//     margin: clamp-vw(24, 10);            // 基準値, 最小値
+//     padding: clamp-vw(24, 10, 2560);     // 基準値, 最小値, 最大ビューポート幅
+//     width: clamp-vw(24, 10, 2560, 1400); // 基準値, 最小値, 最大ビューポート幅, ビューポート幅
 //   }
 @function clamp-vw($values...) {
   // デフォルト値の設定
@@ -119,9 +119,9 @@
   $min: 10;            // デフォルトの最小値
 
   // 引数の数に応じて値を上書き
-  @if length($values) >= 2 { $viewport: nth($values, 2); }
-  @if length($values) >= 3 { $min: nth($values, 3); }
-  @if length($values) >= 4 { $viewport-max: nth($values, 4); }
+  @if length($values) >= 2 { $min: nth($values, 2); }
+  @if length($values) >= 3 { $viewport-max: nth($values, 3); }
+  @if length($values) >= 4 { $viewport: nth($values, 4); }
 
   // clamp関数で最小値、可変値、最大値を設定
   @return clamp(

--- a/app/assets/scss/foundation/_mixin.scss
+++ b/app/assets/scss/foundation/_mixin.scss
@@ -84,12 +84,11 @@
 }
 
 // レスポンシブな最小値を生成するmin関数
-// @param {Number} $values... - 設定値（順番に基準値、ビューポート幅）
 // @return {String} - min関数を使用したレスポンシブな値
 // @example
 //   .element {
-//     font-size: miv-vw(16);      // 基準値のみ
-//     margin: miv-vw(24, 1200);   // 基準値, ビューポート幅
+//     font-size: miv-vw(16);      // デザイン上のサイズ
+//     margin: miv-vw(24, 1200);   // 基準値, 基準にするデザインフレームの横幅
 //   }
 @function min-vw($values...) {
   $value: nth($values, 1);
@@ -102,14 +101,13 @@
 }
 
 // レスポンシブな値を生成するためのclamp関数
-// @param {Number} $values... - 設定値（順番に基準値、最小値、最大ビューポート幅、ビューポート幅）
 // @return {String} - clamp関数を使用したレスポンシブな値
 // @example
 //   .element {
-//     font-size: clamp-vw(16);             // 基準値のみ
-//     margin: clamp-vw(24, 10);            // 基準値, 最小値
-//     padding: clamp-vw(24, 10, 2560);     // 基準値, 最小値, 最大ビューポート幅
-//     width: clamp-vw(24, 10, 2560, 1400); // 基準値, 最小値, 最大ビューポート幅, ビューポート幅
+//     font-size: clamp-vw(16);             // デザイン上のサイズ
+//     margin: clamp-vw(24, 10);            // デザイン上のサイズ, 最小値
+//     padding: clamp-vw(24, 10, 2560);     // デザイン上のサイズ, 最小値, 最大画面幅
+//     width: clamp-vw(24, 10, 2560, 1400); // デザイン上のサイズ, 最小値, 最大画面幅, 基準にするデザインフレームの横幅
 //   }
 @function clamp-vw($values...) {
   // デフォルト値の設定

--- a/app/assets/scss/foundation/_mixin.scss
+++ b/app/assets/scss/foundation/_mixin.scss
@@ -71,6 +71,66 @@
   @return strip-unit($value) * 1em;
 }
 
+// 値をvwに変換する関数
+@function vw-calc($value, $viewport: 1400) {
+  // 単位を取り除きvwを掛ける
+  @return strip-unit($value) / strip-unit($viewport) * 100vw;
+}
+
+// 値をcqwに変換する関数
+// container-size:inline で指定したコンテナのデザイン上の幅を第2引数に指定すること
+@function cqw-calc($value, $container-width: 1400) {
+  @return strip-unit($value) / strip-unit($container-width) * 100cqw;
+}
+
+// レスポンシブな最小値を生成するmin関数
+// @param {Number} $values... - 設定値（順番に基準値、ビューポート幅）
+// @return {String} - min関数を使用したレスポンシブな値
+// @example
+//   .element {
+//     font-size: miv-vw(16);      // 基準値のみ
+//     margin: miv-vw(24, 1200);   // 基準値, ビューポート幅
+//   }
+@function min-vw($values...) {
+  $value: nth($values, 1);
+  $viewport: if(length($values) > 1, nth($values, 2), 1400);
+
+  @return min(
+    rem-calc($value),
+    vw-calc($value, $viewport)
+  );
+}
+
+// レスポンシブな値を生成するためのclamp関数
+// @param {Number} $values... - 設定値（順番に基準値、ビューポート幅、最小値、最大ビューポート幅）
+// @return {String} - clamp関数を使用したレスポンシブな値
+// @example
+//   .element {
+//     font-size: clamp-vw(16);             // 基準値のみ
+//     padding: clamp-vw(20, 1400);         // 基準値, ビューポート幅
+//     margin: clamp-vw(24, 1400, 12);      // 基準値, ビューポート幅, 最小値
+//     width: clamp-vw(100, 1400, 16, 2560);// 基準値, ビューポート幅, 最小値, 最大ビューポート幅
+//   }
+@function clamp-vw($values...) {
+  // デフォルト値の設定
+  $value: nth($values, 1);
+  $viewport: 1400;      // デフォルトのビューポート幅
+  $viewport-max: 2560;  // デフォルトの最大ビューポート幅
+  $min: 10;            // デフォルトの最小値
+
+  // 引数の数に応じて値を上書き
+  @if length($values) >= 2 { $viewport: nth($values, 2); }
+  @if length($values) >= 3 { $min: nth($values, 3); }
+  @if length($values) >= 4 { $viewport-max: nth($values, 4); }
+
+  // clamp関数で最小値、可変値、最大値を設定
+  @return clamp(
+    rem-calc($min),
+    vw-calc($value, $viewport),
+    rem-calc($value / $viewport * $viewport-max)
+  );
+}
+
 // ブレイクポイントのメディアクエリ文字列を返し、方向も返す関数
 @function breakpoint($val: small) {
   $bp: nth($val, 1); // ブレイクポイントの値

--- a/app/assets/scss/layout/header.scss
+++ b/app/assets/scss/layout/header.scss
@@ -40,7 +40,7 @@ category: Layout
 
   &__logo {
     margin: 0;
-    width: 175px;
+    width: min-vw(175);
     flex-shrink: 0;
     @include breakpoint(medium down) {
       width: 148px;
@@ -58,7 +58,7 @@ category: Layout
     display: flex;
     justify-content: flex-end;
     align-items: center;
-    gap: rem-calc(24);
+    gap: min-vw(24);
   }
 
 
@@ -66,7 +66,7 @@ category: Layout
   &__mainmenu {
     display: flex;
     align-items: center;
-    gap: rem-calc(32);
+    gap: min-vw(32);
 
     @include breakpoint(medium down) {
       display: none;
@@ -82,7 +82,7 @@ category: Layout
       }
 
       a {
-        font-size: rem-calc(14);
+        font-size: min-vw(14);
         position: relative;
         padding-bottom: rem-calc(36);
 
@@ -210,7 +210,8 @@ category: Layout
 
     &.c-button.is-sm {
       color: $color-white;
-      max-width: rem-calc(196);
+      font-size: min-vw(14);
+      max-width: min-vw(196);
 
       &::after {
         display: none;
@@ -220,7 +221,7 @@ category: Layout
     //*アイコン
     span {
       font-size: rem-calc(16);
-      padding-right: rem-calc(8);
+      padding-right: min-vw(8);
       vertical-align: sub;
     }
   }
@@ -231,16 +232,16 @@ category: Layout
     position: relative;
     display: block;
     width: 100%;
-    max-width: rem-calc(180);
+    max-width: min-vw(180);
 
     border: 1px solid $font-base-color;
     color: $font-base-color;
     background: none;
     border-radius: 16px;
-    font-size: rem-calc(11);
+    font-size: min-vw(11);
     line-height: 1.5;
     font-weight: 400;
-    padding: rem-calc(8) rem-calc(20) rem-calc(8) rem-calc(42);
+    padding: rem-calc(8) min-vw(20) rem-calc(8) min-vw(42);
     @include transition(.2s);
 
 


### PR DESCRIPTION
https://www.notion.so/growgroup/min-clamp-mixin-1a0eef14914a80a09fb4f437442600e9

# 概要
デザインデータ上の数値から、`min()` や `clamp()` の値を容易に作り出すためのmixin

# 追加した関数
1. vw-calc関数
2. cqw-calc関数
3. min-vw関数
4. clamp-vw関数

# 関数の説明（一部）
## min-vw
```
font-size: min-vw(14);
↓↓
font-size: min(0.875rem, 1vw);

font-size: min-vw(14, 1140)
↓↓
font-size: min(0.875rem, 1.2280701754vw);

```

## clamp-vw
```
font-size: clamp-vw(16);
↓↓ 画面幅2560pxまでは大きくなり続ける。最小フォントサイズ10px。
font-size: clamp(0.625rem, 1.2280701754vw, 1.9649122807rem);
```

clamp-vw(24, 12); //最小サイズを変えたいとき
clamp-vw(24, 12, 1400);     //画面幅1400pxで大きくなるのをやめたいとき
clamp-vw(24, 12, 1400, 1000); // 計算の基準にするデザインの幅を変えたいとき

## cqw-calc
container-typeを指定したコンテナのサイズを第2引数として渡して使うと
コンテナのサイズに合わせて要素を可変させられる。

```
font-size: cqw-calc(14,1140); 
↓↓
font-size: 1.2280701754cqw;
```

