### PR TITLE
[update]misc.pug, contact/index.pug 年月日、年齢のselectのmixin調整・強化

### DIFF
--- a/app/contact/index.pug
+++ b/app/contact/index.pug
@@ -283,6 +283,18 @@ block body
                     +e.input.is-sm
                       input(type="text", name="birth-day", placeholder="01")
                     +span.flex-al-unit 日
+            +e.block
+              +e.title
+                | 生年月日
+                span.c-forms__label 必須
+              +e.content
+                +select-birthday(1970, 2007)
+            +e.block
+              +e.title
+                | 年齢
+                span.c-forms__label 必須
+              +e.content
+                +select-ages(18, 50)
 
           +e.head --MW WP Form版保存用--
           //- ★MW WP Formの場合はname値を日本語にします

--- a/app/contact/index.pug
+++ b/app/contact/index.pug
@@ -288,13 +288,27 @@ block body
                 | 生年月日
                 span.c-forms__label 必須
               +e.content
-                +select-birthday(1970, 2007)
+                +e.flex-al
+                  +e.flex-al-label 西暦
+                  +e("label").flex-al
+                    +span.select.is-sm
+                      +select-nums("birth-year",1975,2007,"----")
+                    +span.flex-al-unit 年
+                  +e("label").flex-al
+                    +span.select.is-sm
+                      +select-nums("birth-month",1,12,"----")
+                    +span.flex-al-unit 月
+                  +e("label").flex-al
+                    +span.select.is-sm
+                      +select-nums("birth-day",1,31,"----")
+                    +span.flex-al-unit 日
             +e.block
               +e.title
                 | 年齢
                 span.c-forms__label 必須
               +e.content
-                +select-ages(18, 50)
+                +e.select.is-sm
+                  +select-nums("age",18,50,"年齢を選択","歳")
 
           +e.head --MW WP Form版保存用--
           //- ★MW WP Formの場合はname値を日本語にします

--- a/app/inc/mixins/_misc.pug
+++ b/app/inc/mixins/_misc.pug
@@ -167,110 +167,53 @@ mixin select-prefectures()
     <option value="鹿児島県">鹿児島県</option>
     <option value="沖縄県">沖縄県</option>
 
-mixin select-ages()
-  select(name="年齢")
+mixin select-ages(start, end)
+  select(name="age")
     option(disabled,selected) 選択してください
-    <option value="0">0</option>
-    <option value="1">1</option>
-    <option value="2">2</option>
-    <option value="3">3</option>
-    <option value="4">4</option>
-    <option value="5">5</option>
-    <option value="6">6</option>
-    <option value="7">7</option>
-    <option value="8">8</option>
-    <option value="9">9</option>
-    <option value="10">10</option>
-    <option value="11">11</option>
-    <option value="12">12</option>
-    <option value="13">13</option>
-    <option value="14">14</option>
-    <option value="15">15</option>
-    <option value="16">16</option>
-    <option value="17">17</option>
-    <option value="18">18</option>
-    <option value="19">19</option>
-    <option value="20">20</option>
-    <option value="21">21</option>
-    <option value="22">22</option>
-    <option value="23">23</option>
-    <option value="24">24</option>
-    <option value="25">25</option>
-    <option value="26">26</option>
-    <option value="27">27</option>
-    <option value="28">28</option>
-    <option value="29">29</option>
-    <option value="30">30</option>
-    <option value="31">31</option>
-    <option value="32">32</option>
-    <option value="33">33</option>
-    <option value="34">34</option>
-    <option value="35">35</option>
-    <option value="36">36</option>
-    <option value="37">37</option>
-    <option value="38">38</option>
-    <option value="39">39</option>
-    <option value="40">40</option>
-    <option value="41">41</option>
-    <option value="42">42</option>
-    <option value="43">43</option>
-    <option value="44">44</option>
-    <option value="45">45</option>
-    <option value="46">46</option>
-    <option value="47">47</option>
-    <option value="48">48</option>
-    <option value="49">49</option>
-    <option value="50">50</option>
-    <option value="51">51</option>
-    <option value="52">52</option>
-    <option value="53">53</option>
-    <option value="54">54</option>
-    <option value="55">55</option>
-    <option value="56">56</option>
-    <option value="57">57</option>
-    <option value="58">58</option>
-    <option value="59">59</option>
-    <option value="60">60</option>
-    <option value="61">61</option>
-    <option value="62">62</option>
-    <option value="63">63</option>
-    <option value="64">64</option>
-    <option value="65">65</option>
-    <option value="66">66</option>
-    <option value="67">67</option>
-    <option value="68">68</option>
-    <option value="69">69</option>
-    <option value="70">70</option>
-    <option value="71">71</option>
-    <option value="72">72</option>
-    <option value="73">73</option>
-    <option value="74">74</option>
-    <option value="75">75</option>
-    <option value="76">76</option>
-    <option value="77">77</option>
-    <option value="78">78</option>
-    <option value="79">79</option>
-    <option value="80">80</option>
-    <option value="81">81</option>
-    <option value="82">82</option>
-    <option value="83">83</option>
-    <option value="84">84</option>
-    <option value="85">85</option>
-    <option value="86">86</option>
-    <option value="87">87</option>
-    <option value="88">88</option>
-    <option value="89">89</option>
-    <option value="90">90</option>
-    <option value="91">91</option>
-    <option value="92">92</option>
-    <option value="93">93</option>
-    <option value="94">94</option>
-    <option value="95">95</option>
-    <option value="96">96</option>
-    <option value="97">97</option>
-    <option value="98">98</option>
-    <option value="99">99</option>
+    - for (let i = start; i <= end; i++)
+      <option value="#{i}">#{i}</option>
   |　歳
