### PR TITLE
[update]アコーディオンでタグ違いも可能にする

### DIFF
--- a/app/assets/js/app/accordion.js
+++ b/app/assets/js/app/accordion.js
@@ -15,6 +15,14 @@
  *      .c-accordion__content-inner
  *        |コンテンツ
  *
+ * # div example:
+ * .c-accordion
+ *   .c-accordion__block.js-accordion(data-open="true")
+ *     .c-accordion__title(data-accordion-title="title")
+ *       |タイトルテキスト
+ *    .c-accordion__content(data-accordion-content="content")
+ *      .c-accordion__content-inner
+ *        |コンテンツ
  */
 
 import Utils from "./utils";
@@ -62,11 +70,11 @@ export default class Accordion {
     for (var i = 0; i < this.targetAll.length; i++) {
       let target = $(this.targetAll[i]);
 
-      
+
       target.isDetails = target.prop("tagName").toLowerCase() === "details";
 
       // ターゲットの初期設定
-      target.defaultOpen = target.attr("open") !== undefined;
+      target.defaultOpen = target.isDetails ? target.prop("open") : target.attr("data-open") !== undefined;
       target.responsive = target.data("accordion-responsive");
       target.title = target.find('*[' + this.options.titleTargetAttr + ']').eq(0);
       target.content = target.find('*[' + this.options.contentTargetAttr + ']').eq(0);
@@ -85,6 +93,11 @@ export default class Accordion {
       } else {
         this.elementInit(target);
       }
+
+      // divかつfalseの時、データ属性を付与
+      if (!target.defaultOpen) {
+        target.attr("data-open", 'true');
+      }
     }
   }
 
@@ -96,7 +109,11 @@ export default class Accordion {
     this.accordion(target);
 
     if (!target.defaultOpen) {
-      target.removeAttr('open');
+      if (target.isDetails) {
+        target.removeAttr("open");
+      } else {
+        target.removeAttr("data-open");
+      }
     }
   }
 
