### PR TITLE
[add]mixin_コンテナクエリ

### DIFF
--- a/app/assets/scss/foundation/_mixin.scss
+++ b/app/assets/scss/foundation/_mixin.scss
@@ -23,6 +23,10 @@
     @warn inspect($value) + ' was passed to rem-calc(), which is not a number.';
     @return $value;
   }
+  // $base が null または 0 の場合、デフォルト値を設定
+  @if $base == null or strip-unit($base) == 0 {
+    $base: $font-base-size;
+  }
   // 値がremでない場合
   @if unit($value) != 'rem' {
     $value: math.div(strip-unit($value), strip-unit($base)) * 1rem;
@@ -222,6 +226,66 @@
       @media not screen and (max-width: #{$bp}) {
         @content;
       }
+    }
+  }
+}
+
+// コンテナクエリのブレイクポイント関数
+@function container($val) {
+  $min: null;
+  $max: null;
+  $dir: null;
+
+  // 範囲指定 (最小値 + 最大値)
+  @if length($val) == 2 and type-of(nth($val, 1)) == 'number' and type-of(nth($val, 2)) == 'number' {
+    $min: to-rem(min(nth($val, 1), nth($val, 2)));
+    $max: to-rem(max(nth($val, 1), nth($val, 2)));
+    $dir: 'range';
+  }
+  // 数値 + 方向指定 (up または down)
+  @else if length($val) == 2 and type-of(nth($val, 1)) == 'number' and type-of(nth($val, 2)) == 'string' {
+    $bp: nth($val, 1);
+    $dir: nth($val, 2);
+
+    @if $dir == 'down' {
+      $max: to-rem($bp);
+    } @else if $dir == 'up' {
+      $min: to-rem($bp);
+    } @else {
+      @error 'container(): Direction must be "up" or "down".';
+    }
+  }
+  // 数値のみ (up をデフォルトに)
+  @else if length($val) == 1 and type-of(nth($val, 1)) == 'number' {
+    $min: to-rem(nth($val, 1));
+    $dir: 'up';
+  }
+  // 不正な入力の場合
+  @else {
+    @error 'container(): Invalid input. Provide one or two numbers, or a number with "up"/"down".';
+  }
+
+  @return ( $min, $max, $dir );
+}
+
+// コンテナクエリ用 Mixin
+@mixin container($value) {
+  $result: container($value);
+  $min: nth($result, 1);
+  $max: nth($result, 2);
+  $dir: nth($result, 3);
+
+  @if $dir == 'range' {
+    @container (min-width: #{$min}) and (max-width: #{$max}) {
+      @content;
+    }
+  } @else if $dir == 'down' {
+    @container (max-width: #{$max}) {
+      @content;
+    }
+  } @else if $dir == 'up' {
+    @container (min-width: #{$min}) {
+      @content;
     }
   }
 }

--- a/app/assets/scss/foundation/_mixin.scss
+++ b/app/assets/scss/foundation/_mixin.scss
@@ -17,15 +17,11 @@
 }
 
 // 値をremに変換する関数
-@function to-rem($value, $base: null) {
+@function to-rem($value, $base: $font-base-size) {
   // 値が数値でない場合の警告
   @if type-of($value) != 'number' {
     @warn inspect($value) + ' was passed to rem-calc(), which is not a number.';
     @return $value;
-  }
-  // $base が null または 0 の場合、デフォルト値を設定
-  @if $base == null or strip-unit($base) == 0 {
-    $base: $font-base-size;
   }
   // 値がremでない場合
   @if unit($value) != 'rem' {


### PR DESCRIPTION
## 改善DB
コンテナクエリ `@container` をmixinで使えるようにしておく
https://www.notion.so/growgroup/container-mixin-191eef14914a80609513f654efb19f08

## 使い方
1.  対象の親にcontainer-typeを付与する
2.  スタイルを当てたい要素に `@include container()`をつける
   - 800px以上の時に反映したい（以上）
     - `@include container(800 up)` 
   - 300px以下の時に反映したい（以下）
     - `@include container(300 down) `
   - 100〜250pxの間の時に反映したい（範囲） 
     - `@include container(100 250) `
     - `@include container(250 100)` でもOK
