### PR TITLE
[update] box-sizing for * selector

### DIFF
--- a/app/assets/scss/foundation/_normalize.scss
+++ b/app/assets/scss/foundation/_normalize.scss
@@ -34,16 +34,12 @@ html {
   scroll-padding-top: var(--header-height); //スクロール位置の調整が不要な場合は 0 にする
 }
 
-* {
+*,
+::before,::after {
   box-sizing: border-box;
   letter-spacing: var(--letter-spacing); //全要素へ基準のletter-spacingを当てる
   min-width: 0;
   text-decoration-thickness: inherit;//from-font の設定値を各要素に適用しやすくする
-
-  &::before,
-  &::after {
-    box-sizing: inherit;
-  }
 }
 
 /**

--- a/app/assets/scss/foundation/_normalize.scss
+++ b/app/assets/scss/foundation/_normalize.scss
@@ -35,11 +35,15 @@ html {
 }
 
 * {
-  -webkit-box-sizing: border-box;
-  -moz-box-sizing: border-box;
   box-sizing: border-box;
   letter-spacing: var(--letter-spacing); //全要素へ基準のletter-spacingを当てる
-  min-width: 0; //flexboxのoverflow対策(from destyle.css)
+  min-width: 0;
+  text-decoration-thickness: inherit;//from-font の設定値を各要素に適用しやすくする
+
+  &::before,
+  &::after {
+    box-sizing: inherit;
+  }
 }
 
 /**


### PR DESCRIPTION
https://www.notion.so/growgroup/before-after-box-sizing-border-box-1a5eef14914a80bb896ef85b143ef1c1

# 内容
`::before` `::after` の疑似要素に`box-sizing:border-box` が効いていない問題の解決として
https://github.com/nicolas-cusan/destyle.css/blob/master/destyle.css を参考に、全称セレクタに当てているCSSを ::before, ::after にも当てるようにしました