### PR TITLE
[edit]news-header marginからgapに変更

### DIFF
--- a/app/assets/scss/object/components/news-header.scss
+++ b/app/assets/scss/object/components/news-header.scss
@@ -27,6 +27,10 @@ category: PostContent
     display: flex;
     align-items: center;
     flex-wrap: wrap;
+    gap: 8px 24px;
+    @include breakpoint(small down) {
+      gap: 8px 16px;
+    }
   }
 
   &__label {
@@ -35,16 +39,10 @@ category: PostContent
 
   &__date {
     @include news-date();
-    margin: 0 24px;
-
-    @include breakpoint(small only) {
-      margin: 0 16px;
-    }
   }
 
   &__tag {
     @include breakpoint(small only) {
-      margin-top: 8px;
       width: 100%;
     }
 
@@ -52,9 +50,9 @@ category: PostContent
       display: flex;
       flex-wrap: wrap;
       align-items: center;
+      gap: 8px 16px;
 
       li {
-        margin-right: 16px;
 
         a {
           text-decoration: none;


### PR DESCRIPTION
news-headerがmarginで実装されており、ラベル、日付等を並び替えた時に毎回調整が必要だったためgapでの実装に変更。
特に見た目上の変更はありません。

▼詳細
c-news-headerのsupをflexのgap実装に変更
https://www.notion.so/growgroup/c-news-header-sup-flex-gap-21feef14914a80398ee0d461bce5b6ef?source=copy_link