### PR TITLE
[edit]dropdown.js isReady = trueのタイミングをDOMContentLoadedに変更

### DIFF
--- a/app/assets/js/app/dropdown.js
+++ b/app/assets/js/app/dropdown.js
@@ -31,7 +31,7 @@ export default class Dropdown {
     this.options = Object.assign({}, defaultOptions, options);
     this.isReady = false;
     // ページロード完了後にisReadyをtrueにする
-    window.addEventListener('load', () => {
+    window.addEventListener('DOMContentLoaded', () => {
       this.isReady = true;
     });
     this.init();


### PR DESCRIPTION
ページが重いとサブメニューがなかなか開かない動作になるため発火タイミングをloadからDOMContentLoadedに変更。

▼詳細
c-news-headerのsupをflexのgap実装に変更
https://www.notion.so/growgroup/dropdown-js-isReady-21ceef14914a80938fabf15af6faf824?source=copy_link