### PR TITLE
[add] text-decoration & underline settings

### DIFF
--- a/app/assets/scss/foundation/_normalize.scss
+++ b/app/assets/scss/foundation/_normalize.scss
@@ -39,7 +39,8 @@ html {
   -moz-box-sizing: border-box;
   box-sizing: border-box;
   letter-spacing: var(--letter-spacing); //全要素へ基準のletter-spacingを当てる
-  min-width: 0; //flexboxのoverflow対策(from destyle.css)
+  min-width: 0;
+  text-decoration-thickness: inherit;//from-font の設定値を各要素に適用しやすくする
 }
 
 /**
@@ -53,9 +54,11 @@ body {
   font-size: $font-base-size;
   font-feature-settings: 'liga';
   -webkit-font-smoothing: antialiased;
-  overflow-wrap: anywhere; /* 収まらない場合に折り返す */
-  word-break: normal; /* 単語の分割はデフォルトに依存 */
-  line-break: strict; /* 禁則処理を厳格に適用 */
+  text-decoration-thickness: from-font;
+  text-underline-position: from-font;
+  overflow-wrap: anywhere;
+  word-break: normal;
+  line-break: strict;
 
   &.is-slidebar-active {
     overflow: hidden;

--- a/app/assets/scss/object/components/forms-normal.scss
+++ b/app/assets/scss/object/components/forms-normal.scss
@@ -110,7 +110,7 @@
     }
     a {
       font-weight: 400;
-      text-decoration: underline;
+      text-decoration-line: underline;
       color: $font-base-color;
     }
   }

--- a/app/assets/scss/object/components/forms-simple.scss
+++ b/app/assets/scss/object/components/forms-simple.scss
@@ -147,7 +147,7 @@
     }
     a {
       font-weight: 400;
-      text-decoration: underline;
+      text-decoration-line: underline;
       color: $font-base-color;
     }
   }

--- a/app/assets/scss/object/components/forms.scss
+++ b/app/assets/scss/object/components/forms.scss
@@ -362,7 +362,7 @@
 
     a {
       font-weight: 400;
-      text-decoration: underline;
+      text-decoration-line: underline;
       color: $font-base-color;
     }
   }

--- a/app/assets/scss/object/utility/text.scss
+++ b/app/assets/scss/object/utility/text.scss
@@ -41,7 +41,7 @@ strong,
 
 del,
 .u-text-del {
-  text-decoration: line-through;
+  text-decoration-line: line-through;
 }
 
 // テキスト - リンク
@@ -51,7 +51,7 @@ del,
 .u-text-link {
   color: $color-primary;
   font-weight: 400;
-  text-decoration: underline;
+  text-decoration-line: underline;
   cursor: pointer;
 }
 


### PR DESCRIPTION
https://www.notion.so/growgroup/Figma-Chrome-text-decoration-underline-1a5eef14914a80969be4e75dd9cfbbf1

# 内容
`text-decoration: underline` のスタイルが、
Google ChromeでFigmaのデザインよりも「太い」「文字に近い」問題の軽減

※ただしunderlineを指定するとき `text-decorationo-line: underline` としないと
  `text-decoration-thickness: from-font;` が継承されません。

参考: https://deep-space.blue/web/3543
