### PR TITLE
[update] dropdown.js : hoverタイプかつaタグ以外のときのキーボード操作

### DIFF
--- a/app/assets/js/app/dropdown.js
+++ b/app/assets/js/app/dropdown.js
@@ -112,6 +112,20 @@ export default class Dropdown {
         this.dropdownOpen(wrapper, target, animationType);
       }
     });
+
+    //aタグ以外の場合はclickでも処理を実行する
+    trigger.addEventListener('click', (e) => {
+      if (e.target.tagName.toLowerCase() === 'a') {
+        return;
+      }
+      //開いて無ければ開く、開いていれば閉じる
+      if (wrapper.classList.contains(this.options.openClass)) {
+        this.dropdownClose(wrapper, target, animationType);
+      } else {
+        this.dropdownOpen(wrapper, target, animationType);
+      }
+    });
+
   }
 
   clickInit(wrapper, trigger, target, animationType) {


### PR DESCRIPTION
▼改善事項
https://www.notion.so/growgroup/dropdown-js-hover-269eef14914a807885d1f9247e09c022

## 起きていた問題
data-dropdown-trigger が `button` タグ かつ hoverで展開するタイプのとき
キーボード操作で展開できない

▼問題が起きていたHTMLの例

```
.c-lang-selector.js-dropdown.js-dropdown-text-sync(data-dropdown-animation="slide")
  button.c-lang-selector__trigger(type="button", data-dropdown-trigger="trigger") Language
  .c-lang-selector__content(data-dropdown-target="target")
```

## 変更したこと
hoverで展開するタイプの時も、aタグ以外の場合はclickで開閉処理を実行するように変更しました

```
    //aタグ以外の場合はclickでも処理を実行する
    trigger.addEventListener('click', (e) => {
      if (e.target.tagName.toLowerCase() === 'a') {
        return;
      }
      //開いて無ければ開く、開いていれば閉じる
      if (wrapper.classList.contains(this.options.openClass)) {
        this.dropdownClose(wrapper, target, animationType);
      } else {
        this.dropdownOpen(wrapper, target, animationType);
      }
    });
```

## 備考
以下、今後の検討した方がよさそうではありますが、開かないよりはマシなので
いったん現在の実装で行ければと思います

- キーボード操作だとナビゲーションからフォーカスが離れてもメニューが開きっぱなしになっているという問題がある
- clickで問題出るようなら、focusで展開するなどを検討してもいいかも？