### PR TITLE
[edit]card-post

### DIFF
--- a/app/archive-twocolumns/category/index.pug
+++ b/app/archive-twocolumns/category/index.pug
@@ -88,17 +88,15 @@ block body
       +c_pagination("is-align-left")
 
       +c.card-post.is-tag-hidden.u-mbs.is-top.is-lg
-        .row
-          +loop(4)
-            .large-3.small-6
-              +e.block
-                +a.c-card-post__image
-                  +img("img-card-01.jpg")
-                +e.content
-                  +e.sup
-                    span.c-card-post__label.c-label カテゴリ名
-                    +e.date 2018.01.01
-                  +e.title タイトルが入ります。タイトルが入ります。
+        +loop(4)
+          +e.block
+            +a.c-card-post__image
+              +img("img-card-01.jpg")
+            +e.content
+              +e.sup
+                span.c-card-post__label.c-label カテゴリ名
+                +e.date 2018.01.01
+              +e.title タイトルが入ります。タイトルが入ります。
       +c_pagination()
 
 block aside

--- a/app/archive-twocolumns/category/page/index.pug
+++ b/app/archive-twocolumns/category/page/index.pug
@@ -164,34 +164,16 @@ block body
             +e.excerpt 本文内容の一文が抜粋されてここに掲載を行います。本文内容の一文が抜粋されてここに掲載を行います。本文内容の一文が抜粋されてここに掲載を行います。本…[続きを見る]
       div.u-mbs.is-top.is-lg
         +c.card-post.is-tag-hidden
-          .row
-            .large-4.small-6
-              +e.block
-                +a.c-card-post__image
-                  +img("img-card-01.jpg")
-                +e.content
-                  +e.sup
-                    +e.date 2018.01.01
-                    span.c-card-post__label.c-label.is-sm カテゴリ名
-                  +e.title タイトルが入ります。タイトルが入ります。
-            .large-4.small-6
-              +e.block
-                +a.c-card-post__image
-                  +img("img-card-01.jpg")
-                +e.content
-                  +e.sup
-                    +e.date 2018.01.01
-                    span.c-card-post__label.c-label.is-sm カテゴリ名
-                  +e.title タイトルが入ります。タイトルが入ります。
-            .large-4.small-6
-              +e.block
-                +a.c-card-post__image
-                  +img("img-card-01.jpg")
-                +e.content
-                  +e.sup
-                    +e.date 2018.01.01
-                    span.c-card-post__label.c-label.is-sm カテゴリ名
-                  +e.title タイトルが入ります。タイトルが入ります。
+          +loop(3)
+            +e.block
+              +a.c-card-post__image
+                +img("img-card-01.jpg")
+              +e.content
+                +e.sup
+                  +e.date 2018.01.01
+                  span.c-card-post__label.c-label.is-sm カテゴリ名
+                +e.title タイトルが入ります。タイトルが入ります。
+
 
 block aside
   +l-aside-posts()

--- a/app/archive-twocolumns/index.pug
+++ b/app/archive-twocolumns/index.pug
@@ -86,17 +86,15 @@ block body
       +c_pagination("is-align-left")
 
       +c.card-post.is-tag-hidden.u-mbs.is-top.is-lg
-        .row
-          +loop(4)
-            .large-3.small-6
-              +e.block
-                +a.c-card-post__image
-                  +img("img-card-01.jpg")
-                +e.content
-                  +e.sup
-                    span.c-card-post__label.c-label カテゴリ名
-                    +e.date 2018.01.01
-                  +e.title タイトルが入ります。タイトルが入ります。
+        +loop(4)
+          +e.block
+            +a.c-card-post__image
+              +img("img-card-01.jpg")
+            +e.content
+              +e.sup
+                span.c-card-post__label.c-label カテゴリ名
+                +e.date 2018.01.01
+              +e.title タイトルが入ります。タイトルが入ります。
       +c_pagination()
 
 block aside

