### PR TITLE
[update] modal.js : entry-modal

### DIFF
--- a/app/assets/js/app/modal.js
+++ b/app/assets/js/app/modal.js
@@ -6,7 +6,7 @@ import MicromodalWrapper from "./wrapperClasses/micromodalWrapper";
    *
    *
    * 【エントリーモーダルの使用方法】
-   * <div style="display: none" class="js-auto-entry-modal" id="entry-modal-content-01" data-entry-modal-id="entry-modal-02" data-entry-modal-type="content" data-entry-modal-src="#entry-modal-content-01" data-entry-modal-title="モーダルタイトル">
+   * <div style="display: none" class="js-auto-entry-modal" id="entry-modal-content-01" data-entry-modal-id="entry-modal-02" data-entry-modal-type="content" data-entry-modal-src="#entry-modal-content-01" data-entry-modal-title="モーダルタイトル" data-entry-modal-light-dismiss="false">
    * <p>モーダルコンテンツ</p>
    * </div>
    */
@@ -104,6 +104,7 @@ export default class modal {
     const modalType = target.dataset.entryModalType || "content";
     const modalSrc = target.dataset.entryModalSrc;
     const modalTitle = target.dataset.entryModalTitle || "Modal Window";
+    const lightDismiss = this.parseLightDismiss(target.dataset.entryModalLightDismiss);
 
     if (!modalId || !modalSrc || !this.micromodalWrapperInstance) return;
     if (this.isEntryModalDismissed(modalId)) return;
@@ -113,8 +114,14 @@ export default class modal {
       modalSrc,
       modalId,
       target,
-      modalTitle
+      modalTitle,
+      { lightDismiss }
     );
+  }
+
+  parseLightDismiss(value) {
+    if (value == null) return true;
+    return !["false", "0", "off"].includes(String(value).toLowerCase());
   }
 
 

--- a/app/assets/js/app/modal.js
+++ b/app/assets/js/app/modal.js
@@ -1,15 +1,27 @@
 import MicroModal from "micromodal";
 import MicromodalWrapper from "./wrapperClasses/micromodalWrapper";
 
