### PR TITLE
[update]js-slidebar-containerの挙動修正

### DIFF
--- a/app/assets/js/app/slidebar.js
+++ b/app/assets/js/app/slidebar.js
@@ -98,7 +98,7 @@ export default class Slidebar {
   bodyTrigger() {
     var self = this;
     $(document).on('click', this.options.containerSelector, function (e) {
-      if (self.isActive) {
+      if (e.target === e.currentTarget && self.isActive) {
         self.close();
       }
     });

--- a/app/assets/js/app/slidebar.js
+++ b/app/assets/js/app/slidebar.js
@@ -9,17 +9,11 @@
  * # example:
  *
  * <div class="js-slidebar-menu">
- *    <ul>
- *        <li>menu</li>
- *        <li>menu</li>
- *        <li>menu</li>
- *    </ul>
- * </div>
+ *  <div class="js-slidebar-container">
  *
- * <a href="#" class="js-slidebar-button"><i class="fa fa-bars"></i></a>
+ *    content
  *
- * <div class="js-slidebar-container">
- *     content
+ *  </div>
  * </div>
  *
  */
@@ -62,7 +56,7 @@ export default class Slidebar {
     this.container = $(this.options.containerSelector)
 
     this.trigger();
-    this.bodyTrigger();
+    this.closeOnOuterClick();
     this.toggle = this.toggle.bind(this);
 
     $("body").addClass('slidebar-init')
@@ -95,7 +89,7 @@ export default class Slidebar {
     }
   }
 
-  bodyTrigger() {
+  closeOnOuterClick() {
     var self = this;
     $(document).on('click', this.options.containerSelector, function (e) {
       if (e.target === e.currentTarget && self.isActive) {

--- a/app/assets/js/app/slidebar.js
+++ b/app/assets/js/app/slidebar.js
@@ -8,6 +8,9 @@
  *
  * # example:
  *
+ *
+ * <button class="js-slidebar-button"></button>
+ *
  * <div class="js-slidebar-menu">
  *  <div class="js-slidebar-container">
  *


### PR DESCRIPTION
## 改善DB
スライドメニューのリンクが少ないとき、余白クリックでスライドメニュー自体を閉じるオプション機能の追加
https://www.notion.so/growgroup/158eef14914a803c9b3ef8ca1101a302

包括要素（小要素クリック時は除外）をクリックした際に
bodyTrigger() を発火させてスライドメニューを格納するよう修正

想定HTML構造
```
<div class="c-slidebar-menu  js-slidebar-menu">
  <div class="c-slidebar-menu__wrapper js-slidebar-container"> // 利用時追加
    <ul class="c-slidebar-menu__list">
・
・
・

```