### PR TITLE
[update]modal要素をaタグとbuttonタグで動くようにしました

### DIFF
--- a/app/assets/js/app/wrapperClasses/micromodalWrapper.js
+++ b/app/assets/js/app/wrapperClasses/micromodalWrapper.js
@@ -135,7 +135,9 @@ export default class MicromodalWrapper {
    */
   setupModalTrigger(trigger) {
     const type = trigger.dataset.modalType;
-    const href = trigger.getAttribute("href");
+    // hrefかdata-modal-srcを参照
+    const href = trigger.getAttribute("href") || trigger.dataset.modalSrc;
+    
     if (!href) {
       // href 属性が無い場合は警告を出力して終了
       console.warn(`Modal trigger element has no href attribute:`, trigger);

--- a/app/format/components/_modal.pug
+++ b/app/format/components/_modal.pug
@@ -1,6 +1,11 @@
 h3 画像モーダル
 +a("https://placehold.jp/300x250.png").c-modal-link.js-modal(data-modal-type="image")
   img(src='https://placehold.jp/300x250.png' alt='画像1')
+
+h3 画像モーダル（Buttonタグ）
+button.c-modal-link.js-modal(data-modal-type="image" , data-modal-src="https://placehold.jp/300x250.png")
+  img(src='https://placehold.jp/300x250.png' alt='画像1')
+
 h3 画像モーダル：グループ化
 +a("https://placehold.jp/300x250.png").c-modal-link.js-modal(data-modal-type="gallery" data-modal-group="group1")
   img(src='https://placehold.jp/300x250.png' alt='画像1')
@@ -37,5 +42,3 @@ h3 その他のコンテンツモーダル
     br
     |     ここに任意のHTMLコンテンツを配置できます。
     |     ここに任意のHTMLコンテンツを配置できますここに任意のHTMLコンテンツを配置できます。
-
-


### PR DESCRIPTION
https://www.notion.so/growgroup/gg-styleguide-modal-button-1cfeef14914a807ca19cc147d8ae9355

## aタグ（従来）
```
+a("https://placehold.jp/300x250.png").c-modal-link.js-modal(data-modal-type="image")
  img(src='https://placehold.jp/300x250.png' alt='画像1')
```

## buttonタグ（今回追加）
```
button.c-modal-link.js-modal(data-modal-type="image" , data-modal-src="https://placehold.jp/300x250.png")
  img(src='https://placehold.jp/300x250.png' alt='画像1')
```