### PR TITLE
postcss-var-pxtorem

### DIFF
--- a/config/postcss-var-pxtorem.js
+++ b/config/postcss-var-pxtorem.js
@@ -1,0 +1,208 @@
+/**
+ * PostCSS Plugin: CSS変数のvar()内のフォールバック値のpxをremに変換
+ *
+ * 例: var(--size, 16px) → var(--size, 1rem)
+ */
+
+const postcss = require('postcss');
+
+const DEFAULT_OPTIONS = {
+  rootValue: 16,
+  unitPrecision: 5,
+  minPixelValue: 0,
+  // 変換から除外するプロパティのパターン
+  exclude: [],
+};
+
+/**
+ * @name toFixed
+ * @description 指定された桁数で数値を丸める
+ * @param {number} number - 丸める対象の数値
+ * @param {number} precision - 小数点以下の桁数
+ * @returns {number} 丸められた数値
+ */
+function toFixed(number, precision) {
+  const multiplier = Math.pow(10, precision + 1);
+  const wholeNumber = Math.floor(number * multiplier);
+  return Math.round(wholeNumber / 10) * 10 / multiplier;
+}
+
+/**
+ * @name convertPxToRem
+ * @description 文字列内のpx値をrem値に変換する
+ * @param {string} value - 変換対象のCSS値
+ * @param {number} rootValue - ルート要素のフォントサイズ（px）
+ * @param {number} unitPrecision - remの小数点以下の桁数
+ * @param {number} minPixelValue - 変換対象とする最小のpx値
+ * @returns {string} 変換後のCSS値
+ */
+function convertPxToRem(value, rootValue, unitPrecision, minPixelValue) {
+  // px値の正規表現（var()内のフォールバック値用）
+  const pxRegex = /(\d*\.?\d+)px/g;
+
+  return value.replace(pxRegex, (match, numValue) => {
+    const pixels = parseFloat(numValue);
+
+    // px値が設定された最小値より小さいかどうかを確認
+    if (pixels < minPixelValue) {
+      return match;
+    }
+
+    const remValue = pixels / rootValue;
+    const fixedRemValue = toFixed(remValue, unitPrecision);
+
+    return `${fixedRemValue}rem`;
+  });
+}
+
+/**
+ * @name processVarFunction
+ * @description CSSのvar()関数を処理し、フォールバック値のpxをremに変換する
+ * @param {string} value - 処理対象のCSSプロパティ値
+ * @param {object} options - プラグインのオプション
+ * @returns {string} 処理後のCSSプロパティ値
+ */
+function processVarFunction(value, options) {
+  // 以前の正規表現ベースのアプローチでは、フォールバック値内のネストされた括弧（例: calc()）で問題がありました。
+  // この新しい実装では、var()関数を手動で解析して、より堅牢性を高めています。
+  const varKeyword = 'var(';
+  let result = '';
+  let lastIndex = 0;
+  let currentIndex = value.indexOf(varKeyword);
+
+  // 文字列内に 'var(' が見つかった場合、ループを開始
+  while (currentIndex !== -1) {
+    result += value.substring(lastIndex, currentIndex);
+
+    const startIndex = currentIndex + varKeyword.length;
+    let balance = 1;
+    let endIndex = startIndex;
+
+    // 対応する閉じ括弧を見つける
+    // カッコのバランスが0になるまでループ
+    while (endIndex < value.length && balance > 0) {
+      // 開き括弧が見つかった場合
+      if (value[endIndex] === '(') {
+        balance++;
+      // 閉じ括弧が見つかった場合
+      } else if (value[endIndex] === ')') {
+        balance--;
+      }
+      endIndex++;
+    }
+
+    // カッコのバランスが正常に0になった（対応する閉じ括弧が見つかった）場合
+    if (balance === 0) {
+      const varContent = value.substring(startIndex, endIndex - 1);
+      // フォールバック値があるかどうかを最初のカンマで判断
+      const separatorIndex = varContent.indexOf(',');
+
+      // フォールバック値が存在するかどうかを確認
+      if (separatorIndex !== -1) {
+        const varName = varContent.substring(0, separatorIndex).trim();
+        const fallbackValue = varContent.substring(separatorIndex + 1).trim();
+
+        // フォールバック値に'px'が含まれているかどうかを確認
+        if (fallbackValue.includes('px')) {
+          const convertedFallback = convertPxToRem(
+            fallbackValue,
+            options.rootValue,
+            options.unitPrecision,
+            options.minPixelValue,
+          );
+          result += `var(${varName}, ${convertedFallback})`;
+        } else {
+          // pxが含まれていなければ、変換せずにそのまま追加
+          result += `var(${varName}, ${fallbackValue})`;
+        }
+      } else {
+        // フォールバック値がなければ、変数名のみでvar()を再構築
+        result += `var(${varContent.trim()})`;
+      }
+      lastIndex = endIndex;
+    } else {
+      // var()関数が正しく閉じられていない場合、残りの文字列を追加して処理を終了
+      result += value.substring(currentIndex);
+      lastIndex = value.length;
+      break;
+    }
+
+    // 次の 'var(' を探す
+    currentIndex = value.indexOf(varKeyword, lastIndex);
+  }
+
+  result += value.substring(lastIndex);
+  return result;
+}
+
+/**
+ * @name shouldExcludeProperty
+ * @description 指定されたCSSプロパティが除外対象かどうかを判定する
+ * @param {string} prop - CSSプロパティ名
+ * @param {(string|RegExp)[]} excludePatterns - 除外パターンの配列
+ * @returns {boolean} 除外対象の場合はtrue
+ */
+function shouldExcludeProperty(prop, excludePatterns) {
+  // 除外パターンが指定されていない、または空の配列であるかを確認
+  if (!excludePatterns || excludePatterns.length === 0) {
+    return false;
+  }
+
+  return excludePatterns.some(pattern => {
+    // パターンが文字列型であるかを確認
+    if (typeof pattern === 'string') {
+      // パターンにワイルドカード（*）が含まれているかどうかを確認
+      if (pattern.includes('*')) {
+        // ワイルドカードを正規表現の.*に変換してマッチング
+        const regexPattern = pattern
+          .replace(/[.*+?^${}()|[\]\\]/g, '\\$&') // 特殊文字をエスケープ
+          .replace(/\\\*/g, '.*'); // \* を .* に変換
+        const regex = new RegExp(`^${regexPattern}$`);
+        return regex.test(prop);
+      } else {
+        // ワイルドカードがなければ、単純な文字列包含でチェック
+        return prop.includes(pattern);
+      }
+    }
+    // パターンが正規表現オブジェクトであるかを確認
+    if (pattern instanceof RegExp) {
+      return pattern.test(prop);
+    }
+    return false;
+  });
+}
+
+/**
+ * @name plugin
+ * @description PostCSSプラグインの本体
+ * @param {object} options - プラグインのオプション
+ * @returns {object} PostCSSプラグインオブジェクト
+ */
+const plugin = (options = {}) => {
+  const opts = { ...DEFAULT_OPTIONS, ...options };
+
+  return {
+    postcssPlugin: 'postcss-var-pxtorem',
+    Declaration(decl) {
+      // 現在のプロパティが除外対象リストに含まれているかを確認
+      if (shouldExcludeProperty(decl.prop, opts.exclude)) {
+        return;
+      }
+
+      // プロパティ値に 'var(' が含まれているかを確認
+      if (decl.value.includes('var(')) {
+        const originalValue = decl.value;
+        const convertedValue = processVarFunction(decl.value, opts);
+
+        // pxtoremによる変換が行われたかどうかを確認
+        if (originalValue !== convertedValue) {
+          decl.value = convertedValue;
+        }
+      }
+    }
+  };
+};
+
+plugin.postcss = true;
+
+module.exports = plugin;

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -4,6 +4,11 @@ module.exports = (ctx) => ({
       propList: ["*", "!border*", "!box-shadow*"],
       selectorBlackList: [/^html$/], //html要素は除外
     },
+    // postcss-pxtoremが対応していないCSS変数のvar()内のフォールバック値のpx→rem変換
+    [require.resolve('./config/postcss-var-pxtorem')]: {
+      rootValue: 16,
+      exclude: ['border*', 'box-shadow*']
+    },
     autoprefixer: {},
     "postcss-prefix-selector":
       ctx.file.basename === "admin-style.css"


### PR DESCRIPTION
https://www.notion.so/growgroup/postcss-pxtorem-var-px-rem-206eef14914a806cab93d9bf5bface92
SCSS側でフォールバック値付きでvar()関数を使うとフォールバック値のpxがrem変換されないため
`postcss-var-pxtorem` を作成して、変換されるように調整しました。

## 起きていた問題
font-size: var(--_card-label-font-size, 13px); ← これが変換されない

---

# postcss-var-pxtorem
CSS変数の `var()` 内のフォールバック値のpx単位をrem単位に変換するPostCSSプラグイン

## 概要
標準の `postcss-pxtorem` プラグインでは、CSS変数のフォールバック値（例：`var(--size, 16px)` の `16px` 部分）は変換されません。このプラグインは、そのような場合にも対応してpx単位をrem単位に変換します。

## インストールと設定

### postcss.config.js での設定
https://github.com/growgroup/gg-styleguide/blob/4db0e19a302b8c886474c3c19b9c7dcece59ec48/postcss.config.js#L7-L11

## オプション

| オプション | 型 | デフォルト | 説明 |
|----------|---|-----------|------|
| `rootValue` | number | 16 | ルート要素のフォントサイズ（px）。変換の基準値 |
| `unitPrecision` | number | 5 | rem値の小数点以下の桁数 |
| `minPixelValue` | number | 0 | 変換する最小のpx値。この値未満は変換されない |
| `exclude` | Array<string\|RegExp> | [] | 変換から除外するプロパティ名のパターン |

## 特徴

### ✅ 対応する機能
- CSS変数のフォールバック値のpx→rem変換
- 複数のvar()を含む値の処理
- calc()との組み合わせ
- 小数点を含むpx値の変換
- 複雑なCSS値内のvar()の処理
- スペースを含むvar()構文の処理

### ❌ 変換されないもの
- フォールバック値にpxが含まれていない場合
- 大文字のPXやPx（意図的に変換を避けたい場合）
- `:root` 内のCSS変数の値（通常のpostcss-pxtoremが担当）