### PR TITLE
.l-post-content>*+*が.l-post-content :where(figure)に負けてる

### DIFF
--- a/app/assets/scss/foundation/_mixin-post-content.scss
+++ b/app/assets/scss/foundation/_mixin-post-content.scss
@@ -160,7 +160,7 @@
   }
 
   // ブラウザのデフォルトスタイルをリセットし、WordPressと同様のスタイリングにする
-  :where(figure) {
+  :where(&) figure{
     margin: 0 0 1em
   }
 


### PR DESCRIPTION
▼改善事項
https://www.notion.so/growgroup/l-post-content-l-post-content-where-figure-253eef14914a80469df0caaa09600d58
## 起きていた問題
https://github.com/growgroup/gg-styleguide/pull/216 のあとから
`.l-post-content>*+*`が`.l-post-content :where(figure)`に負けていて、画像の上に余白がつかない

<img width="1754" height="598" alt="image" src="https://github.com/user-attachments/assets/e31155dd-df7f-4b8e-aa7a-6897b625f055" />

## 解決方法
https://github.com/growgroup/gg-styleguide/pull/216 はあくまでHTML時点のCSSのリセットの問題だったのでとりあえず
セレクタを `:where(.l-post-content) figure` に変更しました。

<img width="1272" height="594" alt="image" src="https://github.com/user-attachments/assets/25656081-cf6a-4f8d-9e1f-8a6b8bd73cbd" />
