### PR TITLE
[update]ニュース一覧のファイルアイコン調整

### DIFF
--- a/app/assets/scss/foundation/_settings.scss
+++ b/app/assets/scss/foundation/_settings.scss
@@ -48,6 +48,12 @@ $color-sns-facebook: #1877f2;
 $color-sns-twitter: #1DA1F2;
 $color-sns-youtube: #DA1725;
 
+// # ファイル種別
+$color-file-pdf: #FF0000;
+$color-file-excel: #217346;
+$color-file-word: #2B579A;
+$color-file-pptx: #D24726;
+
 // # hover opacity
 $base-hover-opacity: 0.5;
 

--- a/app/assets/scss/object/components/news.scss
+++ b/app/assets/scss/object/components/news.scss
@@ -116,7 +116,7 @@ category: News
     flex-shrink: 0;
     align-self: center;
     text-align: center;
-    width: 40px;
+    width: 48px;
 
     @include breakpoint(small only) {
       padding-top: 32px;
@@ -124,12 +124,36 @@ category: News
   }
 
   &__block-icon-file{
+    --news-file-icon-border-color: #{$border-base-color};
+    --news-file-icon-color: #{$font-base-color};
     display: block;
     padding: 1px 4px;
     font-size: 10px;
     text-align: center;
-    border: 1px solid $border-base-color;
+    border: 1px solid var(--news-file-icon-border-color);
     border-radius: 100px;
+    color: var(--news-file-icon-color);
+
+
+    &.is-pdf {
+      --news-file-icon-border-color: #{$color-file-pdf};
+      --news-file-icon-color: #{$color-file-pdf};
+    }
+
+    &.is-excel {
+      --news-file-icon-border-color: #{$color-file-excel};
+      --news-file-icon-color: #{$color-file-excel};
+    }
+
+    &.is-word {
+      --news-file-icon-border-color: #{$color-file-word};
+      --news-file-icon-color: #{$color-file-word};
+    }
+
+    &.is-pptx {
+      --news-file-icon-border-color: #{$color-file-pptx};
+      --news-file-icon-color: #{$color-file-pptx};
+    }
   }
 
 }

--- a/app/assets/scss/object/components/news.scss
+++ b/app/assets/scss/object/components/news.scss
@@ -116,7 +116,7 @@ category: News
     flex-shrink: 0;
     align-self: center;
     text-align: center;
