### PR TITLE
[update] l-header : remove reset A style

### DIFF
--- a/app/assets/scss/layout/header.scss
+++ b/app/assets/scss/layout/header.scss
@@ -18,11 +18,6 @@ category: Layout
     position: fixed;
   }
 
-  a {
-    color: inherit;
-    text-decoration: none;
-  }
-
   &__content {
     max-width: 2560px;
     margin: 0 auto;


### PR DESCRIPTION
https://www.notion.so/growgroup/l-header-210eef14914a80f5bf10dc45b5d1e7eb

---

https://github.com/growgroup/gg-styleguide/pull/205 の結果不要になった l-header の aタグスタイルリセットの記述を除去しました。