### PR TITLE
行の高さを計算している部分をlh単位に置き換える

### DIFF
--- a/app/assets/scss/foundation/_mixin-post-content.scss
+++ b/app/assets/scss/foundation/_mixin-post-content.scss
@@ -263,10 +263,10 @@
 
       content: "";
       width: var(--_icon-size);
-      height: var(--_icon-size);
+      aspect-ratio: 1 / 1;
       background: $color-primary;
       border-radius: 50%;
-      top: calc(1em * #{$font-base-line-height} / 2 - var(--_icon-size) / 2);
+      top: calc(0.5lh - (var(--_icon-size) / 2));
       left: 0.25em;
       position: absolute;
 
@@ -282,10 +282,10 @@
 
       content: "";
       width: var(--_icon-size);
-      height: var(--_icon-size);
+      aspect-ratio: 1 / 1;
       background: $color-primary;
       border-radius: 50%;
-      top: calc(1em * #{$font-base-line-height} / 2 - var(--_icon-size) / 2);
+      top: calc(0.5lh - (var(--_icon-size) / 2));
       left: 0.5em;
       position: absolute;
     }
@@ -300,11 +300,10 @@
     padding-left: 16px;
 
     &::before {
-      //content: counters(list-counter, "-")".";//2-1のようなカウンター用
       content: counter(list-counter) ".";
       counter-increment: list-counter;
       width: 16px;
-      height: calc(1em * $font-base-line-height); //1行分の高さ（liのフォントサイズ * line-height）
+      height: 1lh;
     }
   }
 
@@ -320,7 +319,7 @@
         content: counter(list-counter) ".";
         counter-increment: list-counter;
         width: 16px;
-        height: calc(1em * $font-base-line-height); //1行分の高さ（liのフォントサイズ * line-height）
+        height: 1lh;
       }
     }
   }

--- a/app/assets/scss/object/components/aside-navs.scss
+++ b/app/assets/scss/object/components/aside-navs.scss
@@ -35,13 +35,13 @@
     position: relative;
     padding: 0 16px;
     &::before {
+      --_icon-size: #{8px};
       content: '';
       position: absolute;
-      top: calc(1em * $font-base-line-height / 2);
+      top: calc(0.5lh - (var(--_icon-size) / 2));
       left: 0;
-      transform: translateY(-50%);
-      width: 8px;
-      height: 8px;
+      width: var(--_icon-size);
+      aspect-ratio: 1 / 1;
       border-radius: 50%;
       background: $border-base-color;
     }

--- a/app/assets/scss/object/components/forms.scss
+++ b/app/assets/scss/object/components/forms.scss
@@ -403,12 +403,12 @@
     flex-shrink: 0;
     width: 32px;
     text-align: right;
-    padding-top:calc((#{44px} - 1em * $font-base-line-height)/2);// （inputの高さ - 行の高さ）÷ 2
+    padding-top:calc((#{44px} - 1lh)/2);// （inputの高さ - 行の高さ）÷ 2
   }
 
   &__flex-al-unit{
     flex-shrink: 0;
-    padding-top:calc((#{44px} - 1em * $font-base-line-height)/2);// （inputの高さ - 行の高さ）÷ 2
+    padding-top:calc((#{44px} - 1lh)/2);// （inputの高さ - 行の高さ）÷ 2
   }
 
   &__flexbox {
@@ -433,7 +433,7 @@
   &__flexbox-label {
     min-width: 120px;
     display: block;
-    padding-top:calc((#{44px} - 1em * $font-base-line-height)/2);// （inputの高さ - 行の高さ）÷ 2
+    padding-top:calc((#{44px} - 1lh)/2);// （inputの高さ - 行の高さ）÷ 2
 
     @include breakpoint(small only) {
       min-width: 100%;

--- a/app/assets/scss/object/components/list.scss
+++ b/app/assets/scss/object/components/list.scss
@@ -17,7 +17,7 @@ category: Base
 //
 //    &::before {
 //      width: 16px;
-//      height: calc(1em * $font-base-line-height); //1行分の高さ（1em * line-height = 1lh）
+//      height: 1lh;
 //      content: "・";
 //      color: $font-base-color;
 //    }

--- a/package-lock.json
+++ b/package-lock.json
@@ -59,7 +59,7 @@
         "postcss-sort-media-queries": "^5.2.0",
         "pug": "^3.0.3",
         "rimraf": "^6.0.1",
-        "sass": "1.78.0",
+        "sass": "^1.78.0",
         "sass-loader": "^16.0.5",
         "style-loader": "^4.0.0",
         "stylelint": "^16.19.1",

--- a/package.json
+++ b/package.json
@@ -95,8 +95,8 @@
   "browserslist": [
     "last 3 versions",
     "not dead",
-    "iOS >= 15",
-    "Safari >= 15"
+    "iOS >= 17",
+    "Safari >= 17"
   ],
   "repository": {
     "type": "git",


### PR DESCRIPTION
▼改善事項
https://www.notion.so/growgroup/lh-23eeef14914a8048956cdf9b4a5945f5

## 概要
`1em * $font-base-line-height` のように「1行の高さ」を計算していた部分を
`1lh` に置き換えました。

## 備考
aside-navsのデフォの装飾について、 topで調整しつつさらに transformでも位置を調整していたので、
topのみで調整する形に変更してあります。

## そのほか
iOS16.4からのCSSになるので、
あわせてautoprefixerの対象ブラウザ（browserlist）を `iOS17以下` の設定に変えました。
