### PR TITLE
Update GSAP 3.12 -> 3.13

### DIFF
--- a/app/assets/js/app/gsap.js
+++ b/app/assets/js/app/gsap.js
@@ -1,7 +1,13 @@
 // import Lottie from 'lottie-web';
 import {gsap} from "gsap";
 import {ScrollTrigger} from 'gsap/ScrollTrigger'
+// import {GSDevTools} from "gsap/GSDevTools";
+// import {MorphSVGPlugin} from "gsap/MorphSVGPlugin";
+
 gsap.registerPlugin(ScrollTrigger);
+// gsap.registerPlugin(GSDevTools);
+// gsap.registerPlugin(MorphSVGPlugin);
+
 import Utils from './utils.js';
 
 const utils = new Utils();

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "@fontsource/material-icons-sharp": "^5.1.0",
         "@fontsource/material-icons-two-tone": "^5.1.0",
         "@fontsource/noto-sans-jp": "^5.1.0",
-        "gsap": "^3.12.5",
+        "gsap": "^3.13.0",
         "imagesloaded": "^5.0.0",
         "lenis": "^1.1.18",
         "lottie-web": "^5.12.2",
@@ -6160,9 +6160,9 @@
       "dev": true
     },
     "node_modules/gsap": {
-      "version": "3.12.5",
-      "resolved": "https://registry.npmjs.org/gsap/-/gsap-3.12.5.tgz",
-      "integrity": "sha512-srBfnk4n+Oe/ZnMIOXt3gT605BX9x5+rh/prT2F1SsNJsU1XuMiP0E2aptW481OnonOGACZWBqseH5Z7csHxhQ=="
+      "version": "3.13.0",
+      "resolved": "https://registry.npmjs.org/gsap/-/gsap-3.13.0.tgz",
+      "integrity": "sha512-QL7MJ2WMjm1PHWsoFrAQH/J8wUeqZvMtHO58qdekHpCfhvhSL4gSiz6vJf5EeMP0LOn3ZCprL2ki/gjED8ghVw=="
     },
     "node_modules/hard-rejection": {
       "version": "2.1.0",

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "@fontsource/material-icons-sharp": "^5.1.0",
     "@fontsource/material-icons-two-tone": "^5.1.0",
     "@fontsource/noto-sans-jp": "^5.1.0",
-    "gsap": "^3.12.5",
+    "gsap": "^3.13.0",
     "imagesloaded": "^5.0.0",
     "lenis": "^1.1.18",
     "lottie-web": "^5.12.2",


### PR DESCRIPTION
https://www.notion.so/growgroup/GSAP-3-12-3-13-MorphSVG-1eceef14914a80ab9127eec13bfe151b

# 対応内容
- GSAPのバージョンを 3.12 から 3.13に上げる
- `MorphSVGPlugin` などのimportの例を gsap.js に追加（コメントアウト状態）

# 出来ることの例
https://codepen.io/miral_kashiwagi/pen/oggdWGe

# 参考
https://gsap.com/blog/3-13/