### PR TITLE
[add] stylelint-line-height-unit-change

### DIFF
--- a/.stylelintrc.js
+++ b/.stylelintrc.js
@@ -4,9 +4,11 @@ module.exports = {
   customSyntax: postcssScss,
   "plugins": [
     "stylelint-scss",
-    path.resolve(__dirname, "./config/stylelint-replace-assets-path.js")
+    path.resolve(__dirname, "./config/stylelint-replace-assets-path.js"),
+    path.resolve(__dirname, "./config/stylelint-line-height-unit-change.js")
   ],
   "rules": {
-    "custom/replace-assets-path": true
+    "custom/replace-assets-path": true,
+    "custom/line-height-unit-change": true
   }
 }

--- a/.stylelintrc.js
+++ b/.stylelintrc.js
@@ -9,6 +9,6 @@ module.exports = {
   ],
   "rules": {
     "custom/replace-assets-path": true,
-    "custom/line-height-unit-change": true
+    "custom/line-height-unit-change": [true, { "severity": "warning" }]
   }
 }

--- a/app/assets/scss/foundation/_mixin.scss
+++ b/app/assets/scss/foundation/_mixin.scss
@@ -74,13 +74,13 @@
 // 値をvwに変換する関数
 @function vw-calc($value, $viewport: 1400) {
   // 単位を取り除きvwを掛ける
-  @return strip-unit($value) / strip-unit($viewport) * 100vw;
+  @return calc(strip-unit($value) / strip-unit($viewport)) * 100vw;
 }
 
 // 値をcqwに変換する関数
 // container-type を指定したコンテナのデザイン上の幅を第2引数に指定すること
 @function cqw-calc($value, $container-width: 1400) {
-  @return strip-unit($value) / strip-unit($container-width) * 100cqw;
+  @return calc(strip-unit($value) / strip-unit($container-width)) * 100cqw;
 }
 
 // レスポンシブな最小値を生成するmin関数

--- a/app/assets/scss/layout/header.scss
+++ b/app/assets/scss/layout/header.scss
@@ -13,7 +13,6 @@ category: Layout
   position: absolute;
   top: 0;
   left: 0;
-  line-height: 1.5;
 
   &.is-fixed {
     position: fixed;

--- a/app/assets/scss/layout/header.scss
+++ b/app/assets/scss/layout/header.scss
@@ -13,7 +13,7 @@ category: Layout
   position: absolute;
   top: 0;
   left: 0;
-
+  line-height: 1.5;
 
   &.is-fixed {
     position: fixed;

--- a/config/stylelint-line-height-unit-change.js
+++ b/config/stylelint-line-height-unit-change.js
@@ -1,0 +1,64 @@
+/* eslint-disable */
+const stylelint = require("stylelint");
+const ruleName = "custom/line-height-unit-change";
+const messages = stylelint.utils.ruleMessages(ruleName, {
+  expected: "line-height unit '%' disallow. Change relative value",
+});
+
+/**
+ * stylelintrc.jsonのruleに渡すオプションを引数に指定
+ * @param {object} primaryOption stylelintrcのruleに渡すobject
+ * @param {object} secondaryOption(_) 二次的なオプション必要であれば設定
+ * @param {object} context autoFix実現のために必要 {fix: boolean, newline: string}
+ * @returns {function} returnFunction
+ */
+const ruleFunction = (primaryOption, _, context) => {
+
+  /**
+   * @param {object} root postcssでparseされたASTのrootNode
+   * @param {object} result the PostCSS LazyResult
+   */
+  const returnFunction = (root , result) => {
+    const validOptions = stylelint.utils.validateOptions(result, ruleName, {});
+
+    primaryOption = {"line-height-unit-change/rules": true}
+
+    // プロパティが一致する宣言に対してのみ反復処理が行われる
+    root.walkDecls('line-height', (decl) => {
+      const matched = decl.value.match(/(\d+)(%)/);
+      if (!matched) {
+        return;
+      }
+
+      if (matched) {
+        stylelint.utils.report({
+          ruleName,
+          result,
+          message: messages.expected,
+          node: decl,
+        });
+
+        if (context.fix) {
+          // 文字列変換して%を取る
+          const unitDelete = decl.value.toString().replace(/%/i, '');
+          // 100で割る
+          const changeResult = (Number(unitDelete) / 100).toString();
+
+          return decl.value = changeResult;
+        }
+      }
+    });
+
+    if (!validOptions) {
+      return;
+    }
+  };
+
+  return returnFunction;
+}
+
+module.exports.ruleName = ruleName;
+module.exports.messages = messages;
+
+module.exports = stylelint.createPlugin(ruleName, ruleFunction);
+

--- a/config/stylelint-line-height-unit-change.js
+++ b/config/stylelint-line-height-unit-change.js
@@ -30,24 +30,30 @@ const ruleFunction = (primaryOption, _, context) => {
         return;
       }
 
-      if (matched) {
-        stylelint.utils.report({
-          ruleName,
-          result,
-          message: messages.expected,
-          node: decl,
-        });
+      // %を除去して数値変換
+      const unitDelete = decl.value.toString().replace(/%/i, '');
+      const numberValue = Number(unitDelete);
 
-        if (context.fix) {
-          // 文字列変換して%を取る
-          const unitDelete = decl.value.toString().replace(/%/i, '');
-          // 100で割る
-          const changeResult = (Number(unitDelete) / 100).toString();
+      // 数値変換が失敗してNaNの場合は、エラー報告もせずにそのまま返す
+      if (isNaN(numberValue)) {
+        return;
+      }
 
-          return decl.value = changeResult;
-        }
+      // エラー報告
+      stylelint.utils.report({
+        ruleName,
+        result,
+        message: messages.expected,
+        node: decl,
+      });
+
+      if (context.fix) {
+        // 100で割る
+        const changeResult = (numberValue / 100).toString();
+        decl.value = changeResult;
       }
     });
+
 
     if (!validOptions) {
       return;

--- a/package-lock.json
+++ b/package-lock.json
@@ -60,8 +60,9 @@
         "sass": "^1.78.0",
         "sass-loader": "^16.0.2",
         "style-loader": "^4.0.0",
-        "stylelint": "^16.10.0",
+        "stylelint": "^16.14.1",
         "stylelint-scss": "^6.8.1",
+        "stylelint-webpack-plugin": "^5.0.1",
         "webpack": "^5.94.0",
         "webpack-cli": "^5.1.4",
         "webpack-dev-middleware": "^7.4.2",
@@ -1797,9 +1798,9 @@
       }
     },
     "node_modules/@csstools/css-parser-algorithms": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-3.0.3.tgz",
