### PR TITLE
[update] breadcrumb

### DIFF
--- a/app/inc/mixins/_breadcrumb.pug
+++ b/app/inc/mixins/_breadcrumb.pug
@@ -18,9 +18,9 @@ mixin c_breadcrumb(props, cache)
     - var linkedPath = cache.linkedPath + props.paths[cache.count].url + "/"
     span
       +a(linkedPath)=props.paths[cache.count].text
-      +c_breadcrumb_arrow()
-      //- 次のパンくずリスト要素を再帰的に処理
-      +c_breadcrumb({paths: props.paths}, {count: cache.count + 1, linkedPath: linkedPath})
+    +c_breadcrumb_arrow()
+    //- 次のパンくずリスト要素を再帰的に処理
+    +c_breadcrumb({paths: props.paths}, {count: cache.count + 1, linkedPath: linkedPath})
 
   else
     //- パンくずリストの最初の要素の場合
@@ -42,8 +42,8 @@ mixin c_breadcrumb(props, cache)
               //- パスが存在する場合は最初のパンくず要素を表示
               span
                 +a(`/${props.paths[0].url}/`)=props.paths[0].text
-                +c_breadcrumb_arrow()
-                //- 最初のリンクパスを設定
-                - var linkedPath = `/${props.paths[0].url}/`
-                //- 次のパンくずリスト要素を再帰的に処理
-                +c_breadcrumb({paths: props.paths}, {count: 1, linkedPath: linkedPath})
+              +c_breadcrumb_arrow()
+              //- 最初のリンクパスを設定
+              - var linkedPath = `/${props.paths[0].url}/`
+              //- 次のパンくずリスト要素を再帰的に処理
+              +c_breadcrumb({paths: props.paths}, {count: 1, linkedPath: linkedPath})

--- a/app/inc/mixins/_breadcrumb.pug
+++ b/app/inc/mixins/_breadcrumb.pug
@@ -32,18 +32,18 @@ mixin c_breadcrumb(props, cache)
             span
               //- トップへのリンク（最初の要素）
               +a("/") ホーム
-              +c_breadcrumb_arrow()
+            +c_breadcrumb_arrow()
 
-              if props === undefined ||props.paths === undefined ||!props.paths[0]
-                //- パスが存在しない場合は現在のページタイトルを表示
-                span=current.title
+            if props === undefined ||props.paths === undefined ||!props.paths[0]
+              //- パスが存在しない場合は現在のページタイトルを表示
+              span=current.title
 
-              else
-                //- パスが存在する場合は最初のパンくず要素を表示
-                span
-                  +a(`/${props.paths[0].url}/`)=props.paths[0].text
-                  +c_breadcrumb_arrow()
-                  //- 最初のリンクパスを設定
-                  - var linkedPath = `/${props.paths[0].url}/`
-                  //- 次のパンくずリスト要素を再帰的に処理
-                  +c_breadcrumb({paths: props.paths}, {count: 1, linkedPath: linkedPath})
+            else
+              //- パスが存在する場合は最初のパンくず要素を表示
+              span
+                +a(`/${props.paths[0].url}/`)=props.paths[0].text
+                +c_breadcrumb_arrow()
+                //- 最初のリンクパスを設定
+                - var linkedPath = `/${props.paths[0].url}/`
+                //- 次のパンくずリスト要素を再帰的に処理
+                +c_breadcrumb({paths: props.paths}, {count: 1, linkedPath: linkedPath})


### PR DESCRIPTION
▼改善事項
https://www.notion.so/growgroup/2ceeef14914a8051af80c5e4db80a7d5

# 内容
パンくずリスト内のHTMLの階層構造を調整しました。

# 修正前の状態
## 期待されるHTML構造
```
<div class="c-breadcrumb__inner">
  <span>
    <span>
      <a href="/">TOP</a>
    </span>
    <span class="is-arrow">
      <span class="c-icon-font">chevron_right</span>
    </span>
    <span>フォーマット</span>
  </span>
</div>
```

## 修正前
```
<div class="c-breadcrumb__inner">
  <span>
    <span>
      <a href="/">ホーム</a>
      <span class="is-arrow">
        <span class="c-icon-font">chevron_right</span>
      </span>
      <span>フォーマット</span>
    </span>
  </span>
</div>
```

# 修正後の状態
```
<div class="c-breadcrumb__inner">
  <span>
    <span>
      <a href="/">TOP</a>
    </span>
    <span class="is-arrow">
      <span class="c-icon-font">chevron_right</span>
    </span>
    <span>フォーマット</span>
  </span>
</div>
```


## 備考
いつからインデントがずれていたか不明ですが
2023年頃の時点ですでに以下の階層構造だったため、直近ずれたわけではないようです。

```
<div class="c-breadcrumb__inner">
  <span>
    <span>
      <a href="/">ホーム</a>
      <span class="is-arrow">
        <span class="material-icons-outlined">chevron_right</span>
      </span>
      <span>フォーマット</span>
    </span>
  </span>
</div>
```
