### PR TITLE
フォームのデフォルトスタイル変更

### DIFF
--- a/app/assets/images/icon-form-file.svg
+++ b/app/assets/images/icon-form-file.svg
@@ -1,0 +1,3 @@
+<svg width="10" height="12" viewBox="0 0 10 12" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M0 11.3438V10H9.3125V11.3438H0ZM0 4.65625L4.65625 0L9.3125 4.65625H6.65625V8.65625H2.65625V4.65625H0Z" fill="black"/>
+</svg>

--- a/app/assets/images/icon-form-select.svg
+++ b/app/assets/images/icon-form-select.svg
@@ -1,0 +1,3 @@
+<svg width="9" height="6" viewBox="0 0 9 6" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M1.05469 0L4.5 3.44531L7.94531 0L9 1.05469L4.5 5.55469L0 1.05469L1.05469 0Z" fill="#222222"/>
+</svg>

--- a/app/assets/scss/foundation/_form-controls.scss
+++ b/app/assets/scss/foundation/_form-controls.scss
@@ -12,7 +12,6 @@ $form-controls-active-border-color: $color-primary;
 //input, textarea, selectの共通スタイル
 @mixin form-controls-common-style {
   font-size: $form-controls-font-size;
-  --letter-spacing: 0;
   color: $font-base-color;
   border: 1px solid $form-controls-border-color;
   background-color: $color-background;

--- a/app/assets/scss/foundation/_form-controls.scss
+++ b/app/assets/scss/foundation/_form-controls.scss
@@ -13,7 +13,6 @@ $form-controls-active-border-color: $color-primary;
 @mixin form-controls-common-style {
   font-size: $form-controls-font-size;
   --letter-spacing: 0;
-  line-height: 1.46666;
   color: $font-base-color;
   border: 1px solid $form-controls-border-color;
   background-color: $color-background;
@@ -69,15 +68,22 @@ textarea {
 input[type="file"] {
 
   &::file-selector-button {
+    background-image: url('../images/icon-form-file.svg');
+    background-repeat: no-repeat;
+    background-position: 18px center;
+    background-size: 10px 12px;
     background-color: $color-white;
     border-radius: 4px;
     border: 1px solid $font-base-color;
-    padding: 3px 16px 3px;
+    padding: 3px 16px 3px 40px;
     margin-right: 16px;
     color: $font-base-color;
-    line-height: 1.46666;
-
     appearance: none;
+
+    @include breakpoint(small only) {
+      padding: 3px 12px;
+      background: $color-white;
+    }
   }
 }
 
@@ -138,20 +144,13 @@ input[type="radio"] {
 // Styleguide 1.6.5
 select {
   display: block;
-  height: 57px;
-  padding: 10px 16px;
   text-transform: none;
   appearance: none;
-  background-image: url('data:image/svg+xml;utf8,<svg width="9" height="6" viewBox="0 0 9 6" fill="none" xmlns="http://www.w3.org/2000/svg"> <path d="M7.945 2.38419e-05L9 1.05402L4.5 5.55402L0 1.05402L1.055 -0.000976562L4.5 3.44502L7.945 2.38419e-05Z" fill="%23222222"/></svg>');
+  background-image: url('../images/icon-form-select.svg');
   background-repeat: no-repeat;
   background-position: calc(100% - 16px) center;
   background-size: 9px 5px;
-  @include form-controls-common-style();
-
-  @include breakpoint(small down) {
-    height: 44px;
-    padding: 9px 12px;
-  }
+  @include form-controls-input-style();
 }
 
 /*  プレイスホルダーの色変更 */

--- a/app/assets/scss/foundation/_form-controls.scss
+++ b/app/assets/scss/foundation/_form-controls.scss
@@ -147,9 +147,14 @@ select {
   appearance: none;
   background-image: url('../images/icon-form-select.svg');
   background-repeat: no-repeat;
-  background-position: calc(100% - 16px) center;
-  background-size: 9px 5px;
+  background-position: calc(100% - 26px) center;
+  background-size: 10px 6px;
   @include form-controls-input-style();
+
+  @include breakpoint(small down) {
+    background-position: calc(100% - 12px) center;
+    background-size: 9px 5px;
+  }
 }
 
 /*  プレイスホルダーの色変更 */

--- a/app/assets/scss/foundation/_form-controls.scss
+++ b/app/assets/scss/foundation/_form-controls.scss
@@ -3,9 +3,11 @@
 //============================
 // variables / mixins
 //============================
-$form-controls-font-size: 15px;
-$form-controls-border-color: #D8D8D8;
-$form-controls-active-border-color: #0097D8;
+$form-controls-font-size: 16px;
+$form-controls-border-color: $border-base-color;
+$form-controls-border-radius: 4px;
+$form-controls-active-border-color: $color-primary;
+//active-border-colorはプライマリーカラーがエラーと区別がつかないときは #0097D8
 
 //input, textarea, selectの共通スタイル
 @mixin form-controls-common-style {
@@ -14,7 +16,7 @@ $form-controls-active-border-color: #0097D8;
   line-height: 1.46666;
   color: $font-base-color;
   border: 1px solid $form-controls-border-color;
-  background-color: $color-white;
+  background-color: $color-background;
   width: 100%;
   box-shadow: none;
   @include transition-colors(0.2s,ease-in-out);
@@ -32,7 +34,7 @@ $form-controls-active-border-color: #0097D8;
 
 //input, textareaの共通スタイル
 @mixin form-controls-input-style {
-  padding: 10px 16px;
+  padding: 16px 24px;
   @include form-controls-common-style;
 
   @include breakpoint(small down) {
@@ -65,16 +67,14 @@ textarea {
 
 // ファイル選択
 input[type="file"] {
-  font-size: 12px;
 
   &::file-selector-button {
-    background-color: #F9F9F9;
-    background-image: linear-gradient(135deg, #FFF 0%, #FFF 80%, #EFEFEF 100%);
+    background-color: $color-white;
     border-radius: 4px;
-    border: 1px solid #bababa;
-    padding: 2px 16px 4px;
+    border: 1px solid $font-base-color;
+    padding: 3px 16px 3px;
     margin-right: 16px;
-    color: $color-black;
+    color: $font-base-color;
     line-height: 1.46666;
 
     appearance: none;
@@ -88,7 +88,7 @@ input[type="file"] {
 //
 // Styleguide 1.6.2
 textarea {
-  min-height: 140px;
+  min-height: 136px;
   display: block;
 }
 
@@ -100,8 +100,8 @@ textarea {
 // Styleguide 1.6.3
 
 input[type="checkbox"] {
-  width: 20px;
-  height: 20px;
+  width: 24px;
+  height: 24px;
   vertical-align: middle;
   accent-color: $color-primary;
   flex-shrink: 0;
@@ -116,8 +116,8 @@ input[type="checkbox"] {
 
 input[type="radio"] {
   border-radius: 50%;
-  width: 20px;
-  height: 20px;
+  width: 24px;
+  height: 24px;
   vertical-align: middle;
   accent-color: $color-primary;
   flex-shrink: 0;
@@ -138,7 +138,7 @@ input[type="radio"] {
 // Styleguide 1.6.5
 select {
   display: block;
-  height: 44px;
+  height: 57px;
   padding: 10px 16px;
   text-transform: none;
   appearance: none;
@@ -149,6 +149,7 @@ select {
   @include form-controls-common-style();
 
   @include breakpoint(small down) {
+    height: 44px;
     padding: 9px 12px;
   }
 }

--- a/app/assets/scss/foundation/_settings.scss
+++ b/app/assets/scss/foundation/_settings.scss
@@ -37,7 +37,8 @@ $color-border: #ccc !default;
 
 
 // # 役割別
-$color-state-danger: #cc2919 !default; // 危険
+$color-state-danger: #D03045 !default; // 危険
+$color-state-danger-fill: #FBEBED !default; // 危険
 $color-state-warning: #cc9e12 !default; // 警告
 $color-state-info: #378da3 !default; // お知らせ
 $color-state-success: #13a83a !default; // 成功

--- a/app/assets/scss/object/components/forms.scss
+++ b/app/assets/scss/object/components/forms.scss
@@ -247,7 +247,7 @@
     width: 100%;
 
     &.is-md {
-      width: 294px;
+      width: 240px;
     }
 
     &.is-sm {
@@ -351,10 +351,10 @@
     &.is-border {
       --_options-gap: 4px;
       label {
-        @include forms-input-common-style;
+        border-radius: 4px;
+        background-color: $color-background;
         padding: 12px 32px 12px 16px;
         border: 1px solid $border-base-color;
-        border-radius: $border-radius;
         height: 100%;
 
         @include breakpoint(small only) {
@@ -404,6 +404,8 @@
         }
 
         &[type='checkbox'] {
+          border-radius: 2px;
+
           &:checked {
             background: $color-primary;
             border-color: $color-primary;

--- a/app/assets/scss/object/components/forms.scss
+++ b/app/assets/scss/object/components/forms.scss
@@ -80,7 +80,7 @@
 
     //項目名と項目の横並び
     &:where(.is-horizontal) {
-      grid-template-columns: minmax(auto, min-content) 1fr;
+      grid-template-columns: max(calc(332/1140*100%), 220px) 1fr;
       column-gap: 52px;
       border-bottom: 1px solid $border-base-color;
       padding: 32px 0 32px 24px;
@@ -96,7 +96,7 @@
       }
 
       .c-forms__title {
-        min-width: 220px;
+        // min-width: 220px;
         justify-content: space-between;
 
         @include breakpoint(small only) {
@@ -542,12 +542,20 @@
     }
   }
 
-  // 送信ボタン
-  &__submit {
-    text-align: center;
+
+  &__privacy + &__submit {
     margin-top: 40px;
     @include breakpoint(small only) {
       margin-top: 32px;
+    }
+  }
+
+  // 送信ボタン
+  &__submit {
+    text-align: center;
+    margin-top: 64px;
+    @include breakpoint(small only) {
+      margin-top: 48px;
     }
 
     &__back {

--- a/app/assets/scss/object/components/forms.scss
+++ b/app/assets/scss/object/components/forms.scss
@@ -28,6 +28,10 @@
     padding: 32px 16px;
   }
 
+  &:has(.c-forms__block.is-horizontal) {
+    padding: 0 0;
+  }
+
   &__inner {
     margin: auto;
 
@@ -52,6 +56,7 @@
 
     @include breakpoint(small only) {
       margin-bottom: 24px;
+      text-align: left;
     }
   }
 
@@ -61,6 +66,7 @@
   &__blocks {
     @include breakpoint(small only) {
     }
+
   }
 
   &__block {
@@ -68,17 +74,25 @@
     grid-template-columns: 1fr;
     row-gap: 8px;
 
-    &:not(:last-child) {
+    &:where(:not(:last-child)) {
       margin-bottom: 40px;
     }
 
     //項目名と項目の横並び
-    &.is-horizontal {
+    &:where(.is-horizontal) {
       grid-template-columns: minmax(auto, min-content) 1fr;
-      column-gap: 60px;
+      column-gap: 52px;
+      border-bottom: 1px solid $border-base-color;
+      padding: 32px 0 32px 24px;
+      margin: 0;
+
+      &:where(:first-child) {
+        border-top: 1px solid $border-base-color;
+      }
 
       @include breakpoint(small only) {
         grid-template-columns: 1fr;
+        padding: 24px 0;
       }
 
       .c-forms__title {
@@ -122,6 +136,12 @@
     font-weight: 700;
     line-height: 1;
     flex-shrink: 0;
+
+    &.is-optional {
+      background-color: $color-white;
+      color: $font-base-color;
+      border: 1px solid $border-base-color;
+    }
   }
 
   &__content {
@@ -225,25 +245,28 @@
   //ラジオボタン,チェックボックス
   &__radio,
   &__checkbox {
+    --_options-gap: 9px;
     //Contact Form 7
     &:where(:not(.is-mw)) {
       & > span > span {
         display: flex;
         flex-wrap: wrap;
         align-items: center;
-        gap: 4px;
+        gap: var(--_options-gap);
       }
 
       & > span > span > span {
+        //幅は要素にあわせて自動調整
       }
 
       &.is-column {
+        //2列
         @include breakpoint(small only) {
           flex-direction: column;
         }
 
         & > span > span > span {
-          width: calc(50% - #{5px});
+          width: calc(50% - (var(--_options-gap) / 2));
           @include breakpoint(small only) {
             width: 100%;
           }
@@ -251,6 +274,7 @@
       }
 
       &.is-vertical {
+        //縦並び
         flex-direction: column;
 
         & > span > span > span {
@@ -265,7 +289,7 @@
       display: flex;
       flex-wrap: wrap;
       align-items: center;
-      gap: 4px;
+      gap: var(--_options-gap);
 
       @include breakpoint(small only) {
         flex-direction: column;
@@ -276,18 +300,20 @@
       }
 
       & > span {
-        width: calc(50% - #{5px});
+        //幅は要素にあわせて自動調整
       }
 
       &.is-column {
+        //2列
         flex-direction: column;
 
         & > span {
-          width: calc(50% - #{5px});
+          width: calc(50% - (var(--_options-gap) / 2));
         }
       }
 
       &.is-vertical {
+        //縦並び
         flex-direction: column;
 
         & > span {
@@ -310,11 +336,16 @@
 
 
     &.is-border {
+      --_options-gap: 4px;
       label {
         @include forms-input-common-style;
         padding: 12px 32px 12px 16px;
         border: 1px solid $border-base-color;
         border-radius: $border-radius;
+
+        @include breakpoint(small only) {
+          padding: 9px 24px 9px 12px;
+        }
       }
     }
 
@@ -383,6 +414,10 @@
     font-size: 14px;
     margin-bottom: 8px;
 
+    &.is-mg-lg {
+      margin-bottom: 16px;
+    }
+
     small {
       font-size: inherit;
     }
@@ -390,17 +425,23 @@
 
 
   &__privacy {
+    &.is-display-contents {
+      display: contents;
+    }
+
     margin-top: 24px;
     text-align: center;
 
-    input {
-      margin-right: 10px;
-    }
+    &:not(.is-display-contents) {
+      input {
+        margin-right: 10px;
+      }
 
-    a {
-      font-weight: 400;
-      text-decoration-line: underline;
-      color: $font-base-color;
+      a {
+        font-weight: 400;
+        text-decoration-line: underline;
+        color: $font-base-color;
+      }
     }
   }
 
@@ -408,6 +449,22 @@
     display: flex;
     align-items: flex-start;//エラーメッセージが &__input 内に出たときのため flex-startにする
     gap: 12px;
+
+    @include breakpoint(small only) {
+      gap: 6px;
+    }
+
+    &.is-gap-lg{
+      gap: 24px;
+
+      @include breakpoint(small only) {
+        gap: 8px;
+      }
+    }
+
+    &.is-gap-sm{
+      gap: 8px;
+    }
   }
 
   &__flex-al-label{

--- a/app/assets/scss/object/components/forms.scss
+++ b/app/assets/scss/object/components/forms.scss
@@ -28,6 +28,14 @@
     padding: 32px 16px;
   }
 
+  &.is-padding-sm {
+    padding: 32px 24px;
+    @include breakpoint(small only) {
+      padding: 24px 12px;
+    }
+  }
+
+
   &:has(.c-forms__block.is-horizontal) {
     padding: 0 0;
   }
@@ -121,6 +129,11 @@
 
     &.is-vertical-top {
       align-self: start;
+      padding-top: 16px;
+
+      @include breakpoint(small only) {
+        padding-top: 0;
+      }
     }
   }
 
@@ -251,7 +264,7 @@
       & > span > span {
         display: flex;
         flex-wrap: wrap;
-        align-items: center;
+        align-items: stretch;
         gap: var(--_options-gap);
       }
 
@@ -342,6 +355,7 @@
         padding: 12px 32px 12px 16px;
         border: 1px solid $border-base-color;
         border-radius: $border-radius;
+        height: 100%;
 
         @include breakpoint(small only) {
           padding: 9px 24px 9px 12px;
@@ -436,12 +450,6 @@
       input {
         margin-right: 10px;
       }
-
-      a {
-        font-weight: 400;
-        text-decoration-line: underline;
-        color: $font-base-color;
-      }
     }
   }
 
@@ -529,7 +537,8 @@
     background-color: $color-white;
     display: grid;
     padding: 16px 24px;
-    height: 57px;
+    // height: 57px;
+    align-self: stretch;
     place-content: center;
     text-align: center;
     border-radius: 4px;

--- a/app/assets/scss/object/components/forms.scss
+++ b/app/assets/scss/object/components/forms.scss
@@ -252,6 +252,10 @@
 
     &.is-sm {
       width: 150px;
+
+      @include breakpoint(small down) {
+        width: 78px;
+      }
     }
   }
 

--- a/app/assets/scss/object/components/forms.scss
+++ b/app/assets/scss/object/components/forms.scss
@@ -4,12 +4,13 @@
 
 // メールフォーム専用の input,textarea,select 共通スタイル
 @mixin forms-input-common-style {
-  border-radius: 2px;
-  background-color: #F9F8F7;
+  border-radius: 4px;
+  background-color: $color-background;
 
 
   &:focus,
   &:active {
+    background-color: $color-white;
     border-color: $form-controls-active-border-color;
   }
 }
@@ -18,18 +19,16 @@
 // styles
 //============================
 .c-forms {
-  max-width: 800px;
   margin: auto;
-  padding: 54px 32px 58px;
+  padding: 80px 96px 80px;
   background: $color-white;
+  line-height: 1.6;
 
   @include breakpoint(small only) {
     padding: 32px 16px;
   }
 
   &__inner {
-    width: 100%;
-    max-width: 500px;
     margin: auto;
 
     @include breakpoint(small only) {
@@ -48,8 +47,8 @@
   }
 
   &__text {
-    font-size: 14px;
-    margin-bottom: 40px;
+    margin-bottom: 64px;
+    text-align: center;
 
     @include breakpoint(small only) {
       margin-bottom: 24px;
@@ -67,10 +66,10 @@
   &__block {
     display: grid;
     grid-template-columns: 1fr;
-    row-gap: 4px;
+    row-gap: 8px;
 
     &:not(:last-child) {
-      margin-bottom: 20px;
+      margin-bottom: 40px;
     }
 
     //項目名と項目の横並び
@@ -103,8 +102,7 @@
     gap: 8px;
     align-items: baseline;
     align-self: center;
-    font-size: 14px;
-    --letter-spacing: 0;
+    font-weight: 700;
 
 
     &.is-vertical-top {
@@ -115,15 +113,15 @@
   //ラベル
   &__label {
     display: block;
-    min-width: 34px;
-    padding: 3px;
-    border-radius: 5px;
-    background-color: $color-accent; //#F44336
+    padding: 3px 8px 4px 8px;
+    border-radius: 2px;
+    background-color:#D03045;
     text-align: center;
     color: $color-white;
-    font-size: 12px;
+    font-size: 11px;
+    font-weight: 700;
     line-height: 1;
-    --letter-spacing: 0em;
+    flex-shrink: 0;
   }
 
   &__content {
@@ -156,9 +154,9 @@
     //CF7のバリデーションチップ対応
     .wpcf7-not-valid-tip {
       font-weight: 400;
-      font-size: 12px;
-      line-height: 1.7;
       color: $color-state-danger;
+      margin-top: 8px;
+      display: block;
     }
 
     &:has(.wpcf7-not-valid-tip) {
@@ -167,7 +165,7 @@
       select,
       label:has(input[type="radio"]),
       label:has(input[type="checkbox"]) {
-        background-color: rgba($color-state-danger, 0.05);
+        background-color: $color-state-danger-fill;
         color: $color-state-danger;
         border-color: $color-state-danger;
       }
@@ -178,28 +176,20 @@
   // フォームコントロール
   //============================
 
+
+
   //インプット
   &__input {
-    width: 100%;
-
     input {
       @include forms-input-common-style;
-    }
-
-    &.is-sm {
-      width: 180px;
-
-      input {
-      }
     }
   }
 
   &__file {
-    width: 100%;
-
-
     input {
-      @include forms-input-common-style;
+      border-radius: 4px;
+      background-color: $color-background;
+      border: none;
       width: 100%;
       &::file-selector-button {
       }
@@ -207,20 +197,28 @@
   }
 
   &__select {
-    width: 100%;
-
     select {
       @include forms-input-common-style;
-    }
-
-    &.is-sm {
-      width: 180px;
     }
   }
 
   &__textarea {
     textarea {
       @include forms-input-common-style;
+    }
+  }
+
+
+  //サイズバリエーション
+  &__input, &__select, &__file, &__textarea {
+    width: 100%;
+
+    &.is-md {
+      width: 294px;
+    }
+
+    &.is-sm {
+      width: 150px;
     }
   }
 
@@ -233,17 +231,22 @@
         display: flex;
         flex-wrap: wrap;
         align-items: center;
-        gap: 10px;
-        line-height: 1.2;
-        @include breakpoint(small only) {
-          flex-direction: column;
-        }
+        gap: 4px;
       }
 
       & > span > span > span {
-        width: calc(50% - #{5px});
+      }
+
+      &.is-column {
         @include breakpoint(small only) {
-          width: 100%;
+          flex-direction: column;
+        }
+
+        & > span > span > span {
+          width: calc(50% - #{5px});
+          @include breakpoint(small only) {
+            width: 100%;
+          }
         }
       }
 
@@ -262,8 +265,7 @@
       display: flex;
       flex-wrap: wrap;
       align-items: center;
-      gap: 10px;
-      line-height: 1.2;
+      gap: 4px;
 
       @include breakpoint(small only) {
         flex-direction: column;
@@ -275,6 +277,14 @@
 
       & > span {
         width: calc(50% - #{5px});
+      }
+
+      &.is-column {
+        flex-direction: column;
+
+        & > span {
+          width: calc(50% - #{5px});
+        }
       }
 
       &.is-vertical {
@@ -302,7 +312,7 @@
     &.is-border {
       label {
         @include forms-input-common-style;
-        padding: 11px 8px;
+        padding: 12px 32px 12px 16px;
         border: 1px solid $border-base-color;
         border-radius: $border-radius;
       }
@@ -318,8 +328,8 @@
           appearance: none;
           background: $color-white;
           border: 1px solid $border-base-color;
-          width: 20px;
-          height: 20px;
+          width: 24px;
+          height: 24px;
           position: relative;
 
           &:checked {
@@ -328,13 +338,11 @@
               height: 100%;
               position: relative;
               top: 50%;
-              left: -1px;
               transform: translateY(-50%);
               background-color: $color-white;
               content: '';
               display: inline-block;
               visibility: visible;
-              border: 1px solid $color-primary;
             }
           }
         }
@@ -346,18 +354,22 @@
 
           &:checked::after {
             content: '';
-            background: radial-gradient($color-primary 48%, $color-white 50%);
+            background: radial-gradient($color-primary 45%, $color-white 50%);
           }
         }
 
         &[type='checkbox'] {
           &:checked {
+            background: $color-primary;
+            border-color: $color-primary;
             &::after {
               content: "check";
               @include icon-font();
+              width: 100%;
+              height: 100%;
               display: grid;
               place-content: center;
-              background: $color-primary;
+              background: transparent;
               color: $color-white;
               font-size: 20px;
             }
@@ -368,9 +380,8 @@
   }
 
   &__note {
-    margin-top: 4px;
-    opacity: 0.6;
-    font-size: 12px;
+    font-size: 14px;
+    margin-bottom: 8px;
 
     small {
       font-size: inherit;
@@ -396,26 +407,34 @@
   &__flex-al {
     display: flex;
     align-items: flex-start;//エラーメッセージが &__input 内に出たときのため flex-startにする
-    gap: 16px;
+    gap: 12px;
   }
 
   &__flex-al-label{
     flex-shrink: 0;
     width: 32px;
     text-align: right;
-    padding-top:calc((#{44px} - 1lh)/2);// （inputの高さ - 行の高さ）÷ 2
+    padding-top:calc((#{57px} - 1lh)/2);// （inputの高さ - 行の高さ）÷ 2
+
+    @include breakpoint(small only) {
+      padding-top:calc((#{44px} - 1lh)/2);// （inputの高さ - 行の高さ）÷ 2
+    }
   }
 
   &__flex-al-unit{
     flex-shrink: 0;
-    padding-top:calc((#{44px} - 1lh)/2);// （inputの高さ - 行の高さ）÷ 2
+    padding-top:calc((#{57px} - 1lh)/2);// （inputの高さ - 行の高さ）÷ 2
+
+    @include breakpoint(small only) {
+      padding-top:calc((#{44px} - 1lh)/2);// （inputの高さ - 行の高さ）÷ 2
+    }
   }
 
   &__flexbox {
     display: flex;
     align-items: flex-start;//エラーメッセージが &__input 内に出たときのため flex-startにする
     margin-bottom: 16px;
-    gap: 16px;
+    gap: 8px;
     @include breakpoint(small only) {
       display: block;
     }
@@ -448,20 +467,21 @@
   // 住所自動入力ボタン
   &__button {
     flex: none;
-    max-width: 132px;
     border: 1px solid $font-base-color;
     outline: none;
     background-color: $color-white;
-    padding: 4px 12px;
-    display: block;
+    display: grid;
+    padding: 16px 24px;
+    height: 57px;
+    place-content: center;
     text-align: center;
-    border-radius: 2px;
-    font-size: 14px;
-    margin-top: calc((#{44px} - #{34px})/2);// （inputの高さ - ボタンの高さ）÷ 2
+    border-radius: 4px;
+    margin-top: calc((#{57px} - #{57px})/2);// （inputの高さ - ボタンの高さ）÷ 2
 
     @include breakpoint(small only) {
       padding: 6px 12px;
-      margin-top: calc((#{44px} - #{38px})/2);// （inputの高さ - ボタンの高さ）÷ 2
+      height: 40px;
+      margin-top: calc((#{44px} - #{40px})/2);// （inputの高さ - ボタンの高さ）÷ 2
     }
   }
 

--- a/app/contact/complete/index.pug
+++ b/app/contact/complete/index.pug
@@ -8,9 +8,14 @@ block append config
   - current.depth = 3 // ページの階層
 
 block page_header
+  +l_page_header({
+    image: "img-page-header-format.jpg",
+    title: "お問い合わせ",
+    subtitle: "Contact"
+  })
 
 block body
-  section.l-section.is-xlg.is-bottom.is-bg-color
+  section.l-section.is-xlg.is-bg-color
     .l-container
       //
         +c.form-head
@@ -28,7 +33,37 @@ block body
                 +e.item-text 送信完了
       +c.forms
         +e.inner
-          +h1.head お問い合わせ<br>ありがとうございました。
+          +h1.head.u-text-center お問い合わせ<br>ありがとうございました。
+          +e.text.
+            この度はお問い合わせいただき、誠にありがとうございます。<br>
+            いただいた内容を確認後、担当者より再度ご連絡いたします。<br>
+            大変恐縮ですが、今しばらくお待ちくださいませ。<br><br>
+
+            ※尚、ご入力いただいたメールアドレス宛に<br class="u-hidden-sm">お問い合わせ内容を記載した自動返信メールが配信されております。<br>
+            そちらも併せてご確認くださいませ。<br>
+
+        +e.pagetop.u-text-center
+          +a("/").c-button.is-xlg トップページに戻る
+
+  section.l-section.is-xlg
+    .l-container
+      //
+        +c.form-head
+          +e.block
+            +h1.title お問い合わせ
+            +e.list
+              +e.item
+                +e.item-number 1
+                +e.item-text お客様情報入力
+              +e.item
+                +e.item-number 2
+                +e.item-text 入力内容の確認
+              +e.item.is-current
+                +e.item-number 3
+                +e.item-text 送信完了
+      +c.forms
+        +e.inner
+          +h1.head.u-text-center お問い合わせ<br>ありがとうございました。
           +e.text.
             この度はお問い合わせいただき、誠にありがとうございます。<br>
             いただいた内容を確認後、担当者より再度ご連絡いたします。<br>

--- a/app/contact/confirm/index.pug
+++ b/app/contact/confirm/index.pug
@@ -8,9 +8,14 @@ block append config
   - current.depth = 3 // ページの階層
 
 block page_header
+  +l_page_header({
+    image: "img-page-header-format.jpg",
+    title: "お問い合わせ",
+    subtitle: "Contact"
+  })
 
 block body
-  section.l-section.is-xlg.is-bottom.is-bg-color
+  section.l-section.is-xlg.is-bg-color
     .l-container
       //
         +c.form-head
@@ -29,52 +34,120 @@ block body
       +c.forms
         +e.inner
           +h1.head お問い合わせ：入力内容確認
-          +e.text.
+          +e.text.u-text-left.
             ご入力いただいた内容は下記の通りです。<br>
             お間違いがなければ送信を、入力内容を変更する場合はお手数ですが、再入力をお願い致します。
-          +e.block
-            +e.title
-              | 貴社名
-            +e.content
-              +e.input 株式会社 サンプル
-          +e.block
-            +e.title
-              | 部署
-            +e.content
-              +e.input 総務課
-          +e.block
-            +e.title
-              | ご担当者氏名
-              span.c-forms__label 必須
-            +e.content
-              +e.input 山田 太郎
-          +e.block
-            +e.title
-              | フリガナ
-              span.c-forms__label 必須
-            +e.content
-              +e.input ヤマダ タロウ
-          +e.block
-            +e.title
-              | TEL
-              span.c-forms__label 必須
-            +e.content
-              +e.input 123-456-789
-          +e.block
-            +e.title
-              | メールアドレス
-              span.c-forms__label 必須
-            +e.content
-              +e.input info@mail.com
-          +e.block
-            +e.title
-              | ファイル添付
-            +e.content
-              +e.input text.png
-          +e.block
-            +e.title.is-vertical-top お問い合わせ内容
-            +e.content
-              +e.textarea サービスについてご不明点のある方はこちらにご記載ください。
+          +e.blocks
+            +e.block
+              +e.title
+                | 貴社名
+              +e.content
+                +e.input 株式会社 サンプル
+            +e.block
+              +e.title
+                | 部署
+              +e.content
+                +e.input 総務課
+            +e.block
+              +e.title
+                | ご担当者氏名
+                span.c-forms__label 必須
+              +e.content
+                +e.input 山田 太郎
+            +e.block
+              +e.title
+                | フリガナ
+                span.c-forms__label 必須
+              +e.content
+                +e.input ヤマダ タロウ
+            +e.block
+              +e.title
+                | TEL
+                span.c-forms__label 必須
+              +e.content
+                +e.input 123-456-789
+            +e.block
+              +e.title
+                | メールアドレス
+                span.c-forms__label 必須
+              +e.content
+                +e.input info@mail.com
+            +e.block
+              +e.title
+                | ファイル添付
+              +e.content
+                +e.input text.png
+            +e.block
+              +e.title.is-vertical-top お問い合わせ内容
+              +e.content
+                +e.textarea サービスについてご不明点のある方はこちらにご記載ください。
+        +e.submit
+          button.c-button.c-forms__submit__back.is-lg.is-secondary.is-arrow-left 戻る
+          button.c-button.c-forms__submit__submit.is-lg 送信する
+
+
+  section.l-section.is-xlg
+    h1 タイプ2：横列組
+
+    .l-container
+      //- ★★★★★★★★★★★★★★★★★★★★★★★★★★★★★★★★★★★
+      //- タイプ2：横列組
+      //- タイプ2にのみ任意ラベルあり
+      //- ★★★★★★★★★★★★★★★★★★★★★★★★★★★★★★★★★★★
+      +c.forms
+        +e.inner
+          +h1.head お問い合わせ：入力内容確認
+          +e.text.u-text-left.
+            ご入力いただいた内容は下記の通りです。<br>
+            お間違いがなければ送信を、入力内容を変更する場合はお手数ですが、再入力をお願い致します。
+          +e.blocks
+            +e.block.is-horizontal
+              +e.title
+                | 貴社名
+                span.c-forms__label.is-optional 任意
+              +e.content
+                +e.input 株式会社 サンプル
+            +e.block.is-horizontal
+              +e.title
+                | 部署
+                span.c-forms__label.is-optional 任意
+              +e.content
+                +e.input 総務課
+            +e.block.is-horizontal
+              +e.title
+                | ご担当者氏名
+                span.c-forms__label 必須
+              +e.content
+                +e.input 山田 太郎
+            +e.block.is-horizontal
+              +e.title
+                | フリガナ
+                span.c-forms__label 必須
+              +e.content
+                +e.input ヤマダ タロウ
+            +e.block.is-horizontal
+              +e.title
+                | TEL
+                span.c-forms__label 必須
+              +e.content
+                +e.input 123-456-789
+            +e.block.is-horizontal
+              +e.title
+                | メールアドレス
+                span.c-forms__label 必須
+              +e.content
+                +e.input info@mail.com
+            +e.block.is-horizontal
+              +e.title
+                | ファイル添付
+                span.c-forms__label.is-optional 任意
+              +e.content
+                +e.input text.png
+            +e.block.is-horizontal
+              +e.title お問い合わせ内容
+                span.c-forms__label.is-optional 任意
+              +e.content
+                +e.textarea サービスについてご不明点のある方はこちらにご記載ください。
         +e.submit
           button.c-button.c-forms__submit__back.is-lg.is-secondary.is-arrow-left 戻る
           button.c-button.c-forms__submit__submit.is-lg 送信する

--- a/app/contact/index.pug
+++ b/app/contact/index.pug
@@ -343,8 +343,8 @@ block body
                 | 年齢
                 span.c-forms__label 必須
               +e.content
-                +e.select.is-sm
-                  +select-nums("age",18,50,"年齢を選択","歳")
+                +e.select.is-md
+                  +select-nums("age",18,50,"選択してください","歳")
 
           +e.head --MW WP Form版HTML保存用--
           //- ★MW WP Formの場合はname値を日本語にします

--- a/app/contact/index.pug
+++ b/app/contact/index.pug
@@ -34,11 +34,15 @@ block body
               +e.item-number 3
               +e.item-text 送信完了
       <script src="https://ajaxzip3.github.io/ajaxzip3.js"></script>
+
+
+      //- ★★★★★★★★★★★★★★★★★★★★★★★★★★★★★★★★★★★
+      //- タイプ1: 基本スタイル（1列型）
+      //- ★★★★★★★★★★★★★★★★★★★★★★★★★★★★★★★★★★★
       +c.forms
         +e.inner
-          +e.text ご質問、ご相談はこちらのフォームからご連絡ください。
+          +e.text ご質問・ご相談は下記のフォームからお問い合わせください。
           +e.blocks
-
             +e.block
               +e("fieldset").fieldset
                 +e("legend").title
@@ -51,7 +55,7 @@ block body
                         span
                           label
                             input(type="checkbox", name="service-options", value="選択肢1")
-                            span 選択肢1
+                            span 選択肢テキスト1
                         span
                           label
                             input(type="checkbox", name="service-options", value="選択肢2")
@@ -78,7 +82,7 @@ block body
                         span
                           label
                             input(type="radio", name="service-selection", value="選択肢1")
-                            span 選択肢1
+                            span 選択肢テキスト1
                         span
                           label
                             input(type="radio", name="service-selection", value="選択肢2")
@@ -185,7 +189,7 @@ block body
                 span.c-forms__label 必須
                 //- ★Contact form 7 の場合は name="name" は使えないので name="your-name" にしてください
               +e.content
-                +e.input: input(type="text", name="your-name", placeholder="山田　太郎" , id="your-name")
+                +e.input: input(type="text", name="your-name", placeholder="例）山田　太郎" , id="your-name")
 
             +e.block
               +e("label").title(for="company-name")
@@ -193,39 +197,8 @@ block body
                 span.c-forms__label 必須
               +e.content
                 +p.note: small ※個人の方は、「個人」とご入力ください
-                +e.input: input(type="text", name="company-name", placeholder="〇〇株式会社" , id="company-name")
+                +e.input: input(type="text", name="company-name", placeholder="例）〇〇株式会社" , id="company-name")
 
-            +e.block
-              +e("label").title(for="your-email")
-                | メールアドレス
-                span.c-forms__label 必須
-                //- ★Contact form 7 の場合は メールアドレスは type="email" にしてください
-              +e.content
-                +e.input: input(type="email", name="your-email", placeholder="info@mail.jp" , id="your-email")
-
-            +e.block
-              +e("label").title(for="tel-number")
-                | 電話番号
-                span.c-forms__label 必須
-                //- ★Contact form 7 の場合は 電話番号は type="tel" にしてください
-              +e.content
-                +e.input: input(type="tel", name="tel-number", placeholder="123-456-7890" , id="tel-number")
-
-            +e.block
-              +e("label").title(for="zip-code")
-                | 郵便番号
-                span.c-forms__label 必須
-              +e.content
-                +e.flex-al
-                  +e.input.is-md: input(type="text", name="zip-code", placeholder="0001234" , id="zip-code")
-                  button(onclick="AjaxZip3.zip2addr('zip-code','','address','address');", type="button").c-forms__button#zipauto 住所を自動入力
-
-            +e.block
-              +e("label").title(for="address")
-                | ご住所
-                span.c-forms__label 必須
-              +e.content
-                +e.input: input(type="text", name="address", placeholder="ご住所を入力してください" , id="address")
 
             +e.block
               +e("label").title(for="department-name")
@@ -252,11 +225,45 @@ block body
                     option(value="選択肢C") 選択肢C
 
             +e.block
+              +e("label").title(for="your-email")
+                | メールアドレス
+                span.c-forms__label 必須
+                //- ★Contact form 7 の場合は メールアドレスは type="email" にしてください
+              +e.content
+                +e.input: input(type="email", name="your-email", placeholder="例）info@mail.jp" , id="your-email")
+
+            +e.block
+              +e("label").title(for="tel-number")
+                | 電話番号
+                span.c-forms__label 必須
+                //- ★Contact form 7 の場合は 電話番号は type="tel" にしてください
+              +e.content
+                +p.note: small ※半角数字
+                +e.input: input(type="tel", name="tel-number", placeholder="例）123-456-7890" , id="tel-number")
+
+            +e.block
+              +e("label").title(for="zip-code")
+                | 郵便番号
+                span.c-forms__label 必須
+              +e.content
+                +e.flex-al.is-gap-sm
+                  +e.input.is-md: input(type="text", name="zip-code", placeholder="例）0000000" , id="zip-code")
+                  button(onclick="AjaxZip3.zip2addr('zip-code','','address','address');", type="button").c-forms__button#zipauto 住所を自動入力
+
+            +e.block
+              +e("label").title(for="address")
+                | ご住所
+                span.c-forms__label 必須
+              +e.content
+                +e.input: input(type="text", name="address", placeholder="ご住所を入力してください" , id="address")
+
+
+            +e.block
               +e("label").title(for="your-message")
-                | その他質問等
+                | お問い合わせ内容
               +e.content
                 +e.textarea
-                  textarea(name="your-message", placeholder="" , id="your-message")
+                  textarea(name="your-message", placeholder="お問い合わせ内容をご記入ください" , id="your-message")
 
             +e.block
               +e("label").title(for="file-upload")
@@ -272,7 +279,7 @@ block body
                   | お名前
                   span.c-forms__label 必須
                 +e.content
-                  +e.flex-al
+                  +e.flex-al.is-gap-lg
                     +e("label").flex-al
                       +e("span").flex-al-label 姓
                       +e.input: input(type="text", name="last-name", placeholder="山田")
@@ -285,7 +292,7 @@ block body
                   | フリガナ
                   span.c-forms__label 必須
                 +e.content
-                  +e.flex-al
+                  +e.flex-al.is-gap-lg
                     +e("label").flex-al
                       +e("span").flex-al-label(for="last-kana-name") セイ
                       +e.input: input(type="text", name="last-kana-name", placeholder="ヤマダ" , id="last-kana-name")
@@ -298,10 +305,10 @@ block body
                 | 生年月日
                 span.c-forms__label 必須
               +e.content
-                +e.flex-al
-                  +e.flex-al-label 西暦
+                +e.flex-al.is-gap-lg
                   +e("label").flex-al
-                    +e.input
+                    //-+e.flex-al-label 西暦
+                    +e.input.is-sm
                       input(type="text", name="birth-year", placeholder="1980")
                     +span.flex-al-unit 年
                   +e("label").flex-al
@@ -317,9 +324,9 @@ block body
                 | 生年月日
                 span.c-forms__label 必須
               +e.content
-                +e.flex-al
-                  +e.flex-al-label 西暦
+                +e.flex-al.is-gap-lg
                   +e("label").flex-al
+                    //- +e.flex-al-label 西暦
                     +span.select.is-sm
                       +select-nums("birth-year",1975,2007,"----")
                     +span.flex-al-unit 年
@@ -339,14 +346,14 @@ block body
                 +e.select.is-sm
                   +select-nums("age",18,50,"年齢を選択","歳")
 
-          +e.head --MW WP Form版保存用--
+          +e.head --MW WP Form版HTML保存用--
           //- ★MW WP Formの場合はname値を日本語にします
           +e.blocks
             +e.block
               +e("fieldset").fieldset
                 +e("legend").title チェックボックス
                 +e.content
-                  +e.checkbox.is-mw
+                  +e.checkbox.is-mw.is-border
                     span
                       label
                         input(type="checkbox", name="ご希望のサービス", value="選択肢1")
@@ -359,46 +366,16 @@ block body
               +e("fieldset").fieldset
                 +e("legend").title ラジオボタン
                 +e.content
-                  +e.radio.is-mw
-                  span
-                    label
-                      input(type="radio", name="ご希望のサービス", value="選択肢1")
-                      span 選択肢1
-                  span
-                    label
-                      input(type="radio", name="ご希望のサービス", value="選択肢2")
-                      span 選択肢2
+                  +e.radio.is-mw.is-border
+                    span
+                      label
+                        input(type="radio", name="ご希望のサービス", value="選択肢1")
+                        span 選択肢1
+                    span
+                      label
+                        input(type="radio", name="ご希望のサービス", value="選択肢2")
+                        span 選択肢2
 
-          +e.head --横並びパターン保存用--
-          +e.blocks
-            +e.block.is-horizontal
-              +e("label").title(for="horizontal-pattern")
-                | 横並びパターン
-                span.c-forms__label 必須
-              +e.content
-                +e.input: input(type="text", name="horizontal-pattern", placeholder="〇〇株式会社" , id="horizontal-pattern")
-
-            +e.block.is-horizontal
-              +e("label").title.is-vertical-top(for="horizontal-pattern-title-top")
-                | 横並び（タイトル上寄せ）
-                span.c-forms__label 必須
-              +e.content
-                +p.note: small 補足のテキスト
-                +e.input: input(type="text", name="horizontal-pattern-title-top", placeholder="〇〇株式会社" , id="horizontal-pattern-title-top")
-
-            +e.block.is-horizontal
-              +e("label").title.is-vertical-top(for="zip-code-address")
-                | 住所
-                span.c-forms__label 必須
-              +e.content
-                +e.flexbox
-                  +span.flexbox-label 郵便番号
-                  +e.flex-al
-                    +e.input.is-sm: input(type="text", name="zip-code-address", placeholder="（例）464-0850" , id="zip-code-address")
-                    button(onclick="AjaxZip3.zip2addr('zip-code-address','','address','address');", type="button").c-forms__button#zipauto 住所を自動入力
-                +e.flexbox
-                  +span.flexbox-label(for="address-detail") ご住所
-                  +e.input: input(type="text", name="address-detail", placeholder="（例）愛知県名古屋市千種区今池3丁目12-20 KAビル 6F" , id="address-detail")
 
 
           +e.head --CF7用バリデーションパターン--
@@ -486,6 +463,105 @@ block body
               +a("/privacy-policy/")(target="_blank") 個人情報保護方針
               | の内容に同意する
           +e.submit
-            button.c-button.is-xlg 確認画面へ
-            //button.c-button.c-forms__submit__back.is-lg.is-secondary.is-arrow-left 戻る
-            //button.c-button.c-forms__submit__submit.is-lg 送信する
+            button.c-button.is-xlg この内容で送信する
+            //button.c-button.c-forms__submit__back.is-arrow-left 戻る
+            //button.c-button.c-forms__submit__submit 送信する
+
+
+
+  section.l-section.is-xlg
+    h1 タイプ2：横列組
+
+    .l-container
+      //- ★★★★★★★★★★★★★★★★★★★★★★★★★★★★★★★★★★★
+      //- タイプ2：横列組
+      //- タイプ2にのみ任意ラベルあり
+      //- ★★★★★★★★★★★★★★★★★★★★★★★★★★★★★★★★★★★
+      +c.forms
+        +e.inner
+          +e.text.u-text-left ご質問・ご相談は下記のフォームからお問い合わせください。
+          +e.blocks
+            +e.block.is-horizontal
+              +e("fieldset").fieldset
+                +e("legend").title
+                  | チェックボックス
+                  span.c-forms__label 必須
+                +e.content
+                  +e.checkbox.is-vertical
+                    span
+                      span
+                        span
+                          label
+                            input(type="checkbox", name="service-options", value="選択肢1")
+                            span 選択肢1
+                        span
+                          label
+                            input(type="checkbox", name="service-options", value="選択肢2")
+                            span 選択肢2
+                        span
+                          label
+                            input(type="checkbox", name="service-options", value="選択肢3")
+                            span 選択肢3
+            +e.block.is-horizontal
+              +e("fieldset").fieldset
+                +e("legend").title
+                  | ラジオボタン
+                  span.c-forms__label 必須
+                +e.content
+                  +e.radio.is-vertical
+                    span
+                      span
+                        span
+                          label
+                            input(type="radio", name="service-selection", value="選択肢1")
+                            span 選択肢1
+                        span
+                          label
+                            input(type="radio", name="service-selection", value="選択肢2")
+                            span 選択肢2
+                        span
+                          label
+                            input(type="radio", name="service-selection", value="選択肢3")
+                            span 選択肢3
+
+            +e.block.is-horizontal
+              +e("label").title(for="your-name")
+                | お名前
+                span.c-forms__label 必須
+              +e.content
+                +e.input: input(type="text", name="your-name", placeholder="例）山田　太郎" , id="your-name")
+
+            +e.block.is-horizontal
+              +e("label").title(for="your-message")
+                | お問い合わせ内容
+                span.c-forms__label.is-optional 任意
+              +e.content
+                +e.textarea
+                  textarea(name="your-message", placeholder="お問い合わせ内容をご記入ください" , id="your-message")
+
+            +e.block.is-horizontal
+              +e("label").title.is-vertical-top(for="your-message")
+                | タイトル上寄せパターン保存用
+                span.c-forms__label.is-optional 任意
+              +e.content
+                +e.textarea
+                  textarea(name="your-message", placeholder="お問い合わせ内容をご記入ください" , id="your-message")
+
+            +e.block.is-horizontal
+              +e("label").title(for="your-message")
+                | お問い合わせ内容
+                span.c-forms__label.is-optional 任意
+              +e.content
+                +p.note.is-mg-lg
+                  +a("/privacy-policy/")(target="_blank") 個人情報保護方針
+                  |の同意の上でお進みください。
+                //- WP側で c-forms__privacyの中のinputを判定して処理するので、
+                //- 同意のチェックボックスは .c-forms__privacy の中に入れてください
+                +e.privacy.is-display-contents
+                  +e.checkbox
+                    span
+                      span
+                        span
+                          label
+                            input(type="checkbox", name="policy", value="確認しました")
+                            span 同意する

--- a/app/contact/index.pug
+++ b/app/contact/index.pug
@@ -116,7 +116,7 @@ block body
                         span
                           label
                             input(type="checkbox", name="column-options", value="選択肢3")
-                            span 選択肢3
+                            span 選択肢3テキストが長い時テキストが長い時テキストが長い時テキストが長い時テキストが長い時
                         span
                           label
                             input(type="checkbox", name="column-options", value="選択肢4")
@@ -207,7 +207,7 @@ block body
               +e.content
                 +e.select
                   select(name="department-name" , id="department-name")
-                    option(disabled, selected) ー以下から選択してくださいー
+                    option(disabled, selected) 選択してください
                     option(value="選択肢A") 選択肢A
                     option(value="選択肢B") 選択肢B
                     option(value="選択肢C") 選択肢C
@@ -219,7 +219,7 @@ block body
               +e.content
                 +e.select
                   select(name="position" , id="position")
-                    option(disabled, selected) ー以下から選択してくださいー
+                    option(disabled, selected) 選択してください
                     option(value="選択肢A") 選択肢A
                     option(value="選択肢B") 選択肢B
                     option(value="選択肢C") 選択肢C
@@ -460,10 +460,10 @@ block body
           +e.privacy
             label
               input(type="checkbox", name="policy", value="確認しました")
-              +a("/privacy-policy/")(target="_blank") 個人情報保護方針
+              +a("/privacy-policy/")(target="_blank").u-text-link 個人情報保護方針
               | の内容に同意する
           +e.submit
-            button.c-button.is-xlg この内容で送信する
+            button.c-button この内容で送信する
             //button.c-button.c-forms__submit__back.is-arrow-left 戻る
             //button.c-button.c-forms__submit__submit 送信する
 
@@ -553,7 +553,7 @@ block body
                 span.c-forms__label.is-optional 任意
               +e.content
                 +p.note.is-mg-lg
-                  +a("/privacy-policy/")(target="_blank") 個人情報保護方針
+                  +a("/privacy-policy/")(target="_blank").u-text-link 個人情報保護方針
                   |の同意の上でお進みください。
                 //- WP側で c-forms__privacyの中のinputを判定して処理するので、
                 //- 同意のチェックボックスは .c-forms__privacy の中に入れてください
@@ -566,4 +566,4 @@ block body
                             input(type="checkbox", name="policy", value="確認しました")
                             span 同意する
           +e.submit
-            button.c-button.is-xlg この内容で送信する
+            button.c-button この内容で送信する

--- a/app/contact/index.pug
+++ b/app/contact/index.pug
@@ -8,12 +8,17 @@ block append config
   - current.depth = 2 // ページの階層
 
 block page_header
+  +l_page_header({
+    image: "img-page-header-format.jpg",
+    title: "お問い合わせ",
+    subtitle: "Contact"
+  })
 
   //- ★★★★★★★★★★★★★★★★★★★★★★★★★★★★★★★★★★★
   //- /confirm/ と /complete/ もCSS調整必須！
   //- ★★★★★★★★★★★★★★★★★★★★★★★★★★★★★★★★★★★
 block body
-  section.l-section.is-xlg.is-bottom.is-bg-color
+  section.l-section.is-xlg.is-bg-color
     .l-container
       //+c.form-head
         +e.block
@@ -31,7 +36,6 @@ block body
       <script src="https://ajaxzip3.github.io/ajaxzip3.js"></script>
       +c.forms
         +e.inner
-          +h1.head お問い合わせ
           +e.text ご質問、ご相談はこちらのフォームからご連絡ください。
           +e.blocks
 
@@ -88,11 +92,36 @@ block body
                             input(type="radio", name="service-selection", value="選択肢4")
                             span 選択肢4
 
+            +e.block
+              +e("fieldset").fieldset
+                +e("legend").title
+                  | チェックボックス(2カラムにしたいとき)
+                  span.c-forms__label 必須
+                +e.content
+                  +e.checkbox.is-border.is-column
+                    span
+                      span
+                        span
+                          label
+                            input(type="checkbox", name="column-options", value="選択肢1")
+                            span 選択肢1
+                        span
+                          label
+                            input(type="checkbox", name="column-options", value="選択肢2")
+                            span 選択肢2
+                        span
+                          label
+                            input(type="checkbox", name="column-options", value="選択肢3")
+                            span 選択肢3
+                        span
+                          label
+                            input(type="checkbox", name="column-options", value="選択肢4")
+                            span 選択肢4
 
             +e.block
               +e("fieldset").fieldset
                 +e("legend").title
-                  | ご希望のサービス（テキストが長い場合）
+                  | チェックボックス（テキストが長い場合）
                   span.c-forms__label 必須
                 +e.content
                   +e.checkbox.is-border.is-vertical
@@ -163,8 +192,8 @@ block body
                 | 会社名
                 span.c-forms__label 必須
               +e.content
-                +e.input: input(type="text", name="company-name", placeholder="〇〇株式会社" , id="company-name")
                 +p.note: small ※個人の方は、「個人」とご入力ください
+                +e.input: input(type="text", name="company-name", placeholder="〇〇株式会社" , id="company-name")
 
             +e.block
               +e("label").title(for="your-email")
@@ -188,7 +217,7 @@ block body
                 span.c-forms__label 必須
               +e.content
                 +e.flex-al
-                  +e.input.is-sm: input(type="text", name="zip-code", placeholder="0001234" , id="zip-code")
+                  +e.input.is-md: input(type="text", name="zip-code", placeholder="0001234" , id="zip-code")
                   button(onclick="AjaxZip3.zip2addr('zip-code','','address','address');", type="button").c-forms__button#zipauto 住所を自動入力
 
             +e.block
@@ -354,8 +383,8 @@ block body
                 | 横並び（タイトル上寄せ）
                 span.c-forms__label 必須
               +e.content
-                +e.input: input(type="text", name="horizontal-pattern-title-top", placeholder="〇〇株式会社" , id="horizontal-pattern-title-top")
                 +p.note: small 補足のテキスト
+                +e.input: input(type="text", name="horizontal-pattern-title-top", placeholder="〇〇株式会社" , id="horizontal-pattern-title-top")
 
             +e.block.is-horizontal
               +e("label").title.is-vertical-top(for="zip-code-address")

--- a/app/contact/index.pug
+++ b/app/contact/index.pug
@@ -301,9 +301,10 @@ block body
                       +e.input: input(type="text", name="first-kana-name", placeholder="タロウ" , id="first-kana-name")
 
             +e.block
-              +e.title
-                | 生年月日
-                span.c-forms__label 必須
+              +e("fieldset").fieldset
+                +e("legend").title
+                  | 生年月日
+                  span.c-forms__label 必須
               +e.content
                 +e.flex-al.is-gap-lg
                   +e("label").flex-al
@@ -320,9 +321,10 @@ block body
                       input(type="text", name="birth-day", placeholder="01")
                     +span.flex-al-unit 日
             +e.block
-              +e.title
-                | 生年月日
-                span.c-forms__label 必須
+              +e("fieldset").fieldset
+                +e("legend").title
+                  | 生年月日
+                  span.c-forms__label 必須
               +e.content
                 +e.flex-al.is-gap-lg
                   +e("label").flex-al
@@ -339,12 +341,23 @@ block body
                       +select-nums("birth-day",1,31,"----")
                     +span.flex-al-unit 日
             +e.block
-              +e.title
+              +e("label").title(for="age")
                 | 年齢
                 span.c-forms__label 必須
               +e.content
-                +e.select.is-md
-                  +select-nums("age",18,50,"選択してください","歳")
+                +e.flex-al
+                  +e.input.is-sm
+                    input(type="text", name="age", placeholder="30" , id="age")
+                  +e.flex-al-unit 歳
+            +e.block
+              +e("label").title(for="age-select")
+                | 年齢
+                span.c-forms__label 必須
+              +e.content
+                +e.flex-al
+                  +e.select.is-sm
+                    +select-nums("age",18,50,"----","")#age-select
+                  +e.flex-al-unit 歳
 
           +e.head --MW WP Form版HTML保存用--
           //- ★MW WP Formの場合はname値を日本語にします

--- a/app/contact/index.pug
+++ b/app/contact/index.pug
@@ -565,3 +565,5 @@ block body
                           label
                             input(type="checkbox", name="policy", value="確認しました")
                             span 同意する
+          +e.submit
+            button.c-button.is-xlg この内容で送信する

--- a/app/download/page/index.pug
+++ b/app/download/page/index.pug
@@ -40,7 +40,7 @@ block body
                 +e.slider-next.swiper-next.js-document-slider-next.swiper-button-next
 
         .c-block-document__form
-          +c.forms
+          +c.forms.is-padding-sm
             .c-heading.is-xs.is-mg-level-4 ダウンロードフォーム
             +e.blocks
               +e.block
@@ -72,7 +72,7 @@ block body
                 +e.content
                   +e.select
                     select(name="制作の開始時期について")
-                      option(disabled, selected) ー以下から選択してくださいー
+                      option(disabled, selected) 選択してください
                       option(value="選択肢A") 選択肢A
                       option(value="選択肢B") 選択肢B
                       option(value="選択肢C") 選択肢C
@@ -86,7 +86,7 @@ block body
             +e.privacy
               label
                 input(type="checkbox", name="「個人情報保護の取り扱いに関するご確認」を確認する", value="確認しました")
-                +a("/privacy-policy/")(target="_blank") 個人情報保護方針
+                +a("/privacy-policy/")(target="_blank").u-text-link 個人情報保護方針
                 | の内容に同意する
 
             +e.submit

--- a/app/inc/mixins/_misc.pug
+++ b/app/inc/mixins/_misc.pug
@@ -190,7 +190,7 @@ mixin select-prefectures()
     <option value="沖縄県">沖縄県</option>
 
 mixin select-nums(name="age", start=18, end=50,selected="選択してください", unit)
-  select(name=name)
+  select(name=name)&attributes(attributes)
     option(disabled,selected) !{selected}
     - for (let i = start; i <= end; i++)
       <option value="#{i}">#{i}#{unit || ""}</option>


### PR DESCRIPTION
改善事項
https://www.notion.so/growgroup/26aeef14914a8042b43fffc968263b96

# 内容
新しいデフォルトスタイルに合わせてgg-styleguideを調整しました。

- スタイルの変更
    - l-page-headerを利用するように変更
    - フォーム項目等のテキストスタイルが、bodyのテキストスタイルを基本的に継承するように変更
    - `$form-controls-border-color` などが、デザインのスタイル `$border-base-color` などを継承するように変更 
    など
- 横列組(`+e.block.is-horizontal`) のデザインの適用
    - `span.c-forms__label.is-optional 任意` を追加

▼詳細
https://www.notion.so/growgroup/262eef14914a805f96aac8f04485bdf7

▼デモ
https://a-kobayashi.grgr.blue/test/gg-styleguide/form2025/contact/
確認画面の目安 : https://a-kobayashi.grgr.blue/test/gg-styleguide/form2025/contact/confirm/
完了画面の目安 : https://a-kobayashi.grgr.blue/test/gg-styleguide/form2025/contact/complete/