-      "integrity": "sha512-15WQTALDyxAwSgAvLt7BksAssiSrNNhTv4zM7qX9U6R7FtpNskVVakzWQlYODlwPwXhGpKPmB10LM943pxMe7w==",
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-3.0.4.tgz",
+      "integrity": "sha512-Up7rBoV77rv29d3uKHUIVubz1BTcgyUK72IvCQAbfbMv584xHcGKCKbWh7i8hPrRJ7qU4Y8IO3IY9m+iTB7P3A==",
       "dev": true,
       "funding": [
         {
@@ -1815,7 +1816,7 @@
         "node": ">=18"
       },
       "peerDependencies": {
-        "@csstools/css-tokenizer": "^3.0.2"
+        "@csstools/css-tokenizer": "^3.0.3"
       }
     },
     "node_modules/@csstools/css-tokenizer": {
@@ -1838,9 +1839,9 @@
       }
     },
     "node_modules/@csstools/media-query-list-parser": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@csstools/media-query-list-parser/-/media-query-list-parser-3.0.1.tgz",
-      "integrity": "sha512-HNo8gGD02kHmcbX6PvCoUuOQvn4szyB9ca63vZHKX5A81QytgDG4oxG4IaEfHTlEZSZ6MjPEMWIVU+zF2PZcgw==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@csstools/media-query-list-parser/-/media-query-list-parser-4.0.2.tgz",
+      "integrity": "sha512-EUos465uvVvMJehckATTlNqGj4UJWkTmdWuDMjqvSUkjGpmOyFZBVwb4knxCm/k2GMTXY+c/5RkdndzFYWeX5A==",
       "dev": true,
       "funding": [
         {
@@ -1856,30 +1857,8 @@
         "node": ">=18"
       },
       "peerDependencies": {
-        "@csstools/css-parser-algorithms": "^3.0.1",
-        "@csstools/css-tokenizer": "^3.0.1"
-      }
-    },
-    "node_modules/@csstools/selector-specificity": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@csstools/selector-specificity/-/selector-specificity-4.0.0.tgz",
-      "integrity": "sha512-189nelqtPd8++phaHNwYovKZI0FOzH1vQEE3QhHHkNIGrg5fSs9CbYP3RvfEH5geztnIA9Jwq91wyOIwAW5JIQ==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/csstools"
-        },
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/csstools"
-        }
-      ],
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "postcss-selector-parser": "^6.1.0"
+        "@csstools/css-parser-algorithms": "^3.0.4",
+        "@csstools/css-tokenizer": "^3.0.3"
       }
     },
     "node_modules/@discoveryjs/json-ext": {
@@ -2032,6 +2011,105 @@
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
     },
+    "node_modules/@jest/schemas": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.6.3.tgz",
+      "integrity": "sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==",
+      "dev": true,
+      "dependencies": {
+        "@sinclair/typebox": "^0.27.8"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jest/types": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/@jest/types/-/types-29.6.3.tgz",
+      "integrity": "sha512-u3UPsIilWKOM3F9CXtrG8LEJmNxwoCQC/XVj4IKYXvvpx7QIi/Kg1LI5uDmDpKlac62NUtX7eLjRh+jVZcLOzw==",
+      "dev": true,
+      "dependencies": {
+        "@jest/schemas": "^29.6.3",
+        "@types/istanbul-lib-coverage": "^2.0.0",
+        "@types/istanbul-reports": "^3.0.0",
+        "@types/node": "*",
+        "@types/yargs": "^17.0.8",
+        "chalk": "^4.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jest/types/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@jest/types/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/@jest/types/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/@jest/types/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
+    },
+    "node_modules/@jest/types/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@jest/types/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/@jridgewell/gen-mapping": {
       "version": "0.3.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.5.tgz",
@@ -2142,6 +2220,15 @@
       },
       "peerDependencies": {
         "tslib": "2"
+      }
+    },
+    "node_modules/@keyv/serialize": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@keyv/serialize/-/serialize-1.0.3.tgz",
+      "integrity": "sha512-qnEovoOp5Np2JDGonIDL6Ayihw0RhnRh6vxPuHo4RDn1UOzwEo4AeIfpL6UGIrsceWrCMiVPgwRjbHu4vYFc3g==",
+      "dev": true,
+      "dependencies": {
+        "buffer": "^6.0.3"
       }
     },
     "node_modules/@markuplint/create-rule-helper": {
@@ -2413,6 +2500,12 @@
         "node": ">= 8"
       }
     },
