### PR TITLE
[update]   setHrefValue : telとmailtoをURL変換対象から除外

### DIFF
--- a/app/inc/_settings.pug
+++ b/app/inc/_settings.pug
@@ -153,7 +153,7 @@
   setHrefValue = function (href) {//+a()用のhref属性判定＆設定
     if (href === undefined) {
       return undefined;
-    } else if (href.startsWith('http') || href.startsWith('#')) {
+    } else if (href.startsWith('http') || href.startsWith('#') || href.startsWith('mailto:') || href.startsWith('tel:')) {
       return href;
     } else {
       return config.rootpath + href;


### PR DESCRIPTION
▼改善事項
https://www.notion.so/growgroup/tel-mailto-253eef14914a809aae60e67efd08e770

## 起きていた問題
相対パスでの出力時（ `root: ".",` にしたとき）
以下のように記述していると

```
+c.hoge
  +ae("mailto:example@example.com").mail メール
  +ae("tel:000-0000-0000").tel 電話
```

それぞれ出力されるhtmlが
 `href="..mailto:example@example.com"` `href="..tel:000-0000-0000"` となってしまう問題


## 解決方法
`mailto:` と `tel:` ではじまるURLは
setHrefValueでconfig.rootpathを結合しないようにしました