### PR TITLE
[add] block l-main_top / l-main_bottom

### DIFF
--- a/app/archive-twocolumns/index.pug
+++ b/app/archive-twocolumns/index.pug
@@ -18,6 +18,9 @@ block page_header
   })
   +c_breadcrumb()
 
+block l-main_top
+  //- ページ固有のコンテンツかつ2カラムの上に出したいコンテンツをここに記述
+
 block body
   section.l-section.is-md
     .l-container
@@ -99,3 +102,6 @@ block body
 
 block aside
   +l-aside-posts()
+
+block l-main_bottom
+  //- ページ固有のコンテンツかつ2カラムの下に出したいコンテンツをここに記述

--- a/app/inc/foundation/_base-twocolumn.pug
+++ b/app/inc/foundation/_base-twocolumn.pug
@@ -11,6 +11,7 @@ block layout
     block page_header
     block upper_main
     .l-main
+      block l-main_top
       .l-two-column(class=twoColumnAddClass)
         .l-two-column__main
           block body
@@ -18,6 +19,7 @@ block layout
         aside.l-two-column__side
           .l-aside
             block aside
+      block l-main_bottom
     +l_offer
     //block under_main
 

--- a/app/twocolumns/index.pug
+++ b/app/twocolumns/index.pug
@@ -18,6 +18,10 @@ block page_header
     })
   +c_breadcrumb()
 
+
+block l-main_top
+  //- ページ固有のコンテンツかつ2カラムの上に出したいコンテンツをここに記述
+
 block body
   section.l-section.is-md.is-bg-color
     .l-container
@@ -60,3 +64,6 @@ block body
 
 block aside
   +l-aside()
+
+block l-main_bottom
+  //- ページ固有のコンテンツかつ2カラムの下に出したいコンテンツをここに記述


### PR DESCRIPTION
https://www.notion.so/growgroup/2-l-main-WP-2c3eef14914a80c89ae8c4915c17b51e

WordPress固定ページ流し込みから除外するコンテンツ用の `upper_main` のブロック（以下の赤の方）とは別途、
固定ページ流し込みするコンテンツ用のブロックとして、

`l-main_top` `l-main_bottom` の追加
<img width="742" height="370" alt="image" src="https://github.com/user-attachments/assets/6e8b1f6c-f2e4-4cd3-a388-15c439023ef5" />