+
+
+mixin select-year(name="year", startYear=1975, endYear=2007)
+  select(name=name)
+    option(disabled,selected) ----
+    - for (let i = startYear; i <= endYear; i++)
+      <option value="#{i}">#{i}</option>
+
+
+//デフォルトは1月から12月
+mixin select-month(name="month", start=1, end=12)
+  select(name=name)
+    option(disabled,selected) ----
+    - for (let i = start; i <= end; i++)
+      <option value="#{i}">#{i}</option>
+
+//デフォルトは1日から31日
+mixin select-day(name="day", start=1, end=31)
+  select(name=name)
+    option(disabled,selected) ----
+    - for (let i = start; i <= end; i++)
+      <option value="#{i}">#{i}</option>
+
+
+mixin select-birthday(startYear, endYear)
+  +e.flex-al
+    +e.flex-al-label 西暦
+    +e("label").flex-al
+      +span.select.is-sm
+        +select-year("birth-year")
+      +span.flex-al-unit 年
+    +e("label").flex-al
+      +span.select.is-sm
+        +select-month("birth-month")
+      +span.flex-al-unit 月
+    +e("label").flex-al
+      +span.select.is-sm
+        +select-day("birth-day")
+      +span.flex-al-unit 日
+
+
 
 mixin c_cookie
   +c.block-cookie.js-cookie#cookie

--- a/app/inc/mixins/_misc.pug
+++ b/app/inc/mixins/_misc.pug
@@ -167,53 +167,11 @@ mixin select-prefectures()
     <option value="鹿児島県">鹿児島県</option>
     <option value="沖縄県">沖縄県</option>
 
-mixin select-ages(start, end)
-  select(name="age")
-    option(disabled,selected) 選択してください
-    - for (let i = start; i <= end; i++)
-      <option value="#{i}">#{i}</option>
-  |　歳
-
-
-mixin select-year(name="year", startYear=1975, endYear=2007)
+mixin select-nums(name="age", start=18, end=50,selected="選択してください", unit)
   select(name=name)
-    option(disabled,selected) ----
-    - for (let i = startYear; i <= endYear; i++)
-      <option value="#{i}">#{i}</option>
-
-
-//デフォルトは1月から12月
-mixin select-month(name="month", start=1, end=12)
-  select(name=name)
-    option(disabled,selected) ----
+    option(disabled,selected) !{selected}
     - for (let i = start; i <= end; i++)
-      <option value="#{i}">#{i}</option>
-
-//デフォルトは1日から31日
-mixin select-day(name="day", start=1, end=31)
-  select(name=name)
-    option(disabled,selected) ----
-    - for (let i = start; i <= end; i++)
-      <option value="#{i}">#{i}</option>
-
-
-mixin select-birthday(startYear, endYear)
-  +e.flex-al
-    +e.flex-al-label 西暦
-    +e("label").flex-al
-      +span.select.is-sm
-        +select-year("birth-year")
-      +span.flex-al-unit 年
-    +e("label").flex-al
-      +span.select.is-sm
-        +select-month("birth-month")
-      +span.flex-al-unit 月
-    +e("label").flex-al
-      +span.select.is-sm
-        +select-day("birth-day")
-      +span.flex-al-unit 日
-
-
+      <option value="#{i}">#{i}#{unit || ""}</option>
 
 mixin c_cookie
   +c.block-cookie.js-cookie#cookie

--- a/package-lock.json
+++ b/package-lock.json
@@ -59,7 +59,7 @@
         "postcss-sort-media-queries": "^5.2.0",
         "pug": "^3.0.3",
         "rimraf": "^6.0.1",
-        "sass": "1.78.0",
+        "sass": "^1.78.0",
         "sass-loader": "^16.0.5",
         "style-loader": "^4.0.0",
         "stylelint": "^16.19.1",


### PR DESCRIPTION
# mixin select-ages()等フォームの年月日、年齢周りのmixinの調整・強化

▼改善事項DB
https://www.notion.so/growgroup/mixin-select-ages-for-253eef14914a806bb7d5c4efb0fea2d2?v=3a1267a6dda7402eb247902fd1977c56&source=copy_link

## 変更内容
- select-agesをstart,endを指定できるようにして汎用的に。
- 生年月日のselect仕様を/contact/のフォーマットに追加。
- 年、月、日のselectを生成するmixinを追加。name属性も引数で指定可能。

```Pug misc.pug
mixin select-ages(start, end)
  select(name="age")
    option(disabled,selected) 選択してください
    - for (let i = start; i <= end; i++)
      <option value="#{i}">#{i}</option>
  |　歳


mixin select-year(name="year", startYear=1975, endYear=2007)
  select(name=name)
    option(disabled,selected) ----
    - for (let i = startYear; i <= endYear; i++)
      <option value="#{i}">#{i}</option>


//デフォルトは1月から12月
mixin select-month(name="month", start=1, end=12)
  select(name=name)
    option(disabled,selected) ----
    - for (let i = start; i <= end; i++)
      <option value="#{i}">#{i}</option>

//デフォルトは1日から31日
mixin select-day(name="day", start=1, end=31)
  select(name=name)
    option(disabled,selected) ----
    - for (let i = start; i <= end; i++)
      <option value="#{i}">#{i}</option>


mixin select-birthday(startYear, endYear)
  +e.flex-al
    +e.flex-al-label 西暦
    +e("label").flex-al
      +span.select.is-sm
        +select-year("birth-year")
      +span.flex-al-unit 年
    +e("label").flex-al
      +span.select.is-sm
        +select-month("birth-month")
      +span.flex-al-unit 月
    +e("label").flex-al
      +span.select.is-sm
        +select-day("birth-day")
      +span.flex-al-unit 日

```