### PR TITLE
比較演算子(Range syntax)の導入

### DIFF
--- a/app/assets/scss/foundation/_mixin.scss
+++ b/app/assets/scss/foundation/_mixin.scss
@@ -17,7 +17,7 @@
 }
 
 // 値をremに変換する関数
-@function to-rem($value, $base: $font-base-size) {
+@function to-rem($value, $base: $font-html-size) {
   // 値が数値でない場合の警告
   @if type-of($value) != 'number' {
     @warn inspect($value) + ' was passed to rem-calc(), which is not a number.';
@@ -270,15 +270,15 @@
   $dir: nth($result, 3);
 
   @if $dir == 'range' {
-    @container (min-width: #{$min}) and (max-width: #{$max}) {
+    @container (#{$min} < width <= #{$max}) {
       @content;
     }
   } @else if $dir == 'down' {
-    @container (max-width: #{$max}) {
+    @container (width <= #{$max}) {
       @content;
     }
   } @else if $dir == 'up' {
-    @container (min-width: #{$min}) {
+    @container (width > #{$min}) {
       @content;
     }
   }

--- a/app/assets/scss/foundation/_mixin.scss
+++ b/app/assets/scss/foundation/_mixin.scss
@@ -168,14 +168,14 @@
   }
 
 
-  // ブレイクポイント値をemに変換して微調整
+  // ブレイクポイント値をemに変換
   @if $bp {
-    $bp: to-em($bp) - math.div(1, 16);
+    $bp: to-em($bp);
   }
 
-  // ブレイクポイント最大値がある場合、emに変換して微調整
+  // ブレイクポイント最大値がある場合、emに変換
   @if $bp-max {
-    $bp-max: to-em($bp-max) - math.div(1, 16);
+    $bp-max: to-em($bp-max);
   }
 
   // dir が upで bpが0の場合、dirを''に設定
@@ -209,17 +209,15 @@
   } @else {
     // メディアクエリがある場合、条件付きで内容を出力
     @if $dir == 'only' {
-      @media screen and (max-width: #{$bp-max}) {
-        @media not screen and (max-width: #{$bp}) {
-          @content;
-        }
+      @media screen and (#{$bp} <= width < #{$bp-max}) {
+        @content;
       }
     } @else if $dir == 'down' {
-      @media screen and (max-width: #{$bp-max}) {
+      @media screen and (width < #{$bp-max}) {
         @content;
       }
     } @else if $dir == 'up' {
-      @media not screen and (max-width: #{$bp}) {
+      @media screen and (width >= #{$bp}) {
         @content;
       }
     }


### PR DESCRIPTION
▼改善事項
https://www.notion.so/growgroup/range-syntax-23eeef14914a804ab589f59d3b8419da

# 概要
### Range syntaxの導入
以下のmixinを使用したとき、Range syntaxで出力するように変更しました。
- `@include breakepoint(small down)` のようなメディアクエリ
- `@include container(800 down)` のようなコンテナクエリ

Range syntax についての参考： https://zenn.dev/tonkotsuboy_com/articles/css-range-syntax

###  その他
`@include container(800 down)`のときrem変換で参照している値を修正しました。


# 詳細
mixinの使い方は変更ありません。出力されるCSSだけが変わります。

## 効果
とくに https://github.com/growgroup/gg-styleguide/pull/160 の修正時に冗長になっていた
以下のようなメディアクエリが1行でかけるようになります

### before
```
@media screen and (max-width: 71.1875em) {
    @media not screen and (max-width: 59.3125em) {
    }
}
```
### after
```
@media screen and (59.375em <= width < 71.25em){
}
```


## breakepoint(small down)の場合のbefore/after
厳密には749.5pxの時の挙動が変わっていますが、小数点以下の桁数が少なくて済むように調整しています

### before 「749px以下」
<img width="534" height="172" alt="image" src="https://github.com/user-attachments/assets/3c4c64b0-31a8-4730-a455-590b913ebefa" />

### after 「750px未満」
<img width="482" height="188" alt="image" src="https://github.com/user-attachments/assets/adb93e3c-2481-4ff8-9303-c1806688ce10" />


