### PR TITLE
[update] c-breadcrumb : line-clamp -> text-overflow :elipsis

### DIFF
--- a/app/assets/scss/object/components/breadcrumb.scss
+++ b/app/assets/scss/object/components/breadcrumb.scss
@@ -12,7 +12,9 @@
     line-height: 1.5;
 
     @include breakpoint(small only) {
-      @include line-clamp(1);
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
     }
 
     span {


### PR DESCRIPTION
https://www.notion.so/growgroup/line-clamp-text-overflow-ellipsis-1f3eef14914a809385fdc9071bac2594

# 内容
https://github.com/growgroup/gg-styleguide/commit/9e4c479c7b26ef3f770e429a368767bfaf0429c9 の修正のロールバック。


iOS18.4とiOS18.5で、https://github.com/growgroup/gg-styleguide/commit/bd028cf5c7d2dfdea96d95c562121b1f0e2371c2 の修正と組み合わせたときに以下の問題が発生していたため。

https://github.com/growgroup/gg-styleguide/commit/bd028cf5c7d2dfdea96d95c562121b1f0e2371c2 の方はiOS17以降でのリンクがタップできない問題の対応で現時点では戻せないので、いったん https://github.com/growgroup/gg-styleguide/commit/9e4c479c7b26ef3f770e429a368767bfaf0429c9 の修正のロールバックで対応

## 発生していた問題
![CleanShot 2025-05-12 at 12 12 43@2x](https://github.com/user-attachments/assets/f575a868-4aa3-4ebb-b452-34ce98928b36)
