### PR TITLE
[update] post-content style specificity

### DIFF
--- a/app/assets/scss/editor.scss
+++ b/app/assets/scss/editor.scss
@@ -6,7 +6,7 @@
 @import "foundation/_mixin";
 @import "foundation/_mixin-post-content";
 
-#tinymce {
+:where(#tinymce) {
   //min-width: $grid-row-width !important;
   margin-left: auto !important;
   margin-right: auto !important;
@@ -21,9 +21,9 @@
   }
 
 
-  &.post-type-post, //投稿画面
+  &:where(.post-type-post), //投稿画面
     //&.post-type-hoge, //他投稿タイプ
-  &.mce-content-body.acf_content //ACF tinyMce
+  &:where(.mce-content-body.acf_content) //ACF tinyMce
   {
     //max-width: 736px;
     @include l-post-content;
@@ -50,7 +50,7 @@
 #growp-editor-wrapper {
   font-family: $font-base-family !important;
 
-  &:is(.post-type-post,.growp-post-content) :is(.is-root-container,.mce-content-body) //投稿画面
+  &:where(.post-type-post,.growp-post-content) :where(.is-root-container,.mce-content-body) //投稿画面
   {
     //max-width: 736px;
     @include l-post-content;

--- a/app/assets/scss/foundation/_mixin-post-content.scss
+++ b/app/assets/scss/foundation/_mixin-post-content.scss
@@ -10,7 +10,9 @@
   display: flow-root;
   //word-break: break-all;
 
-  > * + * { //投稿内の各ブロックの間に1emのマージンを設定
+  > * + *:not(html) {
+    //:not(html)は詳細度を 0,0,1 にするための記述
+    //投稿内の各ブロックの間に1emのマージンを設定
     margin-top: 1em;
   }
 

--- a/app/assets/scss/foundation/_mixin-post-content.scss
+++ b/app/assets/scss/foundation/_mixin-post-content.scss
@@ -179,6 +179,10 @@
   }
 }
 
+@mixin text-small{
+  font-size: 0.85em;
+}
+
 // c-table
 @mixin c-table {
   width: 100%;

--- a/app/assets/scss/foundation/_normalize.scss
+++ b/app/assets/scss/foundation/_normalize.scss
@@ -189,7 +189,7 @@ h6 {
  */
 
 small {
-  font-size: 80%;
+  @include text-small();
 }
 
 /**
@@ -210,6 +210,18 @@ sup {
 
 sub {
   bottom: -0.25em;
+}
+
+p{
+  margin: 0;
+}
+
+strong{
+  font-weight: bold;
+}
+
+del{
+  text-decoration-line: line-through;
 }
 
 /* Embedded content

--- a/app/assets/scss/object/utility/text.scss
+++ b/app/assets/scss/object/utility/text.scss
@@ -6,7 +6,6 @@
 //
 // Styleguide 1.2.1
 
-p,
 .u-text-normal {
   margin: 0;
 }
@@ -15,9 +14,8 @@ p,
 //
 // Styleguide 1.2.2
 
-small,
 .u-text-small {
-  font-size: 0.85em;
+  @include text-small();
 }
 body.en{
   //small,
@@ -30,7 +28,6 @@ body.en{
 //
 // Styleguide 1.2.3
 
-strong,
 .u-text-strong {
   font-weight: 700;
 }
@@ -39,7 +36,6 @@ strong,
 //
 // Styleguide 1.2.4
 
-del,
 .u-text-del {
   text-decoration-line: line-through;
 }

--- a/app/assets/scss/wordpress/layout/post-content.scss
+++ b/app/assets/scss/wordpress/layout/post-content.scss
@@ -5,7 +5,7 @@
 
 @use "sass:math";
 
-.l-post-content {
+:where(.l-post-content) {
   // l-post-content 内のスタイルはすべてmixinに記述すること
   @include l-post-content;
 }


### PR DESCRIPTION
▼改善事項
https://www.notion.so/growgroup/l-post-content-32beef14914a807b838dda88dceb2482


## 概要
従来の .l-post-content a (0,1,1)にスタイルを当てる形式だと、
.c-button 単体(0,1,0)でCSSが勝てない問題の調整として、
:where(.l-post-content) a (0,0,1) にする施策

<img width="431" height="483" alt="image" src="https://github.com/user-attachments/assets/e52387a2-06fb-4f04-b4e2-507ec0edd5fd" />

