### PR TITLE
[update] slidebar.js : activateWidthが入っているときに環境によってはナビが開いてしまう問題の修正

### DIFF
--- a/app/assets/js/app/slidebar.js
+++ b/app/assets/js/app/slidebar.js
@@ -86,6 +86,10 @@ export default class Slidebar {
    */
   toggle() {
     if (this.isActive === false) {
+      if (this.options.activateWidth !== null &&
+          window.innerWidth >= this.options.activateWidth) {
+        return;
+      }
       this.open();
     } else {
       this.close();
@@ -152,7 +156,7 @@ export default class Slidebar {
   setupResizeObserver() {
     const resizeObserver = new ResizeObserver(entries => {
       for (const entry of entries) {
-        if (entry.contentRect.width > this.options.activateWidth) {
+        if (entry.contentRect.width >= this.options.activateWidth) {
           document.body.classList.remove("is-slidebar-active");
           this.isActive = false;
           this.menu.attr("inert", "inert");

--- a/app/assets/js/app/slidebar.js
+++ b/app/assets/js/app/slidebar.js
@@ -157,9 +157,7 @@ export default class Slidebar {
     const resizeObserver = new ResizeObserver(entries => {
       for (const entry of entries) {
         if (entry.contentRect.width >= this.options.activateWidth) {
-          document.body.classList.remove("is-slidebar-active");
-          this.isActive = false;
-          this.menu.attr("inert", "inert");
+          this.close();
         }
       }
     });


### PR DESCRIPTION
▼改善事項
https://www.notion.so/growgroup/slidebar-js-activateWidth-253eef14914a808d979eee3fefcc0b15

## 問題
PCサイズでもハンバーガーメニューボタンを利用するデザインで、activateWidthをnullにし忘れても、
一部の閲覧環境ではハンバーガーメニューが開いてしまう問題

## 対応
activateWidthが、開くイベントの発火するかどうかにも影響を与えるように変えました。


## 原因
ハンバーガーメニューボタンを押したとき、開閉イベントは発火していた。

リサイズオブザーバーも発火するので、開閉と同時に閉じるイベントが発火する方向性で作られていたが、
展開時に必ずリサイズオブザーバーが発火するわけではなかったため「普通に開く」環境が存在した。

### 備考
おそらくMacでスクロールバーを表示しない状態だと、
ハンバーガーメニューボタンを押したときにリサイズオブザーバーが発火していなかった、と予想される。
