### PR TITLE
[update] mixin l_page_header :  tag option

### DIFF
--- a/app/archive-twocolumns/category/page/index.pug
+++ b/app/archive-twocolumns/category/page/index.pug
@@ -8,10 +8,12 @@ block append config
   - current.depth = 4 // ページの階層
 
 block page_header
+  //- 記事タイトルをh1にするのでページヘッダーはdivにする。未指定はh1になる
   +l_page_header({
     image: "img-page-header-format.jpg",
     title: "お知らせ",
-    subtitle: "news"
+    subtitle: "news",
+    tag: "div"
   })
   +c_breadcrumb({
       paths: [

--- a/app/inc/mixins/_page-header.pug
+++ b/app/inc/mixins/_page-header.pug
@@ -1,9 +1,15 @@
 //- ページヘッダー
 mixin l_page_header(data)
+  -
+    if (data.tag) {
+      var tag = data.tag
+    } else {
+      var tag = "h1"
+    }
   .l-page-header
     .l-page-header__image
       +img(data.image)
     .l-page-header__inner
       .l-page-header__subtitle !{data.subtitle}
-      h1.l-page-header__title !{data.title}
+      #{tag}.l-page-header__title !{data.title}
 

--- a/app/news/category/page/index.pug
+++ b/app/news/category/page/index.pug
@@ -8,10 +8,12 @@ block append config
   - current.depth = 4 // ページの階層
 
 block page_header
+  //- 記事タイトルをh1にするのでページヘッダーはdivにする。未指定はh1になる
   +l_page_header({
     image: "img-page-header-format.jpg",
     title: "お知らせ",
-    subtitle: "news"
+    subtitle: "news",
+    tag: "div"
   })
   +c_breadcrumb({
     paths: [


### PR DESCRIPTION
▼改善事項
https://www.notion.so/growgroup/l-page-header-pug-mixin-div-h1-2ffeef14914a80f6a12bf5eb0a573470

## 主な変更
以下のようにページのメインコンテンツのタイトルを `h1` とし、
l-page-headerは `div` にしたい時に
<img width="1556" height="606" alt="image" src="https://github.com/user-attachments/assets/4b385323-70c0-491d-89f8-1a2426002945" />

デフォルトの mixin l_page_headerのままでも `tag` を指定可能なように
指定可能なように mixin l_page_header側を更新しました。

```
  +l_page_header({
    image: "img-page-header-format.jpg",
    title: "お知らせ",
    subtitle: "news",
    tag: "div"
  })
```

## ついでに変更
/news/category/page/ および /archive-twocolumns/category/page/ のみ
以下の記述を設定しました

```
  //- 記事タイトルをh1にするのでページヘッダーはdivにする。未指定はh1になる
  +l_page_header({
    image: "img-page-header-format.jpg",
    title: "お知らせ",
    subtitle: "news",
    tag: "div"
  })
```