+  /**
+   * 【モーダル使用方法】/format/ を参考にしてください
+   *
+   *
+   * 【エントリーモーダルの使用方法】
+   * <div style="display: none" class="js-auto-entry-modal" id="entry-modal-content-01" data-entry-modal-id="entry-modal-02" data-entry-modal-src="#entry-modal-content-01" data-entry-modal-title="モーダルタイトル">
+   * <p>モーダルコンテンツ</p>
+   * </div>
+   */
 
 let defaultOptions = {
   selector: ".js-modal",
+  autoEntryModalSelector: ".js-auto-entry-modal",
+  autoEntryModalStoragePrefix: "entryModalDismissed:",
 }
 
 export default class modal {
 
   constructor(options) {
     this.options = Object.assign(defaultOptions, options);
+    this.micromodalWrapperInstance = null;
     this.init();
   }
 
@@ -25,11 +37,15 @@ export default class modal {
    */
   run() {
     this.microModalWrapper();
+
+    this.bindEntryModalCloseStorage();//エントリーモーダル
+    this.setupAutoEntryModal();//エントリーモーダル
+
     // this.microModal();
   }
 
   microModalWrapper() {
-    new MicromodalWrapper({
+    this.micromodalWrapperInstance = new MicromodalWrapper({
       wrapper: {
         modalTrigger: ".js-modal",
         // galleryLoop: true,
@@ -37,6 +53,69 @@ export default class modal {
       }
     });
   }
+
+  /**
+   * 以降は【エントリーモーダル用】の関数群です
+   */
+  //【エントリーモーダル用】ストレージキーを取得
+  getEntryModalStorageKey(modalId) {
+    return `${this.options.autoEntryModalStoragePrefix}${modalId}`;
+  }
+
+  //【エントリーモーダル用】ストレージキーが存在するかを確認
+  isEntryModalDismissed(modalId) {
+    return sessionStorage.getItem(this.getEntryModalStorageKey(modalId)) === "1";
+  }
+
+  //【エントリーモーダル用】ストレージキーを設定
+  setEntryModalDismissed(modalId) {
+    sessionStorage.setItem(this.getEntryModalStorageKey(modalId), "1");
+  }
+
+  //【エントリーモーダル用】モーダルが閉じられた際にストレージキーを設定
+  bindEntryModalCloseStorage() {
+    document.addEventListener("modalClosed", (event) => {
+      const modalId = event?.detail?.modalId;
+      if (!modalId) return;
+      this.setEntryModalDismissed(modalId);
+    });
+  }
+
+  //【エントリーモーダル用】対象要素を取得し、モーダルをセットアップ
+  setupAutoEntryModal() {
+    const runAutoEntryModal = () => {
+      const targets = document.querySelectorAll(this.options.autoEntryModalSelector);
+      targets.forEach((target) => {
+        this.openAutoEntryModal(target);
+      });
+    };
+
+    if (document.readyState === "loading") {
+      document.addEventListener("DOMContentLoaded", runAutoEntryModal, { once: true });
+      return;
+    }
+
+    runAutoEntryModal();
+  }
+
+  //【エントリーモーダル用】モーダルを開く
+  openAutoEntryModal(target) {
+    const modalId = target.dataset.entryModalId;
+    const modalSrc = target.dataset.entryModalSrc;
+    const modalTitle = target.dataset.entryModalTitle || "Modal Window";
+
+    if (!modalId || !modalSrc || !this.micromodalWrapperInstance) return;
+    if (this.isEntryModalDismissed(modalId)) return;
+
+    this.micromodalWrapperInstance.createAndShowModal(
+      "content",
+      modalSrc,
+      modalId,
+      null,
+      modalTitle
+    );
+  }
+
 
   microModal() {
     //Micromodal.js本体をそのまま起動することも可能

--- a/app/assets/js/app/modal.js
+++ b/app/assets/js/app/modal.js
@@ -6,7 +6,7 @@ import MicromodalWrapper from "./wrapperClasses/micromodalWrapper";
    *
    *
    * 【エントリーモーダルの使用方法】
-   * <div style="display: none" class="js-auto-entry-modal" id="entry-modal-content-01" data-entry-modal-id="entry-modal-02" data-entry-modal-src="#entry-modal-content-01" data-entry-modal-title="モーダルタイトル">
+   * <div style="display: none" class="js-auto-entry-modal" id="entry-modal-content-01" data-entry-modal-id="entry-modal-02" data-entry-modal-type="content" data-entry-modal-src="#entry-modal-content-01" data-entry-modal-title="モーダルタイトル">
    * <p>モーダルコンテンツ</p>
    * </div>
    */
@@ -101,6 +101,7 @@ export default class modal {
   //【エントリーモーダル用】モーダルを開く
   openAutoEntryModal(target) {
     const modalId = target.dataset.entryModalId;
+    const modalType = target.dataset.entryModalType || "content";
     const modalSrc = target.dataset.entryModalSrc;
     const modalTitle = target.dataset.entryModalTitle || "Modal Window";
 
@@ -108,10 +109,10 @@ export default class modal {
     if (this.isEntryModalDismissed(modalId)) return;
 
     this.micromodalWrapperInstance.createAndShowModal(
-      "content",
+      modalType,
       modalSrc,
       modalId,
-      null,
+      target,
       modalTitle
     );
   }

--- a/app/assets/js/app/wrapperClasses/micromodalWrapper.js
+++ b/app/assets/js/app/wrapperClasses/micromodalWrapper.js
@@ -88,13 +88,19 @@ export default class MicromodalWrapper {
    * @param {string} id - モーダルのID
    * @param {string} content - モーダル内に表示するコンテンツ
    * @param {string} modalTitle - モーダルのタイトル
+   * @param {Object} modalOptions - モーダルの表示オプション
    */
-  createModalElement(id, content, modalTitle) {
+  createModalElement(id, content, modalTitle, modalOptions = {}) {
     const modalElement = document.createElement("div");
     modalElement.className = "c-mm";
     modalElement.id = id;
     modalElement.setAttribute("aria-hidden", "true");
-    modalElement.innerHTML = this.generateModalHTML(id, content, modalTitle);
+    modalElement.innerHTML = this.generateModalHTML(
+      id,
+      content,
+      modalTitle,
+      modalOptions
+    );
     document.body.appendChild(modalElement);
   }
 
@@ -103,11 +109,15 @@ export default class MicromodalWrapper {
    * @param {string} id - モーダルのID
    * @param {string} content - モーダル内に表示するコンテンツ
    * @param {string} modalTitle - モーダルのタイトル
+   * @param {Object} modalOptions - モーダルの表示オプション
    * @returns {string} 生成されたHTML文字列
    */
-  generateModalHTML(id, content, modalTitle) {
+  generateModalHTML(id, content, modalTitle, modalOptions = {}) {
+    const { lightDismiss = true } = modalOptions;
+    const overlayCloseAttribute = lightDismiss ? "data-micromodal-close" : "";
+
     return `
-      <div class="c-mm__overlay" tabindex="-1" data-micromodal-close>
+      <div class="c-mm__overlay" tabindex="-1" ${overlayCloseAttribute}>
         <div role="dialog" class="c-mm__container" aria-modal="true" aria-label="${modalTitle}">
           <button class="c-mm__close" aria-label="Close modal" data-micromodal-close></button>
           <div class="c-mm__container-inner" id="${id}-container-inner">
@@ -163,11 +173,12 @@ export default class MicromodalWrapper {
    * @param {string} modalId - モーダルのID
    * @param {HTMLElement} trigger - モーダルをトリガーする要素
    * @param {string} modalTitle - モーダルのタイトル
+   * @param {Object} modalOptions - モーダルの表示オプション
    */
-  createAndShowModal(type, href, modalId, trigger, modalTitle) {
+  createAndShowModal(type, href, modalId, trigger, modalTitle, modalOptions = {}) {
     const contentMap = {
       image: () =>
-        `<img src="${href}" alt="${trigger.textContent}" class="c-mm__img">`,
+        `<img src="${href}" alt="${trigger?.textContent || ""}" class="c-mm__img">`,
       youtube: () => this.createYouTubeEmbed(href),
       video: () => this.createVideoEmbed(href),
       iframe: () => `<iframe class="c-mm__iframe" src="${href}"></iframe>`,
@@ -184,7 +195,7 @@ export default class MicromodalWrapper {
     const content = contentFunction();
     if (!content) return; // コンテンツが無い場合は終了
 
-    this.createModalElement(modalId, content, modalTitle);
+    this.createModalElement(modalId, content, modalTitle, modalOptions);
     MicroModal.show(modalId, {
       ...this.micromodalOptions,
       onShow: (modal) => {

--- a/app/assets/js/app/wrapperClasses/micromodalWrapper.js
+++ b/app/assets/js/app/wrapperClasses/micromodalWrapper.js
@@ -159,11 +159,24 @@ export default class MicromodalWrapper {
     const modalId = `modal-${type}-${Math.random().toString(36).slice(2, 11)}`;
     const modalTitle =
       trigger.dataset.modalTitle || this.wrapperOptions.defaultModalTitle;
+    const lightDismiss = this.parseLightDismiss(trigger.dataset.modalLightDismiss);
 
     trigger.addEventListener("click", (e) => {
       e.preventDefault();
-      this.createAndShowModal(type, href, modalId, trigger, modalTitle);
+      this.createAndShowModal(
+        type,
+        href,
+        modalId,
+        trigger,
+        modalTitle,
+        { lightDismiss }
+      );
     });
+  }
+
+  parseLightDismiss(value) {
+    if (value == null) return true;
+    return !["false", "0", "off"].includes(String(value).toLowerCase());
   }
 
   /**

--- a/app/format/components/_modal.pug
+++ b/app/format/components/_modal.pug
@@ -1,3 +1,6 @@
+//- エントリーモーダル（ページを開いたときに表示されるモーダル）を利用したい場合は以下のコメントアウトを解除
+//- +entry-modal01()
+
 h3 画像モーダル
 +a("https://placehold.jp/300x250.png").c-modal-link.js-modal(data-modal-type="image")
   img(src='https://placehold.jp/300x250.png' alt='画像1')

--- a/app/format/components/_modal.pug
+++ b/app/format/components/_modal.pug
@@ -1,5 +1,5 @@
 //- エントリーモーダル（ページを開いたときに表示されるモーダル）を利用したい場合は以下のコメントアウトを解除
-+entry-modal01()
+//- +entry-modal01()
 
 h3 画像モーダル
 +a("https://placehold.jp/300x250.png").c-modal-link.js-modal(data-modal-type="image")

--- a/app/format/components/_modal.pug
+++ b/app/format/components/_modal.pug
@@ -1,5 +1,5 @@
 //- エントリーモーダル（ページを開いたときに表示されるモーダル）を利用したい場合は以下のコメントアウトを解除
-//- +entry-modal01()
++entry-modal01()
 
 h3 画像モーダル
 +a("https://placehold.jp/300x250.png").c-modal-link.js-modal(data-modal-type="image")

--- a/app/inc/mixins/_mixins.pug
+++ b/app/inc/mixins/_mixins.pug
@@ -17,3 +17,4 @@ include /inc/layout/_aside-posts.pug
 include /inc/mixins/_loader.pug
 include /inc/mixins/_pagination.pug
 include /inc/mixins/_searchform.pug
+include /inc/mixins/_modal.pug

--- a/app/inc/mixins/_modal.pug
+++ b/app/inc/mixins/_modal.pug
@@ -9,19 +9,6 @@ mixin entry-modal01()
     data-entry-modal-title="モーダルタイトル"
     data-entry-modal-light-dismiss="false"
   )
-    h2.c-heading.is-lg 医療関係者の確認
-    p
-      | ここからのページは、国内の医療関係者の方々（医師、看護師、臨床工学技士等）を対象に弊社の商品情報を提供するもので、一般の皆様に対する情報提供を目的としたものではないことをご了承ください。
-    h3.c-heading.is-md あなたは医療関係者ですか？
-    button.c-button(data-micromodal-close, type="button") はい
-    +a("/").c-button.is-secondary いいえ
+    +a("https://example.com")
+      +img("img-sample.jpg")
 
-mixin entry-modal02
-  //- エントリーモーダルサンプル02（imageタイプ）
-  #entry-modal-content-02.js-auto-entry-modal(
-    style="display: none"
-    data-entry-modal-id="entry-modal-02"
-    data-entry-modal-type="image"
-    data-entry-modal-src="https://placehold.jp/300x250.png"
-    data-entry-modal-title="画像モーダル"
-  )

--- a/app/inc/mixins/_modal.pug
+++ b/app/inc/mixins/_modal.pug
@@ -7,17 +7,21 @@ mixin entry-modal01()
     data-entry-modal-id="entry-modal-01"
     data-entry-modal-src="#entry-modal-content-01"
     data-entry-modal-title="モーダルタイトル"
+    data-entry-modal-light-dismiss="false"
   )
-    h2.c-heading.is-lg モーダルタイトル01
-    p モーダルコンテンツ
+    h2.c-heading.is-lg 医療関係者の確認
+    p
+      | ここからのページは、国内の医療関係者の方々（医師、看護師、臨床工学技士等）を対象に弊社の商品情報を提供するもので、一般の皆様に対する情報提供を目的としたものではないことをご了承ください。
+    h3.c-heading.is-md あなたは医療関係者ですか？
+    button.c-button(data-micromodal-close, type="button") はい
+    +a("/").c-button.is-secondary いいえ
 
 mixin entry-modal02
-  //- エントリーモーダルサンプル02
+  //- エントリーモーダルサンプル02（imageタイプ）
   #entry-modal-content-02.js-auto-entry-modal(
     style="display: none"
     data-entry-modal-id="entry-modal-02"
-    data-entry-modal-src="#entry-modal-content-02"
-    data-entry-modal-title="モーダルタイトル"
+    data-entry-modal-type="image"
+    data-entry-modal-src="https://placehold.jp/300x250.png"
+    data-entry-modal-title="画像モーダル"
   )
-    h2.c-heading.is-lg モーダルタイトル02
-    p モーダルコンテンツ

--- a/app/inc/mixins/_modal.pug
+++ b/app/inc/mixins/_modal.pug
@@ -1,0 +1,23 @@
+//- エントリーモーダル
+
+mixin entry-modal01()
+  //- エントリーモーダルサンプル01
+  #entry-modal-content-01.js-auto-entry-modal(
+    style="display: none"
+    data-entry-modal-id="entry-modal-01"
+    data-entry-modal-src="#entry-modal-content-01"
+    data-entry-modal-title="モーダルタイトル"
+  )
+    h2.c-heading.is-lg モーダルタイトル01
+    p モーダルコンテンツ
+
+mixin entry-modal02
+  //- エントリーモーダルサンプル02
+  #entry-modal-content-02.js-auto-entry-modal(
+    style="display: none"
+    data-entry-modal-id="entry-modal-02"
+    data-entry-modal-src="#entry-modal-content-02"
+    data-entry-modal-title="モーダルタイトル"
+  )
+    h2.c-heading.is-lg モーダルタイトル02
+    p モーダルコンテンツ


### PR DESCRIPTION
▼改善事項
https://www.notion.so/growgroup/9ad416aa31e14f06a7ab56b5294e0d4b

## 内容
- `window.GApp.modal.micromodalWrapperInstance.createAndShowModal("content", selector, modalId, null, "Modal Window")` のような形で、後工程でmodalを呼び出せるように調整しました
- エントリーモーダル（ページを開いたときに出るモーダル）用のスクリプトを追加しました（/format/にコメントアウト済み）
```
  #entry-modal-content-01.js-auto-entry-modal(
    style="display: none"
    data-entry-modal-id="entry-modal-01"
    data-entry-modal-src="#entry-modal-content-01"
    data-entry-modal-title="モーダルタイトル"
    data-entry-modal-light-dismiss="false"
  )
    +a("https://example.com")
      +img("img-sample.jpg")
```

※/format/の標準のモーダル群の動作に変更はありません


## 動作テスト01：セッションストレージの動作テスト
【モーダルID 01】
https://a-kobayashi.grgr.blue/test/gg-styleguide/entry-modal/test-01-01/
https://a-kobayashi.grgr.blue/test/gg-styleguide/entry-modal/test-01-02/

【モーダルID 02】
https://a-kobayashi.grgr.blue/test/gg-styleguide/entry-modal/test-02-01/
https://a-kobayashi.grgr.blue/test/gg-styleguide/entry-modal/test-02-02/

- /test-01-01/を開いたときモーダルを閉じなければ、/test-01-02/でもモーダルが開く
- /test-01-01/を開いたときモーダルを閉じたら、/test-01-02/ではモーダルが開かない
- /test-01-02/が開かないとき、/test-02-01/のモーダルは開く
- /test-02-01/を開いたときモーダルを閉じなければ、/test-02-02/でもモーダルが開く
- /test-02-01/を開いたときモーダルを閉じたら、/test-02-02/ではモーダルが開かない

## 動作テスト02：エントリーモーダルで、オーバーレイをクリックしたら閉じる（ライトディスミス）を無効にするテスト
https://a-kobayashi.grgr.blue/test/gg-styleguide/entry-modal/test-dissmiss/
- 「はい」と閉じるボタン以外では閉じられない。（実際にはこの文脈だと閉じるボタンは消した方が良いかもだが……）