### PR TITLE
[add]l-post-content内の見出し要素のマージンを優先させる

### DIFF
--- a/app/assets/scss/foundation/_mixin-post-content.scss
+++ b/app/assets/scss/foundation/_mixin-post-content.scss
@@ -14,6 +14,17 @@
     margin-top: 1em;
   }
 
+  > :is(h1, h2, h3, h4, h5, h6) {
+    // 最初の要素が見出しの場合
+    &:first-child {
+      margin-top: 0;
+    }
+    // 見出しの直後の要素にmargin-topを付けない（見出し側にmarginを設定するため）
+    & + * {
+      margin-top: 0;
+    }
+  }
+
   a{
     @include text-link();
   }


### PR DESCRIPTION
業務改善：l-post-content内の要素のmargin-topが見出しのmargin-bottomに勝ってしまう
https://www.notion.so/growgroup/l-post-content-margin-top-margin-bottom-23aeef14914a8015a9c4fde9cbe94a4b