-    width: 48px;
+    width: 40px;
 
     @include breakpoint(small only) {
       padding-top: 32px;

--- a/app/inc/mixins/_misc.pug
+++ b/app/inc/mixins/_misc.pug
@@ -112,9 +112,7 @@ mixin c_news__block(data)
       //-item.iconがあれば .c-icon-fontを追加、+span.block-label-file を追加
       if item.fileType
         +e.block-icon
-          - let fileClass = "is-" + item.fileType.toLowerCase()
-          // ファイル種別は pdf, excel, word, pptx のいずれか
-          +span.block-icon-file(class=fileClass) !{item.fileType}
+          +span.block-icon-file(class=item.fileClass) !{item.fileType}
       else if item.icon
         +e.block-icon
           span.c-icon-font !{item.icon}

--- a/app/inc/mixins/_misc.pug
+++ b/app/inc/mixins/_misc.pug
@@ -110,11 +110,14 @@ mixin c_news__block(data)
           if item.excerpt
             +e.block-excerpt !{item.excerpt}
       //-item.iconがあれば .c-icon-fontを追加、+span.block-label-file を追加
-      +e.block-icon
-        if item.icon
+      if item.fileType
+        +e.block-icon
+          - let fileClass = "is-" + item.fileType.toLowerCase()
+          // ファイル種別は pdf, excel, word, pptx のいずれか
+          +span.block-icon-file(class=fileClass) !{item.fileType}
+      else if item.icon
+        +e.block-icon
           span.c-icon-font !{item.icon}
-        else
-          +span.block-icon-file PDF
 
 mixin select-prefectures()
   select(name="都道府県")

--- a/app/news/index.pug
+++ b/app/news/index.pug
@@ -28,7 +28,7 @@ block body
                 +e.block-text-wrap
                   +e.block-text リンク無し記事のテストリンク無し記事のテストリンク無し記事のテストリンク無し記事のテストリンク無し記事のテストリンク無し記事のテストリンク無し記事のテストリンク無し記事のテスト
                   +e.block-excerpt リンク無し記事のテストリンク無し記事のテストリンク無し記事のテスト
-            +loop(3)
+            +loop(2)
               +c_news__block([
                 {
                   url: "/news/category/page/",
@@ -50,6 +50,28 @@ block body
                   date: "2022.01.01",
                   label: "カテゴリ",
                   title: "お知らせの投稿タイトルがここに入ります。お知らせの投稿タイトルがここに入ります。お知らせの投稿タイトルがここに入ります。",
+                  fileType: "PDF"
+                },
+                {
+                  url: "https://example.com/",
+                  date: "2022.01.01",
+                  label: "カテゴリ",
+                  title: "お知らせの投稿タイトルがここに入ります。お知らせの投稿タイトルがここに入ります。お知らせの投稿タイトルがここに入ります。",
+                  fileType: "Excel"
+                },
+                {
+                  url: "https://example.com/",
+                  date: "2022.01.01",
+                  label: "カテゴリ",
+                  title: "お知らせの投稿タイトルがここに入ります。お知らせの投稿タイトルがここに入ります。お知らせの投稿タイトルがここに入ります。",
+                  fileType: "Word"
+                },
+                {
+                  url: "https://example.com/",
+                  date: "2022.01.01",
+                  label: "カテゴリ",
+                  title: "お知らせの投稿タイトルがここに入ります。お知らせの投稿タイトルがここに入ります。お知らせの投稿タイトルがここに入ります。",
+                  fileType: "PPTX"
                 }
               ])
         +c_pagination()

--- a/app/news/index.pug
+++ b/app/news/index.pug
@@ -50,6 +50,7 @@ block body
                   date: "2022.01.01",
                   label: "カテゴリ",
                   title: "お知らせの投稿タイトルがここに入ります。お知らせの投稿タイトルがここに入ります。お知らせの投稿タイトルがここに入ります。",
+                  fileClass: "is-pdf",
                   fileType: "PDF"
                 },
                 {
@@ -57,6 +58,7 @@ block body
                   date: "2022.01.01",
                   label: "カテゴリ",
                   title: "お知らせの投稿タイトルがここに入ります。お知らせの投稿タイトルがここに入ります。お知らせの投稿タイトルがここに入ります。",
+                  fileClass: "is-excel",
                   fileType: "Excel"
                 },
                 {
@@ -64,6 +66,7 @@ block body
                   date: "2022.01.01",
                   label: "カテゴリ",
                   title: "お知らせの投稿タイトルがここに入ります。お知らせの投稿タイトルがここに入ります。お知らせの投稿タイトルがここに入ります。",
+                  fileClass: "is-word",
                   fileType: "Word"
                 },
                 {
@@ -71,6 +74,7 @@ block body
                   date: "2022.01.01",
                   label: "カテゴリ",
                   title: "お知らせの投稿タイトルがここに入ります。お知らせの投稿タイトルがここに入ります。お知らせの投稿タイトルがここに入ります。",
+                  fileClass: "is-pptx",
                   fileType: "PPTX"
                 }
               ])

--- a/package-lock.json
+++ b/package-lock.json
@@ -59,7 +59,7 @@
         "postcss-sort-media-queries": "^5.2.0",
         "pug": "^3.0.3",
         "rimraf": "^6.0.1",
-        "sass": "1.78.0",
+        "sass": "^1.78.0",
         "sass-loader": "^16.0.5",
         "style-loader": "^4.0.0",
         "stylelint": "^16.19.1",


### PR DESCRIPTION
# お知らせリンクのラベル調整
▼改善事項DB
https://www.notion.so/growgroup/23eeef14914a80d189eacb8210395aa3?source=copy_link

## 変更点
- .c-news__block-icon-fileにmodifierを設定。
- settings.scssにファイル別のカラー変数を設定。
- mixin c_news__blockのロジックを微調整

▼表示は/news/で確認できます。
<img width="977" height="419" alt="image" src="https://github.com/user-attachments/assets/ed7bd33a-7bd4-4b29-bc30-ecb18f670fdd" />
