### PR TITLE
base-twocolumnでl-offerがl-mainの中に入っていたのを外に出す

### DIFF
--- a/app/inc/foundation/_base-twocolumn.pug
+++ b/app/inc/foundation/_base-twocolumn.pug
@@ -18,8 +18,8 @@ block layout
         aside.l-two-column__side
           .l-aside
             block aside
-      +l_offer
-      //block under_main
+    +l_offer
+    //block under_main
 
   //- フッター
   block footer


### PR DESCRIPTION
https://www.notion.so/growgroup/base-twocolumn-l-offer-l-main-1bbeef14914a80c7a0cbcc9e992b7028

2カラムレイアウトのときだけ、l-mainのなかにl-offerが入ってしまっていたのを
1カラムのときと同じ位置に修正。

以下の状態に修正

```
main
  <略>
  .l-main
    .l-two-column
        <略>
  .l-offer
```