+    "node_modules/@sinclair/typebox": {
+      "version": "0.27.8",
+      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.8.tgz",
+      "integrity": "sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA==",
+      "dev": true
+    },
     "node_modules/@sindresorhus/merge-streams": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/@sindresorhus/merge-streams/-/merge-streams-2.3.0.tgz",
@@ -2467,6 +2560,30 @@
       "integrity": "sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw==",
       "dev": true
     },
+    "node_modules/@types/istanbul-lib-coverage": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.6.tgz",
+      "integrity": "sha512-2QF/t/auWm0lsy8XtKVPG19v3sSOQlJe/YHZgfjb/KBBHOGSV+J2q/S671rcq9uTBrLAXmZpqJiaQbMT+zNU1w==",
+      "dev": true
+    },
+    "node_modules/@types/istanbul-lib-report": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/istanbul-lib-report/-/istanbul-lib-report-3.0.3.tgz",
+      "integrity": "sha512-NQn7AHQnk/RSLOxrBbGyJM/aVQ+pjj5HCgasFxc0K/KhoATfQ/47AyUl15I2yBUpihjmas+a+VJBOqecrFH+uA==",
+      "dev": true,
+      "dependencies": {
+        "@types/istanbul-lib-coverage": "*"
+      }
+    },
+    "node_modules/@types/istanbul-reports": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.4.tgz",
+      "integrity": "sha512-pk2B1NWalF9toCRu6gjBzR69syFjP4Od8WRAX+0mmf9lAjCRicLOWc+ZrxZHx/0XRjotgkF9t6iaMJ+aXcOdZQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/istanbul-lib-report": "*"
+      }
+    },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
@@ -2498,6 +2615,21 @@
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.2.tgz",
       "integrity": "sha512-dISoDXWWQwUquiKsyZ4Ng+HX2KsPL7LyHKHQwgGFEA3IaKac4Obd+h2a/a6waisAoepJlBcx9paWqjA8/HVjCw==",
+      "dev": true
+    },
+    "node_modules/@types/yargs": {
+      "version": "17.0.33",
+      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.33.tgz",
+      "integrity": "sha512-WpxBCKWPLr4xSsHgz511rFJAM+wS28w2zEO1QDNY5zM/S8ok70NNfztH0xwhqKyaK0OHCbN98LDAZuy1ctxDkA==",
+      "dev": true,
+      "dependencies": {
+        "@types/yargs-parser": "*"
+      }
+    },
+    "node_modules/@types/yargs-parser": {
+      "version": "21.0.3",
+      "resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-21.0.3.tgz",
+      "integrity": "sha512-I4q9QU9MQv4oEOz4tAHJtNz1cwuLxn2F3xcc2iV5WdqLPpUnj30aUuxt1mAxYTG+oe8CZMV/+6rU4S4gRDzqtQ==",
       "dev": true
     },
     "node_modules/@webassemblyjs/ast": {
@@ -3289,6 +3421,26 @@
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true
     },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
+    },
     "node_modules/base64id": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/base64id/-/base64id-2.0.0.tgz",
@@ -3611,6 +3763,30 @@
       "integrity": "sha512-BXvDkqhDNxXEjeGM8LFkSbR+jzmP/CYpCiVKYn+soB1dDldeU15EBNDkwVXndKuX35wnNUaPd0qSoQEAkmQtMw==",
       "dev": true
     },
+    "node_modules/buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
+      }
+    },
     "node_modules/buffer-from": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
@@ -3624,6 +3800,16 @@
       "dev": true,
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/cacheable": {
+      "version": "1.8.8",
+      "resolved": "https://registry.npmjs.org/cacheable/-/cacheable-1.8.8.tgz",
+      "integrity": "sha512-OE1/jlarWxROUIpd0qGBSKFLkNsotY8pt4GeiVErUYh/NUeTNrT+SBksUgllQv4m6a0W/VZsLuiHb88maavqEw==",
+      "dev": true,
+      "dependencies": {
+        "hookified": "^1.7.0",
+        "keyv": "^5.2.3"
       }
     },
     "node_modules/call-bind": {
@@ -3802,6 +3988,21 @@
       "dev": true,
       "engines": {
         "node": ">=6.0"
+      }
+    },
+    "node_modules/ci-info": {
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.9.0.tgz",
+      "integrity": "sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/sibiraj-s"
+        }
+      ],
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/clean-css": {
@@ -4290,12 +4491,12 @@
       }
     },
     "node_modules/css-tree": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.0.0.tgz",
-      "integrity": "sha512-o88DVQ6GzsABn1+6+zo2ct801dBO5OASVyxbbvA2W20ue2puSh/VOuqUj90eUeMSX/xqGqBmOKiRQN7tJOuBXw==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.1.0.tgz",
+      "integrity": "sha512-0eW44TGN5SQXU1mWSkKwFstI/22X2bG1nYzZTYMAWjylYURhse752YgbE4Cx46AC+bAvI+/dYTPRk1LqSUnu6w==",
       "dev": true,
       "dependencies": {
-        "mdn-data": "2.10.0",
+        "mdn-data": "2.12.2",
         "source-map-js": "^1.0.1"
       },
       "engines": {
@@ -5259,16 +5460,16 @@
       "dev": true
     },
     "node_modules/fast-glob": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.2.tgz",