@@ -135,13 +152,13 @@ export default class Accordion {
           el.content.hide().slideDown(this.options.speed);
         }
       } else {
-        // 通常のアコーディオン
-        if (el.content.parent().attr("open")) {
+        // 通常のアコーディオン (divなど)
+        if (el.content.parent().attr("data-open")) {
           el.content.slideUp(this.options.speed, function () {
-            $(this).parent().removeAttr("open").show();
+            $(this).parent().removeAttr("data-open").show();
           });
         } else {
-          el.content.parent().attr("open", '');
+          el.content.parent().attr("data-open", "true");
           el.content.hide().slideDown(this.options.speed);
         }
       }

--- a/app/assets/js/app/accordion.js
+++ b/app/assets/js/app/accordion.js
@@ -21,7 +21,6 @@ import Utils from "./utils";
 
 const utils = new Utils();
 
-
 var defaultOptions = {
   selector: '.js-accordion',
   titleTargetAttr: 'data-accordion-title',
@@ -44,7 +43,6 @@ export default class Accordion {
    * 初期化
    */
   init() {
-
     // ターゲットを取得する
     this.targetAll = $(this.options.selector);
 
@@ -64,15 +62,17 @@ export default class Accordion {
     for (var i = 0; i < this.targetAll.length; i++) {
       let target = $(this.targetAll[i]);
 
+      
+      target.isDetails = target.prop("tagName").toLowerCase() === "details";
+
       // ターゲットの初期設定
-      target.defaultOpen = target.attr("open") !== undefined; //初期値がopenか確認
+      target.defaultOpen = target.attr("open") !== undefined;
       target.responsive = target.data("accordion-responsive");
       target.title = target.find('*[' + this.options.titleTargetAttr + ']').eq(0);
       target.content = target.find('*[' + this.options.contentTargetAttr + ']').eq(0);
 
       // レスポンシブの設定がある場合
       if (target.responsive !== undefined) {
-        // Media Query にマッチするか確認
         utils.responsiveMatch(
           () => {
             this.elementInit(target);
@@ -83,37 +83,37 @@ export default class Accordion {
           "max-width: " + target.responsive + "px"
         );
       } else {
-        // レスポンシブの設定がない場合、 そのまま実行
         this.elementInit(target);
       }
     }
   }
 
-  // ターゲットの初期化
+  /**
+   * ターゲットの初期化
+   */
   elementInit(target) {
-    target.title.off('click'); // イベントを削除
+    target.title.off('click');
     this.accordion(target);
 
-    if(!target.defaultOpen){
+    if (!target.defaultOpen) {
       target.removeAttr('open');
     }
   }
 
-  // ターゲットの破棄
+  /**
+   * ターゲットの破棄
+   */
   elementDestroy(target) {
-    target.attr("open",'');//open属性をつける（アコーディオンを開く）
+    target.attr("open", '');
 
-    target.title.off('click'); // イベントを削除
+    target.title.off('click');
     target.title.on('click', (e) => {
-      // クリックされた要素が a タグの場合は処理をスキップ
       if (e.target.tagName.toLowerCase() === 'a') {
         return;
       }
-      // デフォルトの動作をキャンセル
-      e.preventDefault();
+      e.preventDefault(); // デフォルトの動作をキャンセル
     });
   }
-
 
   /**
    * アコーディオンの動作
@@ -122,21 +122,29 @@ export default class Accordion {
   accordion(el) {
     $(el.title).on('click', (e) => {
       e.preventDefault();
-      if(el.content.parent().attr("open")){
-        // open属性がついていれば：アコーディオンを閉じるときの処理
-        el.content.slideUp(this.options.speed, function (){
-          // アニメーションの完了後にopen属性を取り除き、display:none;を外す
-          $(this).parent().removeAttr("open");
-          $(this).show();
-        });
+
+      if (el.isDetails) {
+        // detailsタグのアコーディオン
+        if (el.prop("open")) {
+          el.content.slideUp(this.options.speed, function (){
+            $(this).parent().removeAttr("open");
+            $(this).show();
+          });
+        } else {
+          el.content.parent().attr("open",'');
+          el.content.hide().slideDown(this.options.speed);
+        }
       } else {
-        // open属性が無ければ:アコーディオンを開くときの処理
-        // open属性を付ける
-        el.content.parent().attr("open",'');
-        // いったんdisplay:none;してからslideDownで開く
-        el.content.hide().slideDown(this.options.speed);
+        // 通常のアコーディオン
+        if (el.content.parent().attr("open")) {
+          el.content.slideUp(this.options.speed, function () {
+            $(this).parent().removeAttr("open").show();
+          });
+        } else {
+          el.content.parent().attr("open", '');
+          el.content.hide().slideDown(this.options.speed);
+        }
       }
     });
-
   }
 }

--- a/app/assets/scss/foundation/_mixin.scss
+++ b/app/assets/scss/foundation/_mixin.scss
@@ -633,3 +633,5 @@
   width: 1em;
   height: 1em;
 }
+
+

--- a/app/assets/scss/layout/footer.scss
+++ b/app/assets/scss/layout/footer.scss
@@ -5,6 +5,11 @@ category: Layout
 ---
 */
 
+.l-footer__unit {
+  @include breakpoint(medium down) {
+    display: none;
+  }
+}
 .l-footer {
   position: relative;
   background-color: $font-base-color;

--- a/app/format/components/_other.pug
+++ b/app/format/components/_other.pug
@@ -1,1 +1,127 @@
-//アコーディオンdiv.u-mbs.is-bottom  .l-container    +accordion-list([      {        title: "見出しタイトルテキスト　テキストテキストテキストテキストテキスト",        content: "ここにテキストが入ります。ここにテキストが入ります。ここにテキストが入ります。ここにテキストが入ります。ここにテキストが入ります。ここにテキストが入ります。ここにテキストが入ります。ここにテキストが入ります。ここにテキストが入ります。ここにテキストが入ります。ここにテキストが入ります。ここにテキストが入ります。ここにテキストが入ります。ここにテキストが入ります。ここにテキストが入ります。ここにテキストが入ります。",        defaultOpen: true,      },      {        title: "見出しタイトルテキスト　テキストテキストテキストテキストテキスト",        content: `テキスト                <br>                <a href="">リンク</a>`,      },      {        title: "<a href='https://example.com' target='_blank'>スマホではアコーディオン、PCでははじめから展開しているパターンのサンプル：PCのときリンクがあっても動作する</a>",        content: "ここにテキストが入ります。ここにテキストが入ります。ここにテキストが入ります。ここにテキストが入ります。ここにテキストが入ります。ここにテキストが入ります。ここにテキストが入ります。ここにテキストが入ります。ここにテキストが入ります。ここにテキストが入ります。ここにテキストが入ります。ここにテキストが入ります。ここにテキストが入ります。ここにテキストが入ります。ここにテキストが入ります。ここにテキストが入ります。",        responsive: "950"      },    ])h3 カードスライダーdiv.u-mbs.is-bottom  +c.card.js-card-slider.swiper    +e.slider.swiper-wrapper      +e.block.swiper-slide        +e.image: +img("img-card-01.jpg","",712,420)        +e.content          h3.c-card__title スマホでスライダーになるサンプル          p.c-card__text ここにテキストが入ります。ここにテキストが入ります。ここにテキストが入ります。ここにテキストが入ります。ここにテキストが入ります。      +e.block.swiper-slide        +e.image: +img("img-card-01.jpg","",712,420)        +e.content          h3.c-card__title スマホでスライダーになるサンプル          p.c-card__text ここにテキストが入ります。ここにテキストが入ります。ここにテキストが入ります。ここにテキストが入ります。ここにテキストが入ります。    +e.slider-nav      +button.button-prev.js-card-slider-prev < 前へ      +button.button-next.js-card-slider-next > 次へ    +e.slider-pagination.js-card-slider-paginationdiv.u-mbs.is-bottom  +c.card.js-card-slider.swiper    +e.slider.swiper-wrapper      +e.block.swiper-slide        +e.image: +img("img-card-01.jpg","",712,420)        +e.content          h3.c-card__title スマホでスライダーになるサンプル          p.c-card__text ここにテキストが入ります。ここにテキストが入ります。ここにテキストが入ります。ここにテキストが入ります。ここにテキストが入ります。      +e.block.swiper-slide        +e.image: +img("img-card-01.jpg","",712,420)        +e.content          h3.c-card__title スマホでスライダーになるサンプル          p.c-card__text ここにテキストが入ります。ここにテキストが入ります。ここにテキストが入ります。ここにテキストが入ります。ここにテキストが入ります。    +e.slider-nav      +button.button-prev.js-card-slider-prev < 前へ      +button.button-next.js-card-slider-next > 次へ    +e.slider-pagination.js-card-slider-pagination  h3 横に流れ続けるスライダー  div.u-mbs.is-bottom    +c.gallery-text.js-text-loop.swiper      ul.swiper-wrapper        +loop(2)          li.swiper-slide: span TEXTGALLERY  div.u-mbs.is-bottom    +c.gallery-logo      .l-container        +h2.head.c-heading.is-md.is-center.is-mg-level-2 ロゴギャラリー      +e.slider.js-logo-slider.swiper        +e.images.swiper-wrapper          for num in [1,2]            - var img = "https://placehold.jp/3d4070/ffffff/300x80.png?text=" + num + ".png"            +e.image.swiper-slide: +img(img)      +e.slider.js-logo-slider.swiper        +e.images.swiper-wrapper          for num in [1,2,3,4,5,6]            - var img = "https://placehold.jp/3d4070/ffffff/300x80.png?text=" + num + ".png"            +e.image.swiper-slide: +img(img)h3 画面幅が狭いとき横スクロールする画像やテーブルdiv.u-mbs.is-bottom  .c-scrollable    // scroll-hint が .js-scrollableの親の要素に対して適用されるため    // c-scrollableと .js-scrollableを分けることを推奨    .js-scrollable      +img("img-sample.jpg")div.u-mbs.is-bottom  .c-scrollable    .js-scrollable      table.c-table        tbody          tr            th テスト            th テスト            th テスト            th テスト            th テスト          tr            td テスト            td テスト            td テスト            td テスト            td テスト
+//アコーディオン
+div.u-mbs.is-bottom
+  .l-container
+    <div class="l-footer__item   js-accordion js-slidebar" data-accordion-responsive="750">
+      <span><a class="l-footer__item-link" href="/service/" data-accordion-title="title">事業内容</a>
+      </span>
+      <div class="l-footer__unit" data-accordion-content="content">
+        <div class="l-footer__unit-item"><a class="l-footer__unit-link" href="/service/domestic-business-trip/">国内出張 手配</a>
+        </div>
+        <div class="l-footer__unit-item"><a class="l-footer__unit-link" href="/service/overseas-business-trip/">海外出張 手配</a>
+        </div>
+        <div class="l-footer__unit-item"><a class="l-footer__unit-link" href="/service/group-travel/">社員・団体旅行</a>
+        </div>
+        <div class="l-footer__unit-item"><a class="l-footer__unit-link" href="/topics/category-02/">個人向け旅行 手配</a>
+        </div>
+      </div>
+    </div>
+    +accordion-list([
+      {
+        title: "見出しタイトルテキスト　テキストテキストテキストテキストテキスト",
+        content: "ここにテキストが入ります。ここにテキストが入ります。ここにテキストが入ります。ここにテキストが入ります。ここにテキストが入ります。ここにテキストが入ります。ここにテキストが入ります。ここにテキストが入ります。ここにテキストが入ります。ここにテキストが入ります。ここにテキストが入ります。ここにテキストが入ります。ここにテキストが入ります。ここにテキストが入ります。ここにテキストが入ります。ここにテキストが入ります。",
+        defaultOpen: true,
+      },
+      {
+        title: "見出しタイトルテキスト　テキストテキストテキストテキストテキスト",
+        content: `テキスト
+                <br>
+                <a href="">リンク</a>`,
+      },
+
+      {
+        title: "<a href='https://example.com' target='_blank'>スマホではアコーディオン、PCでははじめから展開しているパターンのサンプル：PCのときリンクがあっても動作する</a>",
+        content: "ここにテキストが入ります。ここにテキストが入ります。ここにテキストが入ります。ここにテキストが入ります。ここにテキストが入ります。ここにテキストが入ります。ここにテキストが入ります。ここにテキストが入ります。ここにテキストが入ります。ここにテキストが入ります。ここにテキストが入ります。ここにテキストが入ります。ここにテキストが入ります。ここにテキストが入ります。ここにテキストが入ります。ここにテキストが入ります。",
+        responsive: "950"
+      },
+    ])
+
+
+
+h3 カードスライダー
+div.u-mbs.is-bottom
+  +c.card.js-card-slider.swiper
+    +e.slider.swiper-wrapper
+      +e.block.swiper-slide
+        +e.image: +img("img-card-01.jpg","",712,420)
+        +e.content
+          h3.c-card__title スマホでスライダーになるサンプル
+          p.c-card__text ここにテキストが入ります。ここにテキストが入ります。ここにテキストが入ります。ここにテキストが入ります。ここにテキストが入ります。
+      +e.block.swiper-slide
+        +e.image: +img("img-card-01.jpg","",712,420)
+        +e.content
+          h3.c-card__title スマホでスライダーになるサンプル
+          p.c-card__text ここにテキストが入ります。ここにテキストが入ります。ここにテキストが入ります。ここにテキストが入ります。ここにテキストが入ります。
+
+    +e.slider-nav
+      +button.button-prev.js-card-slider-prev < 前へ
+      +button.button-next.js-card-slider-next > 次へ
+    +e.slider-pagination.js-card-slider-pagination
+div.u-mbs.is-bottom
+  +c.card.js-card-slider.swiper
+    +e.slider.swiper-wrapper
+      +e.block.swiper-slide
+        +e.image: +img("img-card-01.jpg","",712,420)
+        +e.content
+          h3.c-card__title スマホでスライダーになるサンプル
+          p.c-card__text ここにテキストが入ります。ここにテキストが入ります。ここにテキストが入ります。ここにテキストが入ります。ここにテキストが入ります。
+      +e.block.swiper-slide
+        +e.image: +img("img-card-01.jpg","",712,420)
+        +e.content
+          h3.c-card__title スマホでスライダーになるサンプル
+          p.c-card__text ここにテキストが入ります。ここにテキストが入ります。ここにテキストが入ります。ここにテキストが入ります。ここにテキストが入ります。
+
+    +e.slider-nav
+      +button.button-prev.js-card-slider-prev < 前へ
+      +button.button-next.js-card-slider-next > 次へ
+    +e.slider-pagination.js-card-slider-pagination
+
+  h3 横に流れ続けるスライダー
+  div.u-mbs.is-bottom
+    +c.gallery-text.js-text-loop.swiper
+      ul.swiper-wrapper
+        +loop(2)
+          li.swiper-slide: span TEXTGALLERY
+
+  div.u-mbs.is-bottom
+    +c.gallery-logo
+      .l-container
+        +h2.head.c-heading.is-md.is-center.is-mg-level-2 ロゴギャラリー
+
+      +e.slider.js-logo-slider.swiper
+        +e.images.swiper-wrapper
+          for num in [1,2]
+            - var img = "https://placehold.jp/3d4070/ffffff/300x80.png?text=" + num + ".png"
+            +e.image.swiper-slide: +img(img)
+
+      +e.slider.js-logo-slider.swiper
+        +e.images.swiper-wrapper
+          for num in [1,2,3,4,5,6]
+            - var img = "https://placehold.jp/3d4070/ffffff/300x80.png?text=" + num + ".png"
+            +e.image.swiper-slide: +img(img)
+
+h3 画面幅が狭いとき横スクロールする画像やテーブル
+
+div.u-mbs.is-bottom
+  .c-scrollable
+    // scroll-hint が .js-scrollableの親の要素に対して適用されるため
+    // c-scrollableと .js-scrollableを分けることを推奨
+    .js-scrollable
+      +img("img-sample.jpg")
+
+div.u-mbs.is-bottom
+  .c-scrollable
+    .js-scrollable
+      table.c-table
+        tbody
+          tr
+            th テスト
+            th テスト
+            th テスト
+            th テスト
+            th テスト
+          tr
+            td テスト
+            td テスト
+            td テスト
+            td テスト
+            td テスト

--- a/app/format/components/_other.pug
+++ b/app/format/components/_other.pug
@@ -1,20 +1,6 @@
 //アコーディオン
 div.u-mbs.is-bottom
   .l-container
-    <div class="l-footer__item   js-accordion js-slidebar" data-accordion-responsive="750">
-      <span><a class="l-footer__item-link" href="/service/" data-accordion-title="title">事業内容</a>
-      </span>
-      <div class="l-footer__unit" data-accordion-content="content">
-        <div class="l-footer__unit-item"><a class="l-footer__unit-link" href="/service/domestic-business-trip/">国内出張 手配</a>
-        </div>
-        <div class="l-footer__unit-item"><a class="l-footer__unit-link" href="/service/overseas-business-trip/">海外出張 手配</a>
-        </div>
-        <div class="l-footer__unit-item"><a class="l-footer__unit-link" href="/service/group-travel/">社員・団体旅行</a>
-        </div>
-        <div class="l-footer__unit-item"><a class="l-footer__unit-link" href="/topics/category-02/">個人向け旅行 手配</a>
-        </div>
-      </div>
-    </div>
     +accordion-list([
       {
         title: "見出しタイトルテキスト　テキストテキストテキストテキストテキスト",

--- a/app/inc/foundation/_base.pug
+++ b/app/inc/foundation/_base.pug
@@ -17,4 +17,3 @@ block layout
   //- フッター
   block footer
     include /inc/layout/_footer.pug
-


### PR DESCRIPTION
改善事項DBより
https://www.notion.so/growgroup/_-DB-f9d56812e4754b0ba5070a7e3d34fce1?p=185eef14914a80878928c18306c2d8ac&pm=s

detailsかそれ以外で判定し可能にしました。

---

## メモ
PCではリンク、スマホではアコーディオンにする構成のとき、
summaryの内部に a を置くのが若干変なので
（summaryは子にフレージングコンテンツを持てるので、フレージングコンテンツであるaは置けはするが）
従来のHTML構造に近い状態でも動作させられるように変更