### PR TITLE
[update] postcss.config.js : admin-style.css

### DIFF
--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,3 +1,9 @@
+const selectorParser = require("postcss-selector-parser");
+
+const EDITOR_WRAPPER_ID = "growp-editor-wrapper";
+const EDITOR_WRAPPER_PREFIX = `#${EDITOR_WRAPPER_ID} `;
+const EXCLUSION_GUARD = ":where(:not(.acf-fields *):not(.components-placeholder *))";
+
 module.exports = (ctx) => ({
   plugins: {
     "postcss-pxtorem": {
@@ -13,14 +19,111 @@ module.exports = (ctx) => ({
     "postcss-prefix-selector":
       ctx.file.basename === "admin-style.css"
         ? {
-          prefix: "#growp-editor-wrapper ",
+          // :root以外に #growp-editor-wrapper を付与
+          prefix: EDITOR_WRAPPER_PREFIX,
           exclude: [":root"],
-          transform: function (prefix, selector, prefixedSelector) {
-            if (selector.includes("#growp-editor-wrapper")) {
-              return selector;
-            } else {
-              return prefixedSelector;
+          // タグ名単体またはタグ名[属性名]のみのセレクタに対して「祖先に.acf-fieldsまたは.components-placeholderがないときだけ」を付与
+          transform: function (prefix, selector) {
+            let hasEditorWrapper = false;
+
+            // セレクタをASTとして走査し、必要なものだけ除外ガードを付与する
+            const modifiedSelector = selectorParser((selectors) => {
+              // どこかに #growp-editor-wrapper が含まれているかを先に記録する
+              selectors.walkIds((idNode) => {
+                if (idNode.value === EDITOR_WRAPPER_ID) {
+                  hasEditorWrapper = true;
+                }
+              });
+
+              selectors.each((sel) => {
+                let alreadyScoped = false;
+                // 個々のセレクタが既に #growp-editor-wrapper 配下なら対象外
+                sel.walkIds((idNode) => {
+                  if (idNode.value === EDITOR_WRAPPER_ID) {
+                    alreadyScoped = true;
+                  }
+                });
+
+                // 既にスコープ済み、または同じ除外ガード付きなら何もしない
+                if (alreadyScoped || sel.toString().includes(EXCLUSION_GUARD)) {
+                  return;
+                }
+
+                // 複合セレクタをコンビネータ単位で分割し、単一compoundのみ対象にする
+                const compounds = [];
+                let currentCompound = [];
+
+                sel.each((node) => {
+                  if (node.type === "combinator") {
+                    if (currentCompound.length) {
+                      compounds.push(currentCompound);
+                      currentCompound = [];
+                    }
+                  } else {
+                    currentCompound.push(node);
+                  }
+                });
+                if (currentCompound.length) compounds.push(currentCompound);
+
+                if (compounds.length !== 1) {
+                  return;
+                }
+
+                // 対象にする形（* / ::before のみ / tag[attrs][::before]）かを判定
+                const compound = compounds[0];
+                const tagNodes = compound.filter((n) => n.type === "tag");
+                const hasClass = compound.some((n) => n.type === "class");
+                const pseudoElementIndex = compound.findIndex(
+                  (n) => n.type === "pseudo" && n.value && n.value.startsWith("::")
+                );
+                const isUniversal =
+                  compound.length === 1 && compound[0].type === "universal";
+                const isSinglePseudoElement =
+                  compound.length === 1 && pseudoElementIndex === 0;
+                const isTagWithOptionalAttributesAndPseudoElement =
+                  tagNodes.length === 1 &&
+                  !hasClass &&
+                  compound.every((n) => {
+                    if (n.type === "tag" || n.type === "attribute") {
+                      return true;
+                    }
+                    return (
+                      n.type === "pseudo" &&
+                      typeof n.value === "string" &&
+                      n.value.startsWith("::")
+                    );
+                  });
+                const shouldAppendGuard =
+                  isUniversal ||
+                  isSinglePseudoElement ||
+                  isTagWithOptionalAttributesAndPseudoElement;
+
+                if (!shouldAppendGuard) {
+                  return;
+                }
+
+                // 疑似要素があれば直前、なければ末尾に除外ガードを挿入
+                const guardPseudo = selectorParser.pseudo({ value: EXCLUSION_GUARD });
+
+                if (pseudoElementIndex > -1) {
+                  compound[pseudoElementIndex].parent.insertBefore(
+                    compound[pseudoElementIndex],
+                    guardPseudo
+                  );
+                  return;
+                }
+
+                const lastNode = compound[compound.length - 1];
+                lastNode.parent.insertAfter(lastNode, guardPseudo);
+              });
+            }).processSync(selector);
+
+            // 既に #growp-editor-wrapper を含む場合はそのまま返し、なければprefixを付与
+            if (hasEditorWrapper) {
+              return modifiedSelector;
             }
+
+            return prefix + modifiedSelector;
           },
         }
         : false,

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -25,6 +25,60 @@ module.exports = (ctx) => ({
           // タグ名単体またはタグ名[属性名]のみのセレクタに対して「祖先に.acf-fieldsまたは.components-placeholderがないときだけ」を付与
           transform: function (prefix, selector) {
             let hasEditorWrapper = false;
+            const isAttributeOnlyWherePseudo = (pseudoNode) => {
+              if (
+                pseudoNode.type !== "pseudo" ||
+                pseudoNode.value !== ":where" ||
+                !Array.isArray(pseudoNode.nodes) ||
+                pseudoNode.nodes.length === 0
+              ) {
+                return false;
+              }
+
+              return pseudoNode.nodes.every((innerSelector) => {
+                return (
+                  innerSelector.type === "selector" &&
+                  innerSelector.nodes.length > 0 &&
+                  innerSelector.nodes.every((innerNode) => innerNode.type === "attribute")
+                );
+              });
+            };
+            const isRootTagOnlySelector = (sel) => {
+              const compounds = [];
+              let currentCompound = [];
+
+              sel.each((node) => {
+                if (node.type === "combinator") {
+                  if (currentCompound.length) {
+                    compounds.push(currentCompound);
+                    currentCompound = [];
+                  }
+                } else {
+                  currentCompound.push(node);
+                }
+              });
+              if (currentCompound.length) compounds.push(currentCompound);
+              if (compounds.length !== 1) return false;
+
+              const compound = compounds[0];
+              const tagNodes = compound.filter((n) => n.type === "tag");
+              if (tagNodes.length !== 1) return false;
+
+              const tagName = tagNodes[0].value && tagNodes[0].value.toLowerCase();
+              if (tagName !== "html" && tagName !== "body") return false;
+
+              return compound.every((n) => {
+                if (
+                  n.type === "tag" ||
+                  n.type === "attribute" ||
+                  isAttributeOnlyWherePseudo(n) ||
+                  (n.type === "pseudo" && n.toString() === EXCLUSION_GUARD)
+                ) {
+                  return true;
+                }
+                return false;
+              });
+            };
 
             // セレクタをASTとして走査し、必要なものだけ除外ガードを付与する
             const modifiedSelector = selectorParser((selectors) => {
@@ -76,24 +130,6 @@ module.exports = (ctx) => ({
                 const pseudoElementIndex = compound.findIndex(
                   (n) => n.type === "pseudo" && n.value && n.value.startsWith("::")
                 );
-                const isAttributeOnlyWherePseudo = (pseudoNode) => {
-                  if (
-                    pseudoNode.type !== "pseudo" ||
-                    pseudoNode.value !== ":where" ||
-                    !Array.isArray(pseudoNode.nodes) ||
-                    pseudoNode.nodes.length === 0
-                  ) {
-                    return false;
-                  }
-
-                  return pseudoNode.nodes.every((innerSelector) => {
-                    return (
-                      innerSelector.type === "selector" &&
-                      innerSelector.nodes.length > 0 &&
-                      innerSelector.nodes.every((innerNode) => innerNode.type === "attribute")
-                    );
-                  });
-                };
                 const isUniversal =
                   compound.length === 1 && compound[0].type === "universal";
                 const isSinglePseudoElement =
@@ -140,12 +176,31 @@ module.exports = (ctx) => ({
               });
             }).processSync(selector);
 
+            // html/body 系は配下指定ではなくラッパー自体のセレクタに正規化する
+            const normalizedSelector = selectorParser((selectors) => {
+              selectors.each((sel) => {
+                if (!isRootTagOnlySelector(sel)) {
+                  return;
+                }
+                sel.removeAll();
+                sel.append(selectorParser.id({ value: EDITOR_WRAPPER_ID }));
+              });
+            }).processSync(modifiedSelector);
+
+            const hasEditorWrapperAfterNormalize = selectorParser((selectors) => {
+              selectors.walkIds((idNode) => {
+                if (idNode.value === EDITOR_WRAPPER_ID) {
+                  hasEditorWrapper = true;
+                }
+              });
+            }).processSync(normalizedSelector);
+
             // 既に #growp-editor-wrapper を含む場合はそのまま返し、なければprefixを付与
             if (hasEditorWrapper) {
-              return modifiedSelector;
+              return hasEditorWrapperAfterNormalize;
             }
 
-            return prefix + modifiedSelector;
+            return prefix + hasEditorWrapperAfterNormalize;
           },
         }
         : false,


### PR DESCRIPTION
▼改善事項
https://www.notion.so/growgroup/WP-admin-style-css-normalize-UI-303eef14914a80588d10d679bd5389e8

postcss.config.jsの「admin-style.cssに#growp-editor-wrapperを付ける」処理を調整し、
admin-style.cssにおいては
` .acf-fields` または`.components-placeholder` の子孫要素には
要素セレクタ（と[type=”text”]のようなセレクタ）が適用されなくなるようにしました。

▼戻し方
以下のコミットまで postcss.config.js を戻せば、元の挙動に戻せます
https://github.com/growgroup/gg-styleguide/blob/4db0e19a302b8c886474c3c19b9c7dcece59ec48/postcss.config.js