-      "integrity": "sha512-oX2ruAFQwf/Orj8m737Y5adxDQO0LAB7/S5MnxCdTNDd4p6BsyIVsv9JQsATbTSq8KHRpLwIHbVlUNatxd+1Ow==",
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
+      "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
       "dev": true,
       "dependencies": {
         "@nodelib/fs.stat": "^2.0.2",
         "@nodelib/fs.walk": "^1.2.3",
         "glob-parent": "^5.1.2",
         "merge2": "^1.3.0",
-        "micromatch": "^4.0.4"
+        "micromatch": "^4.0.8"
       },
       "engines": {
         "node": ">=8.6.0"
@@ -5322,15 +5523,12 @@
       }
     },
     "node_modules/file-entry-cache": {
-      "version": "9.1.0",
-      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-9.1.0.tgz",
-      "integrity": "sha512-/pqPFG+FdxWQj+/WSuzXSDaNzxgTLr/OrR1QuqfEZzDakpdYE70PwUxL7BPUa8hpjbvY1+qvCl8k+8Tq34xJgg==",
+      "version": "10.0.6",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-10.0.6.tgz",
+      "integrity": "sha512-0wvv16mVo9nN0Md3k7DMjgAPKG/TY4F/gYMBVb/wMThFRJvzrpaqBFqF6km9wf8QfYTN+mNg5aeaBLfy8k35uA==",
       "dev": true,
       "dependencies": {
-        "flat-cache": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=18"
+        "flat-cache": "^6.1.6"
       }
     },
     "node_modules/file-loader": {
@@ -5512,22 +5710,20 @@
       }
     },
     "node_modules/flat-cache": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-5.0.0.tgz",
-      "integrity": "sha512-JrqFmyUl2PnPi1OvLyTVHnQvwQ0S+e6lGSwu8OkAZlSaNIZciTY2H/cOOROxsBA1m/LZNHDsqAgDZt6akWcjsQ==",
+      "version": "6.1.6",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-6.1.6.tgz",
+      "integrity": "sha512-F+CKgSwp0pzLx67u+Zy1aCueVWFAHWbXepvXlZ+bWVTaASbm5SyCnSJ80Fp1ePEmS57wU+Bf6cx6525qtMZ4lQ==",
       "dev": true,
       "dependencies": {
-        "flatted": "^3.3.1",
-        "keyv": "^4.5.4"
-      },
-      "engines": {
-        "node": ">=18"
+        "cacheable": "^1.8.8",
+        "flatted": "^3.3.2",
+        "hookified": "^1.7.0"
       }
     },
     "node_modules/flatted": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.1.tgz",
-      "integrity": "sha512-X8cqMLLie7KsNUDSdzeN8FYK9rEt4Dt67OsG/DNGnYTSDBG4uFAJFBnUeiV+zCVAvwFy56IjM9sH51jVaEhNxw==",
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.3.tgz",
+      "integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
       "dev": true
     },
     "node_modules/follow-redirects": {
@@ -6108,6 +6304,12 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/hookified": {
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/hookified/-/hookified-1.7.1.tgz",
+      "integrity": "sha512-OXcdHsXeOiD7OJ5zvWj8Oy/6RCdLwntAX+wUrfemNcMGn6sux4xbEHi2QXwqePYhjQ/yvxxq2MvCRirdlHscBw==",
+      "dev": true
+    },
     "node_modules/hosted-git-info": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-4.1.0.tgz",
@@ -6246,6 +6448,26 @@
       "peerDependencies": {
         "postcss": "^8.1.0"
       }
+    },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
     },
     "node_modules/ignore": {
       "version": "5.3.2",
@@ -6953,6 +7175,93 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/jest-util": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-29.7.0.tgz",
+      "integrity": "sha512-z6EbKajIpqGKU56y5KBUgy1dt1ihhQJgWzUlZHArA/+X2ad7Cb5iF+AK1EWVL/Bo7Rz9uurpqw6SiBCefUbCGA==",
+      "dev": true,
+      "dependencies": {
+        "@jest/types": "^29.6.3",
+        "@types/node": "*",
+        "chalk": "^4.0.0",
+        "ci-info": "^3.2.0",
+        "graceful-fs": "^4.2.9",
+        "picomatch": "^2.2.3"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-util/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/jest-util/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/jest-util/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/jest-util/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
+    },
+    "node_modules/jest-util/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jest-util/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/jest-worker": {
       "version": "27.5.1",
       "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-27.5.1.tgz",
@@ -7041,12 +7350,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/json-buffer": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
-      "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
-      "dev": true
-    },
     "node_modules/json-parse-better-errors": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
@@ -7127,12 +7430,12 @@
       }
     },
     "node_modules/keyv": {
-      "version": "4.5.4",
-      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
-      "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-5.2.3.tgz",
+      "integrity": "sha512-AGKecUfzrowabUv0bH1RIR5Vf7w+l4S3xtQAypKaUpTdIR1EbrAcTxHCrpo9Q+IWeUlFE2palRtgIQcgm+PQJw==",
       "dev": true,
       "dependencies": {
-        "json-buffer": "3.0.1"
+        "@keyv/serialize": "^1.0.2"
       }
     },
     "node_modules/kind-of": {
@@ -7515,9 +7818,9 @@
       }
     },
     "node_modules/mdn-data": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.10.0.tgz",
