### PR TITLE
[add] dropdown.js & dropdown-text-sync.js

### DIFF
--- a/app/assets/js/app.js
+++ b/app/assets/js/app.js
@@ -22,6 +22,7 @@ import GsapAnimation from "./app/gsap";
 // import modaalCss from 'modaal/dist/css/modaal.css';
 import Scrollable from "./app/scrollable";
 import Dropdown from "./app/dropdown";
+import DropdownTextSync from "./app/dropdown-text-sync";
 // import Parallax from "./app/parallax";
 // import LenisScroll from "./app/lenis";
 
@@ -29,6 +30,7 @@ class App {
   constructor() {
     this.Utils = new Utils();
     this.Dropdown = new Dropdown();
+    this.DropdownTextSync = new DropdownTextSync();
     this.Accordion = new Accordion();
     this.Anchor = new Anchor();
     this.FixedHeader = new FixedHeader();

--- a/app/assets/js/app.js
+++ b/app/assets/js/app.js
@@ -21,12 +21,14 @@ import modal from './app/modal.js';
 import GsapAnimation from "./app/gsap";
 // import modaalCss from 'modaal/dist/css/modaal.css';
 import Scrollable from "./app/scrollable";
+import Dropdown from "./app/dropdown";
 // import Parallax from "./app/parallax";
 // import LenisScroll from "./app/lenis";
 
 class App {
   constructor() {
     this.Utils = new Utils();
+    this.Dropdown = new Dropdown();
     this.Accordion = new Accordion();
     this.Anchor = new Anchor();
     this.FixedHeader = new FixedHeader();

--- a/app/assets/js/app/dropdown-text-sync.js
+++ b/app/assets/js/app/dropdown-text-sync.js
@@ -17,7 +17,7 @@ const defaultOptions = {
   selector: '.js-dropdown-text-sync',
   triggerSelector: 'data-dropdown-trigger',
   targetSelector: 'data-dropdown-target',
-  currentClass: 'is-current',
+  currentClasses: ['is-current', 'is-active', 'gt-current-lang'], // 複数のクラスを配列で指定
 };
 
 export default class DropdownTextSync {
@@ -52,11 +52,16 @@ export default class DropdownTextSync {
 
     if (!trigger || !target) return;
 
-    const currentElement = target.querySelector(`.${this.options.currentClass}`);
+    // いずれかのクラスを持つ要素を検索
+    const currentElement = this.options.currentClasses.reduce((found, className) => {
+      return found || target.querySelector(`.${className}`);
+    }, null);
+
     if (currentElement) {
       trigger.textContent = currentElement.textContent.trim();
     }
   }
+
 
 
   /**

--- a/app/assets/js/app/dropdown-text-sync.js
+++ b/app/assets/js/app/dropdown-text-sync.js
@@ -1,0 +1,89 @@
+/**
+ * ドロップダウンメニューにおいて、選択された要素のテキストをトリガー要素のテキストにする
+ * ※.js-dropdownと組み合わせて使う想定
+ *
+ *  // 例
+ * .c-dropdown.js-dropdown.js-dropdown-text-sync
+ *   button.c-dropdown__trigger(data-dropdown-trigger="trigger") Triger※ここがCurrentに置き換わる
+ *   .c-dropdown__content(data-dropdown-target="target")
+ *     +a("/hoge/").c-dropdown__item.is-current Current
+ *     +a("/fuga/").c-dropdown__item Another
+ *
+ */
+
+'use strict';
+
+const defaultOptions = {
+  selector: '.js-dropdown-text-sync',
+  triggerSelector: 'data-dropdown-trigger',
+  targetSelector: 'data-dropdown-target',
+  currentClass: 'is-current',
+};
+
+export default class DropdownTextSync {
+  constructor(options) {
+    this.options = Object.assign({}, defaultOptions, options);
+    this.init();
+  }
+
+
+  /**
+   * 初期化処理
+   * ドロップダウン要素を取得し、テキスト同期と変更監視を設定
+   */
+  init() {
+    this.dropdown = document.querySelectorAll(this.options.selector);
+    if (!this.dropdown.length) return;
+
+    this.dropdown.forEach(element => {
+      this.syncCurrentText(element);
+      this.observeChanges(element);
+    });
+  }
+
+
+  /**
+   * 選択された要素のテキストをトリガー要素に同期
+   * @param {Element} element - ドロップダウンのルート要素
+   */
+  syncCurrentText(element) {
+    const trigger = element.querySelector(`[${this.options.triggerSelector}]`);
+    const target = element.querySelector(`[${this.options.targetSelector}]`);
+
+    if (!trigger || !target) return;
+
+    const currentElement = target.querySelector(`.${this.options.currentClass}`);
+    if (currentElement) {
+      trigger.textContent = currentElement.textContent.trim();
+    }
+  }
+
+
+  /**
+   * 要素の変更を監視し、クラスの変更があった場合にテキストを同期
+   * @param {Element} element - 監視対象のドロップダウン要素
+   */
+  observeChanges(element) {
+    const target = element.querySelector(`[${this.options.targetSelector}]`);
+    if (!target) return;
+
+    const observer = new MutationObserver((mutations) => {
+      mutations.forEach((mutation) => {
+        if (
+          mutation.type === 'attributes' &&
+          mutation.attributeName === 'class'
+        ) {
+          this.syncCurrentText(element);
+        }
+      });
+    });
+
+    const config = {
+      attributes: true,// 属性の変更を監視
+      subtree: true,// 属性の変更を監視
+      attributeFilter: ['class']// classの変更のみを監視
+    };
+
+    observer.observe(target, config);
+  }
+}

--- a/app/assets/js/app/dropdown.js
+++ b/app/assets/js/app/dropdown.js
@@ -1,3 +1,18 @@
+/**
+ * ドロップダウンメニューを制御するクラス
+ *
+ *  // hoverで展開・fadeIn
+ * .c-dropdown.js-dropdown
+ *   +a("/format/").c-dropdown-trigger(data-dropdown-trigger="trigger") FORMAT
+ *   .c-dropdown-content(data-dropdown-target="target")
+ *
+ *  // clickで展開・slideDown
+ * .c-dropdown.js-dropdown(data-dropdown-event="click", data-dropdown-animation="slide")
+ *   +a("/format/").c-dropdown-trigger(data-dropdown-trigger="trigger") FORMAT
+ *   .c-dropdown-content(data-dropdown-target="target")
+ *
+ */
+
 'use strict';
 
 import {gsap} from "gsap";
@@ -29,9 +44,7 @@ export default class Dropdown {
       const wrapper = dropdown;
       const trigger = dropdown.querySelector(`[${this.options.triggerSelector}]`);
       const target = dropdown.querySelector(`[${this.options.targetSelector}]`);
-      //dropdownのイベントタイプを取得
       const eventType = dropdown.getAttribute(this.options.eventTypeSelector);
-      //dropdownのアニメーションタイプを取得
       const animationType = dropdown.getAttribute(this.options.animationTypeSelector);
 
       //triggerまたはtargetが存在しないときerrorを投げる
@@ -39,12 +52,13 @@ export default class Dropdown {
         throw new Error('triggerまたはtargetが存在しません');
       }
 
-      //wrapperにis-openクラスがないかつanimationTypeがnone以外の場合はtargetを非表示にする
+      //wrapperにis-openクラスがない ＆ animationTypeがnone以外の場合はtargetを非表示にする
       if (!wrapper.classList.contains(this.options.openClass)&&animationType!=='none') {
         target.style.visibility = 'hidden';
         target.style.opacity = 0;
       }
 
+      // イベントタイプごとにイベントを初期化
       if (eventType !== 'click') {
         this.hoverInit(wrapper, trigger, target, animationType);
       } else {
@@ -57,7 +71,7 @@ export default class Dropdown {
     let timeoutId;
 
     trigger.addEventListener('mouseenter', () => {
-      // ページロード完了から1秒経過していない場合は処理を実行しない
+      // ページを開いた瞬間は処理を実行しない
       if (!this.isReady) return;
       if (timeoutId) clearTimeout(timeoutId);
       if (wrapper.classList.contains(this.options.openClass)) {
@@ -69,9 +83,8 @@ export default class Dropdown {
       this.dropdownOpen(wrapper, target, animationType);
     });
 
-
+    //wrapperからマウスが離れたら閉じる
     wrapper.addEventListener('mouseleave', () => {
-
       //100ms後に処理を実行
       timeoutId =
         setTimeout(() => {
@@ -82,35 +95,26 @@ export default class Dropdown {
       }, 100);
     });
 
+    //targetにマウスが載ったとき、閉じる途中であれば再度開く
     target.addEventListener('mouseenter', () => {
       if (timeoutId) clearTimeout(timeoutId);
-
-      //targetにマウスが乗った時に、targetが開いている場合はクリア
       if (wrapper.classList.contains(this.options.openClass)) {
         return;
       }
       if (gsap.isTweening(target)) {
         const currentTween = gsap.getTweensOf(target)[0];
         const progress = currentTween.progress();
-
-        // 進捗が50%以上の場合は処理をキャンセル
-        if (progress >= 0.5) {
+        // 進捗が80%以上の場合は処理をキャンセル
+        if (progress >= 0.8) {
           return;
         }
-
         gsap.killTweensOf(target);
+        this.dropdownOpen(wrapper, target, animationType);
       }
-      this.dropdownOpen(wrapper, target, animationType);
-
     });
-
-
-
-
   }
 
   clickInit(wrapper, trigger, target, animationType) {
-    // triggerのクリックイベント
     trigger.addEventListener('click', (e) => {
       e.preventDefault();
       e.stopPropagation(); // クリックイベントの伝播を止める
@@ -127,10 +131,8 @@ export default class Dropdown {
       }
     });
 
-    // ドキュメントのクリックイベント
     const handleClickOutside = (e) => {
       if (!wrapper.classList.contains(this.options.openClass)) return;
-
       // triggerとtarget以外をクリックした場合に閉じる
       if (!target.contains(e.target) && !trigger.contains(e.target)) {
         this.dropdownClose(wrapper, target, animationType);
@@ -169,7 +171,6 @@ export default class Dropdown {
     if (animationType === 'none') {
       return;
     }
-
 
     if (animationType === 'slide') {
       this.animationSlideUp(target);
@@ -224,7 +225,6 @@ export default class Dropdown {
   }
 
   animationSlideUp(target) {
-
     gsap.to(target, {
       duration: 0.3,
       clipPath: 'inset(0 0 100% 0)',
@@ -232,6 +232,4 @@ export default class Dropdown {
       ease: 'power2.out',
     });
   }
-
-
 }

--- a/app/assets/js/app/dropdown.js
+++ b/app/assets/js/app/dropdown.js
@@ -6,7 +6,6 @@ const defaultOptions = {
   selector: '.js-dropdown',
   triggerSelector: 'data-dropdown-trigger',
   targetSelector: 'data-dropdown-target',
-  closeButtonSelector: 'data-dropdown-close',
   eventTypeSelector: 'data-dropdown-event',
   animationTypeSelector: 'data-dropdown-animation',
   openClass: 'is-open',
@@ -25,6 +24,7 @@ export default class Dropdown {
 
   init() {
     this.dropdown = document.querySelectorAll(this.options.selector);
+    if (!this.dropdown.length) return;
     this.dropdown.forEach((dropdown) => {
       const wrapper = dropdown;
       const trigger = dropdown.querySelector(`[${this.options.triggerSelector}]`);
@@ -110,8 +110,6 @@ export default class Dropdown {
   }
 
   clickInit(wrapper, trigger, target, animationType) {
-    const closeBtn = wrapper.querySelector(`[${this.options.closeButtonSelector}]`);
-
     // triggerのクリックイベント
     trigger.addEventListener('click', (e) => {
       e.preventDefault();
@@ -128,19 +126,6 @@ export default class Dropdown {
         this.dropdownOpen(wrapper, target, animationType);
       }
     });
-
-    if (closeBtn) {
-      closeBtn.addEventListener('click', (e) => {
-        e.preventDefault();
-        e.stopPropagation(); // クリックイベントの伝播を止める
-
-        if (gsap.isTweening(target)) {
-          gsap.killTweensOf(target);
-        }
-
-        this.dropdownClose(wrapper, target, animationType);
-      });
-    }
 
     // ドキュメントのクリックイベント
     const handleClickOutside = (e) => {

--- a/app/assets/js/app/dropdown.js
+++ b/app/assets/js/app/dropdown.js
@@ -1,0 +1,252 @@
+'use strict';
+
+import {gsap} from "gsap";
+
+const defaultOptions = {
+  selector: '.js-dropdown',
+  triggerSelector: 'data-dropdown-trigger',
+  targetSelector: 'data-dropdown-target',
+  closeButtonSelector: 'data-dropdown-close',
+  eventTypeSelector: 'data-dropdown-event',
+  animationTypeSelector: 'data-dropdown-animation',
+  openClass: 'is-open',
+};
+
+export default class Dropdown {
+  constructor(options) {
+    this.options = Object.assign({}, defaultOptions, options);
+    this.isReady = false;
+    // ページロード完了後にisReadyをtrueにする
+    window.addEventListener('load', () => {
+      this.isReady = true;
+    });
+    this.init();
+  }
+
+  init() {
+    this.dropdown = document.querySelectorAll(this.options.selector);
+    this.dropdown.forEach((dropdown) => {
+      const wrapper = dropdown;
+      const trigger = dropdown.querySelector(`[${this.options.triggerSelector}]`);
+      const target = dropdown.querySelector(`[${this.options.targetSelector}]`);
+      //dropdownのイベントタイプを取得
+      const eventType = dropdown.getAttribute(this.options.eventTypeSelector);
+      //dropdownのアニメーションタイプを取得
+      const animationType = dropdown.getAttribute(this.options.animationTypeSelector);
+
+      //triggerまたはtargetが存在しないときerrorを投げる
+      if (!trigger || !target) {
+        throw new Error('triggerまたはtargetが存在しません');
+      }
+
+      //wrapperにis-openクラスがないかつanimationTypeがnone以外の場合はtargetを非表示にする
+      if (!wrapper.classList.contains(this.options.openClass)&&animationType!=='none') {
+        target.style.visibility = 'hidden';
+        target.style.opacity = 0;
+      }
+
+      if (eventType !== 'click') {
+        this.hoverInit(wrapper, trigger, target, animationType);
+      } else {
+        this.clickInit(wrapper, trigger, target, animationType);
+      }
+    });
+  }
+
+  hoverInit(wrapper, trigger, target, animationType) {
+    let timeoutId;
+
+    trigger.addEventListener('mouseenter', () => {
+      // ページロード完了から1秒経過していない場合は処理を実行しない
+      if (!this.isReady) return;
+      if (timeoutId) clearTimeout(timeoutId);
+      if (wrapper.classList.contains(this.options.openClass)) {
+        return;
+      }
+      if (gsap.isTweening(target)) {
+        gsap.killTweensOf(target);
+      }
+      this.dropdownOpen(wrapper, target, animationType);
+    });
+
+
+    wrapper.addEventListener('mouseleave', () => {
+
+      //100ms後に処理を実行
+      timeoutId =
+        setTimeout(() => {
+          if (gsap.isTweening(target)) {
+            gsap.killTweensOf(target);
+          }
+        this.dropdownClose(wrapper, target, animationType);
+      }, 100);
+    });
+
+    target.addEventListener('mouseenter', () => {
+      if (timeoutId) clearTimeout(timeoutId);
+
+      //targetにマウスが乗った時に、targetが開いている場合はクリア
+      if (wrapper.classList.contains(this.options.openClass)) {
+        return;
+      }
+      if (gsap.isTweening(target)) {
+        const currentTween = gsap.getTweensOf(target)[0];
+        const progress = currentTween.progress();
+
+        // 進捗が50%以上の場合は処理をキャンセル
+        if (progress >= 0.5) {
+          return;
+        }
+
+        gsap.killTweensOf(target);
+      }
+      this.dropdownOpen(wrapper, target, animationType);
+
+    });
+
+
+
+
+  }
+
+  clickInit(wrapper, trigger, target, animationType) {
+    const closeBtn = wrapper.querySelector(`[${this.options.closeButtonSelector}]`);
+
+    // triggerのクリックイベント
+    trigger.addEventListener('click', (e) => {
+      e.preventDefault();
+      e.stopPropagation(); // クリックイベントの伝播を止める
+
+      if (gsap.isTweening(target)) {
+        gsap.killTweensOf(target);
+      }
+
+      // トグル動作の実装
+      if (wrapper.classList.contains(this.options.openClass)) {
+        this.dropdownClose(wrapper, target, animationType);
+      } else {
+        this.dropdownOpen(wrapper, target, animationType);
+      }
+    });
+
+    if (closeBtn) {
+      closeBtn.addEventListener('click', (e) => {
+        e.preventDefault();
+        e.stopPropagation(); // クリックイベントの伝播を止める
+
+        if (gsap.isTweening(target)) {
+          gsap.killTweensOf(target);
+        }
+
+        this.dropdownClose(wrapper, target, animationType);
+      });
+    }
+
+    // ドキュメントのクリックイベント
+    const handleClickOutside = (e) => {
+      if (!wrapper.classList.contains(this.options.openClass)) return;
+
+      // triggerとtarget以外をクリックした場合に閉じる
+      if (!target.contains(e.target) && !trigger.contains(e.target)) {
+        this.dropdownClose(wrapper, target, animationType);
+      }
+    };
+
+    document.addEventListener('click', handleClickOutside);
+  }
+
+
+  dropdownOpen(wrapper, target, animationType) {
+    wrapper.classList.add(this.options.openClass);
+
+    //classの付け外しのみにしたいときはnoneを指定
+    if (animationType === 'none') {
+      return;
+    }
+
+    if (animationType === 'slide') {
+      this.animationSlideDown(target);
+      return;
+    }
+    // カスタムアニメーションを指定する場合
+    // if(animationType==='custom'){
+    //   this.animationCustomIn(target);
+    //   return;
+    // }
+
+    //アニメーションタイプ指定が無ければフェードイン
+    this.animationFadeIn(target);
+  }
+
+  dropdownClose(wrapper, target, animationType) {
+    wrapper.classList.remove(this.options.openClass);
+    //classの付け外しのみにしたいときはnoneを指定
+    if (animationType === 'none') {
+      return;
+    }
+
+
+    if (animationType === 'slide') {
+      this.animationSlideUp(target);
+      return;
+    }
+
+    // カスタムアニメーションを指定する場合
+    // if(animationType==='custom'){
+    //   this.animationCustomOut(target);
+    //   return;
+    // }
+
+    //アニメーションタイプ指定が無ければフェードアウト
+    this.animationFadeOut(target);
+  }
+
+  animationFadeIn(target) {
+    gsap.fromTo(target,
+      {
+        autoAlpha: 0,
+      },
+      {
+        duration: 0.2,
+        ease: 'power2.out',
+        autoAlpha: 1,
+      }
+    );
+  }
+
+
+  animationFadeOut(target) {
+    gsap.to(target, {
+      duration: 0.3,
+      autoAlpha: 0,
+      ease: 'power2.out',
+    });
+  }
+
+  animationSlideDown(target) {
+    gsap.fromTo(target,
+      {
+        autoAlpha: 1,
+        clipPath: 'inset(0 0 100% 0)'
+      },
+      {
+        autoAlpha: 1,
+        clipPath: 'inset(0 0 0% 0)',
+        duration: 0.3,
+        ease: "power2.out"
+      }
+    );
+  }
+
+  animationSlideUp(target) {
+
+    gsap.to(target, {
+      duration: 0.3,
+      clipPath: 'inset(0 0 100% 0)',
+      autoAlpha: 0,
+      ease: 'power2.out',
+    });
+  }
+
+
+}

--- a/app/assets/scss/layout/header.scss
+++ b/app/assets/scss/layout/header.scss
@@ -73,13 +73,6 @@ category: Layout
     }
 
     li {
-      //submenu表示用のhoverは hover mixinの利用を避ける
-      &:hover {
-        .l-header__submenu {
-          visibility: visible;
-          opacity: 1;
-        }
-      }
 
       a {
         font-size: min-vw(14);

--- a/app/assets/scss/layout/header.scss
+++ b/app/assets/scss/layout/header.scss
@@ -195,6 +195,14 @@ category: Layout
   }
 
 
+  &__lang{
+    font-size: min-vw(14);
+
+    @include breakpoint(medium down) {
+      display: none;
+    }
+  }
+
   //その他
   &__button {
     @include breakpoint(medium down) {

--- a/app/assets/scss/object/components/_index.scss
+++ b/app/assets/scss/object/components/_index.scss
@@ -38,6 +38,7 @@
 @import 'hr';
 @import 'icon-font';
 @import 'label';
+@import 'lang-selector';
 @import 'lead';
 @import 'list';
 @import 'loader';

--- a/app/assets/scss/object/components/lang-selector.scss
+++ b/app/assets/scss/object/components/lang-selector.scss
@@ -1,0 +1,67 @@
+//button.c-lang-selector__trigger(data-dropdown-trigger="trigger") Language
+//          .c-lang-selector__content(data-dropdown-target="target")
+//            ul.c-lang-selector__list
+//              li.c-lang-selector__item: +a("/").c-lang-selector__link.is-current 日本語
+//              li.c-lang-selector__item: +a("/en/").c-lang-selector__link English
+
+.c-lang-selector {
+  position: relative;
+
+  &__trigger {
+    display: flex;
+    gap: min-vw(4);
+    align-items: center;
+    cursor: pointer;
+    background: none;
+    border: solid 1px $color-border;
+    border-radius: 100px;
+    font-size: inherit;
+    padding: rem-calc(4) rem-calc(8);
+
+    @include hover(){
+      opacity: 0.5;
+    }
+
+    &::before{
+      @include icon-font();
+      content: "language";
+    }
+  }
+
+  &__content {
+    position: absolute;
+    top: 100%;
+    left: 0;
+    background-color: #fff;
+    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+    //display: none;
+    min-width: 120px;
+    z-index: 100;
+
+    @at-root .c-lang-selector.is-open & {
+      //display: block;
+    }
+  }
+
+  &__list {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+  }
+
+  &__item {
+    &:not(:last-child) {
+      border-bottom: 1px solid #eee;
+    }
+  }
+
+  &__link {
+    display: block;
+    text-decoration: none;
+    padding: rem-calc(8) rem-calc(16);
+
+    &.is-current {
+      background-color: $color-background;
+    }
+  }
+}

--- a/app/inc/layout/_header.pug
+++ b/app/inc/layout/_header.pug
@@ -42,21 +42,13 @@ header(class=className)
                   +a("/blocks/").l-header__submenu-block
                     .l-header__submenu-image: +img("img-sample.jpg", "ブロック編集ページ")
                     span ブロック編集ページ
-        li.l-header__mainmenu-item.js-dropdown(data-dropdown-animation="slide" data-dropdown-event="click")
-          +a("/format/")(data-dropdown-trigger="trigger") CLICK
-          .l-header__submenu(data-dropdown-target="target")
-            .l-header__submenu-outer
-              .l-header__submenu-title
-                span FORMAT
-                small フォーマット
-              .l-header__submenu-content
-                .l-header__submenu-menus
-                  +a("/format/").l-header__submenu-block
-                    .l-header__submenu-image: +img("img-sample.jpg", "フォーマット")
-                    span フォーマット
-                  +a("/blocks/").l-header__submenu-block
-                    .l-header__submenu-image: +img("img-sample.jpg", "ブロック編集ページ")
-                    span ブロック編集ページ
+      .l-header__lang
+        .c-lang-selector.js-dropdown.js-dropdown-text-sync(data-dropdown-event="click", data-dropdown-animation="slide")
+          button.c-lang-selector__trigger(type="button", data-dropdown-trigger="trigger") Language
+          .c-lang-selector__content(data-dropdown-target="target")
+            ul.c-lang-selector__list
+              li.c-lang-selector__item: +a("/").c-lang-selector__link.is-current 日本語
+              li.c-lang-selector__item: +a("/en/").c-lang-selector__link English
       button.l-header__search.js-header-searchform-open(aria-label="キーワードから検索") <span>キーワードから検索</span>
       +a("/contact/").l-header__button.c-button.is-sm <span class="c-icon-font">mail</span>お問い合わせ
 

--- a/app/inc/layout/_header.pug
+++ b/app/inc/layout/_header.pug
@@ -27,9 +27,24 @@ header(class=className)
         li.l-header__mainmenu-item: +a("/twocolumns/") 2COLUMN
         li.l-header__mainmenu-item: +a("/news/") NEWS
         li.l-header__mainmenu-item: +a("/archive-twocolumns/") ARCHIVE2
-        li.l-header__mainmenu-item
-          +a("/format/") FORMAT
-          .l-header__submenu
+        li.l-header__mainmenu-item.js-dropdown
+          +a("/format/")(data-dropdown-trigger="trigger") FORMAT
+          .l-header__submenu(data-dropdown-target="target")
+            .l-header__submenu-outer
+              .l-header__submenu-title
+                span FORMAT
+                small フォーマット
+              .l-header__submenu-content
+                .l-header__submenu-menus
+                  +a("/format/").l-header__submenu-block
+                    .l-header__submenu-image: +img("img-sample.jpg", "フォーマット")
+                    span フォーマット
+                  +a("/blocks/").l-header__submenu-block
+                    .l-header__submenu-image: +img("img-sample.jpg", "ブロック編集ページ")
+                    span ブロック編集ページ
+        li.l-header__mainmenu-item.js-dropdown(data-dropdown-animation="slide" data-dropdown-event="click")
+          +a("/format/")(data-dropdown-trigger="trigger") CLICK
+          .l-header__submenu(data-dropdown-target="target")
             .l-header__submenu-outer
               .l-header__submenu-title
                 span FORMAT


### PR DESCRIPTION
https://www.notion.so/growgroup/js-896e9a802c0a4e6fa9b211997c2cecb2
https://www.notion.so/growgroup/17beef14914a80ceb4b9d2f7e50320ab
https://www.notion.so/growgroup/header_megamenu-e7fd25061ed94e34af8c0df7c3c3f596

# 主な変更点
- l-header__submenu の展開をCSSから、JavaScript制御へ変更
- select風言語切り替えナビゲーションのサンプル実装追加

https://github.com/user-attachments/assets/626f123f-e7aa-44aa-bdb9-094f8106604e




## l-header__submenu の展開をCSSから、JavaScript制御へ変更
- dropdown.js を追加
- header.pugとheader.scssの書き換え

### 効果
- サイズの大きなメガメニューをもつ場合に、ページを開いた瞬間からメニューが展開していると、現在のページが分かりづらい問題を解決しました
- liからマウスが離れたとき直ちにメニューが閉じるため、斜め方向にマウスを移動したときにメニューが閉じやすい問題を軽減しました
- 上記の問題をCSSで軽減したとき、消え終わったように見えるメニューの位置にマウスを移動すると、再度展開する問題を軽減しました

### 使い方
data属性で振る舞いをコントロールできます。
必要に応じて dropdown.js を編集し、アニメーションの種類を追加したり、アニメーションの詳細を変更したりしてください。

```
 // hoverで展開・fadeIn
.c-dropdown.js-dropdown
  +a("/format/").c-dropdown-trigger(data-dropdown-trigger="trigger") FORMAT
  .c-dropdown-content(data-dropdown-target="target")

 // clickで展開・slideDown
.c-dropdown.js-dropdown(data-dropdown-event="click", data-dropdown-animation="slide")
  +a("/format/").c-dropdown-trigger(data-dropdown-trigger="trigger") FORMAT
  .c-dropdown-content(data-dropdown-target="target")
```

## select風言語切り替えナビゲーションのサンプル実装追加
- dropdown-text-sync.jsの追加
- header.pugにサンプルHTMLを追加

### 使い方
- .js-dropdown をもちいて実装したドロップダウンメニューに、`.js-dropdown-text-sync` を追加
- トリガー部分のテキストに表示したい項目に `.is-current` を付与（`.gt-current-lang` も機能します）
  - `.is-current` はJavaScriptで動的に付与しても機能します
