### PR TITLE
print.scss : hide scroll-hint-icon

### DIFF
--- a/app/assets/scss/print.scss
+++ b/app/assets/scss/print.scss
@@ -41,4 +41,8 @@
     display: none;
   }
 
+  .scroll-hint-icon{
+    display: none;
+  }
+
 }


### PR DESCRIPTION
改善事項
https://www.notion.so/growgroup/CSS-scroll-hint-icon-2b7eef14914a8072a640cdabf5a75f7c

印刷時にscroll-hint-iconが必ず表示されてしまう問題を解消しました。

| before | after |
| ---- | ---- |
| <img width="1150" height="860" alt="CleanShot 2025-12-04-14 13 56" src="https://github.com/user-attachments/assets/45019d0e-b4b2-4375-afb7-4ff25565950e" /> | <img width="1314" height="859" alt="CleanShot 2025-12-04-14 14 34" src="https://github.com/user-attachments/assets/c1ec8a15-98b0-466c-833d-b241997990aa" /> |