-      "integrity": "sha512-qq7C3EtK3yJXMwz1zAab65pjl+UhohqMOctTgcqjLOWABqmwj+me02LSsCuEUxnst9X1lCBpoE0WArGKgdGDzw==",
+      "version": "2.12.2",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.12.2.tgz",
+      "integrity": "sha512-IEn+pegP1aManZuckezWCO+XZQDplx1366JoVhTpMpBB1sPey/SbveZQUosKiKiGYjg1wH4pMlNgXbCiYgihQA==",
       "dev": true
     },
     "node_modules/mem": {
@@ -7780,9 +8083,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.7",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.7.tgz",
-      "integrity": "sha512-eSRppjcPIatRIMC1U6UngP8XFcz8MQWGQdt1MTBQ7NaAmvXDfvNxbvWV3x2y6CdEUciCSsDHDQZbhYaB8QEo2g==",
+      "version": "3.3.8",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.8.tgz",
+      "integrity": "sha512-WNLf5Sd8oZxOm+TzppcYk8gVOgP+l58xNy58D0nbUnOxOWRWvlcCV4kUF7ltmI6PsrLl/BgKEyS4mqsGChFN0w==",
       "dev": true,
       "funding": [
         {
@@ -8368,9 +8671,9 @@
       }
     },
     "node_modules/picocolors": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.0.tgz",
-      "integrity": "sha512-TQ92mBOW0l3LeMeyLV6mzy/kWr8lkd/hp3mTg7wYK7zJhuBStmGMBG0BdeDZS/dZx1IukaX6Bk11zcln25o1Aw==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
       "dev": true
     },
     "node_modules/picomatch": {
@@ -8450,9 +8753,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.4.47",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.47.tgz",
-      "integrity": "sha512-56rxCq7G/XfB4EkXq9Egn5GCqugWvDFjafDOThIdMBsI15iqPqR5r15TfSr1YPYeEI19YeaXMCbY6u88Y76GLQ==",
+      "version": "8.5.3",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.3.tgz",
+      "integrity": "sha512-dle9A3yYxlBSrt8Fu+IpjGT8SY8hN0mlaA6GY8t0P5PjIOZemULz/E2Bnm/2dcUOena75OTNkHI76uZBNUUq3A==",
       "dev": true,
       "funding": [
         {
@@ -8469,8 +8772,8 @@
         }
       ],
       "dependencies": {
-        "nanoid": "^3.3.7",
-        "picocolors": "^1.1.0",
+        "nanoid": "^3.3.8",
+        "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
       "engines": {
@@ -10835,9 +11138,9 @@
       }
     },
     "node_modules/stylelint": {
-      "version": "16.10.0",
-      "resolved": "https://registry.npmjs.org/stylelint/-/stylelint-16.10.0.tgz",
-      "integrity": "sha512-z/8X2rZ52dt2c0stVwI9QL2AFJhLhbPkyfpDFcizs200V/g7v+UYY6SNcB9hKOLcDDX/yGLDsY/pX08sLkz9xQ==",
+      "version": "16.14.1",
+      "resolved": "https://registry.npmjs.org/stylelint/-/stylelint-16.14.1.tgz",
+      "integrity": "sha512-oqCL7AC3786oTax35T/nuLL8p2C3k/8rHKAooezrPGRvUX0wX+qqs5kMWh5YYT4PHQgVDobHT4tw55WgpYG6Sw==",
       "dev": true,
       "funding": [
         {
@@ -10850,43 +11153,43 @@
         }
       ],
       "dependencies": {
-        "@csstools/css-parser-algorithms": "^3.0.1",
-        "@csstools/css-tokenizer": "^3.0.1",
-        "@csstools/media-query-list-parser": "^3.0.1",
-        "@csstools/selector-specificity": "^4.0.0",
+        "@csstools/css-parser-algorithms": "^3.0.4",
+        "@csstools/css-tokenizer": "^3.0.3",
+        "@csstools/media-query-list-parser": "^4.0.2",
+        "@csstools/selector-specificity": "^5.0.0",
         "@dual-bundle/import-meta-resolve": "^4.1.0",
         "balanced-match": "^2.0.0",
         "colord": "^2.9.3",
         "cosmiconfig": "^9.0.0",
         "css-functions-list": "^3.2.3",
-        "css-tree": "^3.0.0",
+        "css-tree": "^3.1.0",
         "debug": "^4.3.7",
-        "fast-glob": "^3.3.2",
+        "fast-glob": "^3.3.3",
         "fastest-levenshtein": "^1.0.16",
-        "file-entry-cache": "^9.1.0",
+        "file-entry-cache": "^10.0.5",
         "global-modules": "^2.0.0",
         "globby": "^11.1.0",
         "globjoin": "^0.1.4",
         "html-tags": "^3.3.1",
-        "ignore": "^6.0.2",
+        "ignore": "^7.0.3",
         "imurmurhash": "^0.1.4",
         "is-plain-object": "^5.0.0",
-        "known-css-properties": "^0.34.0",
+        "known-css-properties": "^0.35.0",
         "mathml-tag-names": "^2.1.3",
         "meow": "^13.2.0",
         "micromatch": "^4.0.8",
         "normalize-path": "^3.0.0",
-        "picocolors": "^1.0.1",
-        "postcss": "^8.4.47",
+        "picocolors": "^1.1.1",
+        "postcss": "^8.5.1",
         "postcss-resolve-nested-selector": "^0.1.6",
         "postcss-safe-parser": "^7.0.1",
-        "postcss-selector-parser": "^6.1.2",
+        "postcss-selector-parser": "^7.0.0",
         "postcss-value-parser": "^4.2.0",
         "resolve-from": "^5.0.0",
         "string-width": "^4.2.3",
         "supports-hyperlinks": "^3.1.0",
         "svg-tags": "^1.0.0",
-        "table": "^6.8.2",
+        "table": "^6.9.0",
         "write-file-atomic": "^5.0.1"
       },
       "bin": {
@@ -10927,11 +11230,119 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/stylelint-scss/node_modules/mdn-data": {
-      "version": "2.12.1",
-      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.12.1.tgz",
-      "integrity": "sha512-rsfnCbOHjqrhWxwt5/wtSLzpoKTzW7OXdT5lLOIH1OTYhWu9rRJveGq0sKvDZODABH7RX+uoR+DYcpFnq4Tf6Q==",
-      "dev": true
+    "node_modules/stylelint-webpack-plugin": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/stylelint-webpack-plugin/-/stylelint-webpack-plugin-5.0.1.tgz",
+      "integrity": "sha512-07lpo1uVoFctKv0EOOg/YSrUppcLMjNBSMRqgooNnlbfAOgQfMzvLK+EbXz0HQiEgZobr+XQX9md/TgwTGdzbw==",
+      "dev": true,
+      "dependencies": {
+        "globby": "^11.1.0",
+        "jest-worker": "^29.7.0",
+        "micromatch": "^4.0.5",
+        "normalize-path": "^3.0.0",
+        "schema-utils": "^4.2.0"
+      },
+      "engines": {
+        "node": ">= 18.12.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      },
+      "peerDependencies": {
+        "stylelint": "^13.0.0 || ^14.0.0 || ^15.0.0 || ^16.0.0",
+        "webpack": "^5.0.0"
+      }
+    },
+    "node_modules/stylelint-webpack-plugin/node_modules/globby": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
+      "integrity": "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==",
+      "dev": true,
+      "dependencies": {
+        "array-union": "^2.1.0",
+        "dir-glob": "^3.0.1",
+        "fast-glob": "^3.2.9",
+        "ignore": "^5.2.0",
+        "merge2": "^1.4.1",
+        "slash": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/stylelint-webpack-plugin/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/stylelint-webpack-plugin/node_modules/jest-worker": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-29.7.0.tgz",
+      "integrity": "sha512-eIz2msL/EzL9UFTFFx7jBTkeZfku0yUAyZZZmJ93H2TYEiroIx2PQjEXcwYtYl8zXCxb+PAmA2hLIt/6ZEkPHw==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*",
+        "jest-util": "^29.7.0",
+        "merge-stream": "^2.0.0",
+        "supports-color": "^8.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/stylelint-webpack-plugin/node_modules/slash": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
+      "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/stylelint-webpack-plugin/node_modules/supports-color": {
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+      "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
+    "node_modules/stylelint/node_modules/@csstools/selector-specificity": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/selector-specificity/-/selector-specificity-5.0.0.tgz",
+      "integrity": "sha512-PCqQV3c4CoVm3kdPhyeZ07VmBRdH2EpMFA/pd9OASpOEC3aXNGoqPDAZ80D0cLpMBxnmk0+yNhGsEx31hq7Gtw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "postcss-selector-parser": "^7.0.0"
+      }
     },
     "node_modules/stylelint/node_modules/balanced-match": {
       "version": "2.0.0",
@@ -10995,9 +11406,9 @@
       }
     },
     "node_modules/stylelint/node_modules/ignore": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-6.0.2.tgz",
-      "integrity": "sha512-InwqeHHN2XpumIkMvpl/DCJVrAHgCsG5+cn1XlnLWGwtZBm8QJfSusItfrwx81CTp5agNZqpKU2J/ccC5nGT4A==",
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.3.tgz",
+      "integrity": "sha512-bAH5jbK/F3T3Jls4I0SO1hmPR0dKU0a7+SY6n1yzRtG54FLO8d6w/nxLFX2Nb7dBu6cCWXPaAME6cYqFUMmuCA==",
       "dev": true,
       "engines": {
         "node": ">= 4"
@@ -11010,6 +11421,25 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stylelint/node_modules/known-css-properties": {
+      "version": "0.35.0",
+      "resolved": "https://registry.npmjs.org/known-css-properties/-/known-css-properties-0.35.0.tgz",
+      "integrity": "sha512-a/RAk2BfKk+WFGhhOCAYqSiFLc34k8Mt/6NWRI4joER0EYUzXIcFivjjnoD3+XU1DggLn/tZc3DOAgke7l8a4A==",
+      "dev": true
+    },
+    "node_modules/stylelint/node_modules/postcss-selector-parser": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.0.tgz",
+      "integrity": "sha512-8sLjZwK0R+JlxlYcTuVnyT2v+htpdrjDOKuMcOVdYjt52Lh8hWRYpxBPoKx/Zg+bcjc3wx6fmQevMmUztS/ccA==",
+      "dev": true,
+      "dependencies": {
+        "cssesc": "^3.0.0",
+        "util-deprecate": "^1.0.2"
+      },
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/stylelint/node_modules/resolve-from": {
@@ -11131,9 +11561,9 @@
       }
     },
     "node_modules/table": {
-      "version": "6.8.2",
-      "resolved": "https://registry.npmjs.org/table/-/table-6.8.2.tgz",
-      "integrity": "sha512-w2sfv80nrAh2VCbqR5AK27wswXhqcck2AhfnNW76beQXskGZ1V12GwS//yYVa3d3fcvAip2OUnbDAjW2k3v9fA==",
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/table/-/table-6.9.0.tgz",
+      "integrity": "sha512-9kY+CygyYM6j02t5YFHbNz2FN5QmYGv9zAjVp4lCDjlCw7amdckXlEt/bjMhUIfj4ThGRE4gCUH5+yGnNuPo5A==",
       "dev": true,
       "dependencies": {
         "ajv": "^8.0.1",

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "style-loader": "^4.0.0",
     "stylelint": "^16.14.1",
     "stylelint-scss": "^6.8.1",
+    "stylelint-webpack-plugin": "^5.0.1",
     "webpack": "^5.94.0",
     "webpack-cli": "^5.1.4",
     "webpack-dev-middleware": "^7.4.2",

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "sass": "^1.78.0",
     "sass-loader": "^16.0.2",
     "style-loader": "^4.0.0",
-    "stylelint": "^16.10.0",
+    "stylelint": "^16.14.1",
     "stylelint-scss": "^6.8.1",
     "webpack": "^5.94.0",
     "webpack-cli": "^5.1.4",

--- a/server.js
+++ b/server.js
@@ -9,7 +9,6 @@ const webpackStyleConfig = require("./webpack.style.config.babel.js")
 // const jsCompiler = webpack(webpackConfig({}, {mode: 'development'}));
 const styleCompiler = webpack(webpackStyleConfig({}, {mode: 'development'}));
 const browserSync = require("browser-sync")
-const stylelint = require("stylelint");
 const url = require("url")
 const path = require("path")
 const fs = require("fs")
@@ -121,13 +120,7 @@ bs.watch(["app/*.pug", "app/**/*.pug"]).on("change", function (event) {
     bs.reload("*.html")
 });
 
-bs.watch("app/assets/**/*.scss").on("change", async function (event) {
-  const results = await stylelint.lint({
-    files: event,
-    formatter: "string",
-    fix: true
-  });
-
+bs.watch("app/assets/**/*.scss").on("change", function (event) {
   bs.reload("*.css")
 });
 bs.watch("dist/assets/**/*.js").on("change", function () {

--- a/server.js
+++ b/server.js
@@ -98,7 +98,7 @@ var config = {
       // }),
       webpackDevMiddleware(styleCompiler, {
         publicPath: '/',
-        stats: {colors: true}
+        stats: 'minimal',
       }),
 
       // webpackHotMiddleware(jsCompiler),

--- a/server.js
+++ b/server.js
@@ -9,6 +9,7 @@ const webpackStyleConfig = require("./webpack.style.config.babel.js")
 // const jsCompiler = webpack(webpackConfig({}, {mode: 'development'}));
 const styleCompiler = webpack(webpackStyleConfig({}, {mode: 'development'}));
 const browserSync = require("browser-sync")
+const stylelint = require("stylelint");
 const url = require("url")
 const path = require("path")
 const fs = require("fs")
@@ -120,7 +121,13 @@ bs.watch(["app/*.pug", "app/**/*.pug"]).on("change", function (event) {
     bs.reload("*.html")
 });
 
-bs.watch("app/assets/**/*.scss").on("change", function (event) {
+bs.watch("app/assets/**/*.scss").on("change", async function (event) {
+  const results = await stylelint.lint({
+    files: event,
+    formatter: "string",
+    fix: true
+  });
+
   bs.reload("*.css")
 });
 bs.watch("dist/assets/**/*.js").on("change", function () {

--- a/webpack.config.babel.js
+++ b/webpack.config.babel.js
@@ -14,7 +14,7 @@ module.exports = (env, argv) => {
 
   const configs = {
     mode: argv.mode,
-
+    stats:'minimal',
     context: __dirname + '/app/',
     entry: {
       app: __dirname + '/app/assets/js/app.js',

--- a/webpack.style.config.babel.js
+++ b/webpack.style.config.babel.js
@@ -13,6 +13,7 @@ module.exports = (env, argv) => {
 
   const configs = {
     mode: argv.mode,
+    stats:'minimal',
     context: __dirname + '/app/',
     // cache: {
     //     type: 'filesystem',

--- a/webpack.style.config.babel.js
+++ b/webpack.style.config.babel.js
@@ -66,6 +66,13 @@ module.exports = (env, argv) => {
             },
             {
               loader: 'sass-loader',
+              options: {
+                // dart-sassのJS APIに渡すオプション
+                sassOptions: {
+                  silenceDeprecations:['mixed-decls']
+                  // silenceDeprecations: ['DEPRECATION_MIXED_DECLARATIONS']
+                }
+              }
             }
           ],
         },

--- a/webpack.style.config.babel.js
+++ b/webpack.style.config.babel.js
@@ -2,98 +2,104 @@ const webpack = require('webpack');
 const MiniCssExtractPlugin = require('mini-css-extract-plugin');
 const RemoveEmptyScriptsPlugin = require('webpack-remove-empty-scripts');
 const path = require('path');
+const StylelintWebpackPlugin = require('stylelint-webpack-plugin');
 
 const BASE_DIR = "../../"
 
 module.exports = (env, argv) => {
-    // 開発モードかどうか
-    // モード（none / production / development）
-    const IS_DEVELOPMENT = argv.mode === 'development';
+  // 開発モードかどうか
+  // モード（none / production / development）
+  const IS_DEVELOPMENT = argv.mode === 'development';
 
-    const configs = {
-      mode: argv.mode,
-      context: __dirname + '/app/',
-      // cache: {
-      //     type: 'filesystem',
-      //     buildDependencies: {
-      //         config: [__filename]
-      //     }
-      // },
-      entry: {
-        style: __dirname + '/app/assets/scss/style.scss',
-        editor: __dirname + '/app/assets/scss/editor.scss',
-        print: __dirname + '/app/assets/scss/print.scss',
-      },
-      output: {
-        path: path.join(__dirname, 'dist/'),
-        filename: 'assets/js/[name].js',
-        publicPath: BASE_DIR,
-      },
-      watch: false,
-      module: {
-        rules: [
-          {
-            test: /\.(scss|css|sass)$/,
-            include: [
-              path.resolve(__dirname, 'app/assets/scss'),
-            ],
-            use: [
-              {
-                loader: MiniCssExtractPlugin.loader,
-              },
-              {
-                loader: 'css-loader',
-                options: {
-                  url: false
-                }
-              },
-              {
-                loader: "postcss-loader",
-                options: {
-                  postcssOptions: {
-                    plugins: [
-                      [
-                        'postcss-sort-media-queries',
-                        {
-                          sort: 'desktop-first',
-                          onlyTopLevel: true,
-                        }
-                      ],
+  const configs = {
+    mode: argv.mode,
+    context: __dirname + '/app/',
+    // cache: {
+    //     type: 'filesystem',
+    //     buildDependencies: {
+    //         config: [__filename]
+    //     }
+    // },
+    entry: {
+      style: __dirname + '/app/assets/scss/style.scss',
+      editor: __dirname + '/app/assets/scss/editor.scss',
+      print: __dirname + '/app/assets/scss/print.scss',
+    },
+    output: {
+      path: path.join(__dirname, 'dist/'),
+      filename: 'assets/js/[name].js',
+      publicPath: BASE_DIR,
+    },
+    watch: false,
+    module: {
+      rules: [
+        {
+          test: /\.(scss|css|sass)$/,
+          include: [
+            path.resolve(__dirname, 'app/assets/scss'),
+          ],
+          use: [
+            {
+              loader: MiniCssExtractPlugin.loader,
+            },
+            {
+              loader: 'css-loader',
+              options: {
+                url: false
+              }
+            },
+            {
+              loader: "postcss-loader",
+              options: {
+                postcssOptions: {
+                  plugins: [
+                    [
+                      'postcss-sort-media-queries',
+                      {
+                        sort: 'desktop-first',
+                        onlyTopLevel: true,
+                      }
                     ],
-                  },
+                  ],
                 },
               },
-              {
-                loader: 'sass-loader',
-              }
-            ],
-          },
+            },
+            {
+              loader: 'sass-loader',
+            }
+          ],
+        },
 
-        ]
-      },
-      plugins: [
-        new RemoveEmptyScriptsPlugin(), // CSS別出力時の不要JSファイルを削除
-        new MiniCssExtractPlugin({
-          filename: "assets/css/[name].css",
-          chunkFilename: "[id].css"
-        })
-      ],
-    }
-    if (IS_DEVELOPMENT) {
-      // development であれば、devtool を追加
-      configs.devtool = 'eval';
-      configs.cache = {
-        type: 'filesystem',
-        buildDependencies: {
-          config: [__filename]
-        }
-      };
-      Object.keys(configs.entry).forEach(entryName => {
-        configs.entry[entryName] = ['webpack-hot-middleware/client?reload=true', configs.entry[entryName]];
-      });
-      configs.plugins.push(new webpack.HotModuleReplacementPlugin());
-    }
+      ]
+    },
+    plugins: [
+      new StylelintWebpackPlugin({
+        files: 'assets/scss/**/*.scss', // チェック対象のファイルパターン
+        fix: true, // 自動修正を有効にする場合
+        failOnError: false, // エラーがあった場合ビルドを中断するか
+      }),
+      new RemoveEmptyScriptsPlugin(), // CSS別出力時の不要JSファイルを削除
+      new MiniCssExtractPlugin({
+        filename: "assets/css/[name].css",
+        chunkFilename: "[id].css"
+      })
+    ],
+  }
+  if (IS_DEVELOPMENT) {
+    // development であれば、devtool を追加
+    configs.devtool = 'eval';
+    configs.cache = {
+      type: 'filesystem',
+      buildDependencies: {
+        config: [__filename]
+      }
+    };
+    Object.keys(configs.entry).forEach(entryName => {
+      configs.entry[entryName] = ['webpack-hot-middleware/client?reload=true', configs.entry[entryName]];
+    });
+    configs.plugins.push(new webpack.HotModuleReplacementPlugin());
+  }
 
 
-    return configs;
+  return configs;
 }


### PR DESCRIPTION
https://www.notion.so/growgroup/Figma-line-height-180-line-height-1-8-1a5eef14914a807493fddd84a98d6980

# 概要
- `line-height: 100%` と書いて保存すると、自動的に `line-height: 1` になるようにする
- ついでに、npm start 中のログの表示を整理・一部SCSSの記述を調整

## `line-height: 100%` と書いて保存すると、自動的に `line-height: 1` になるようにする
stylelintを `npm start` 中に自動実行するようにしました。auto fix機能で自動でline-heightが書き換わります。
（PhpStormでは、一度ファイルからフォーカスを外さないと見かけ上は更新されません）

参考：https://qiita.com/pons_cawaii/items/476d1953aa7b34664471

▼動作
https://github.com/user-attachments/assets/83d02d6e-dcb4-42a0-86cf-bfd26c5e0596

## ついでに、npm start 中のログの表示を整理・一部SCSSの記述を調整
ログ表示を調整して、stylelintの実行結果を見やすくしました

### 変更前
![CleanShot 2025-02-25 at 22 17 54@2x](https://github.com/user-attachments/assets/f3a57bd2-8987-40d5-bc26-ea518d2b2e3b)

### 変更後
![CleanShot 2025-02-25 at 22 15 54@2x](https://github.com/user-attachments/assets/b79ddc1a-6f9e-401b-933e-95e69db62eec)