--- a/app/assets/scss/object/components/card-post.scss
+++ b/app/assets/scss/object/components/card-post.scss
@@ -5,6 +5,11 @@ category: News
 ---
 */
 .c-card-post {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+  gap: 8px;
+
+
   &__block {
     width: 100%;
     display: block;
@@ -48,6 +53,7 @@ category: News
     font-size: 18px;
     font-weight: 700;
     line-height: 1.6;
+    margin-top: 8px;
   }
 
   &__text {
@@ -63,6 +69,7 @@ category: News
     margin-top: 6px;
     display: flex;
     align-items: flex-start;
+    gap: 8px;
   }
 
   &__date {
@@ -105,7 +112,6 @@ category: News
       position: relative;
       display: flex;
       align-items: center;
-      margin-bottom: 8px;
     }
 
     .c-card-post__label {
@@ -114,7 +120,6 @@ category: News
 
     .c-card-post__date {
       margin-right: 0;
-      margin-left: 18px;
     }
 
     .c-card-post__title {

--- a/app/news/category/page/index.pug
+++ b/app/news/category/page/index.pug
@@ -164,34 +164,15 @@ block body
             +e.excerpt 本文内容の一文が抜粋されてここに掲載を行います。本文内容の一文が抜粋されてここに掲載を行います。本文内容の一文が抜粋されてここに掲載を行います。本…[続きを見る]
       div.u-mbs.is-top.is-lg
         +c.card-post.is-tag-hidden
-          .row
-            .large-4.small-6
-              +e.block
-                +a.c-card-post__image
-                  +img("img-card-01.jpg")
-                +e.content
-                  +e.sup
-                    span.c-card-post__label.c-label.is-sm カテゴリ名
-                    +e.date 2018.01.01
-                  +e.title タイトルが入ります。タイトルが入ります。
-            .large-4.small-6
-              +e.block
-                +a.c-card-post__image
-                  +img("img-card-01.jpg")
-                +e.content
-                  +e.sup
-                    span.c-card-post__label.c-label.is-sm カテゴリ名
-                    +e.date 2018.01.01
-                  +e.title タイトルが入ります。タイトルが入ります。
-            .large-4.small-6
-              +e.block
-                +a.c-card-post__image
-                  +img("img-card-01.jpg")
-                +e.content
-                  +e.sup
-                    span.c-card-post__label.c-label.is-sm カテゴリ名
-                    +e.date 2018.01.01
-                  +e.title タイトルが入ります。タイトルが入ります。
+          +loop(3)
+            +e.block
+              +a.c-card-post__image
+                +img("img-card-01.jpg")
+              +e.content
+                +e.sup
+                  span.c-card-post__label.c-label.is-sm カテゴリ名
+                  +e.date 2018.01.01
+                +e.title タイトルが入ります。タイトルが入ります。
 
 block under_main
   +l_offer

--- a/app/news/index.pug
+++ b/app/news/index.pug
@@ -83,17 +83,15 @@ block body
         +c_pagination("is-align-left")
 
         +c.card-post.is-tag-hidden.u-mbs.is-top.is-lg
-          .row
-            +loop(4)
-              .large-3.small-6
-                +e.block
-                  +a.c-card-post__image
-                    +img("img-card-01.jpg")
-                  +e.content
-                    +e.sup
-                      span.c-card-post__label.c-label カテゴリ名
-                      +e.date 2018.01.01
-                    +e.title タイトルが入ります。タイトルが入ります。
+          +loop(4)
+            +e.block
+              +a.c-card-post__image
+                +img("img-card-01.jpg")
+              +e.content
+                +e.sup
+                  span.c-card-post__label.c-label カテゴリ名
+                  +e.date 2018.01.01
+                +e.title タイトルが入ります。タイトルが入ります。
         +c_pagination()
 
 block under_main


### PR DESCRIPTION
news/category/page等で実装されていた
.c-card-post内の.row/.large-**/.small-**のクラスを使ったカラムレイアウトをdisplay: gridを使った実装に変更しました。

▼改善事項DB
https://www.notion.so/growgroup/c-card-post-display-grid-auto-fill-114eef14914a80e198a4fd58ee1bfbce?source=copy_link