### PR TITLE
+c. を使用しているmixinにclassを渡す方法を(class=attributes.class)に変える

### DIFF
--- a/app/archive-twocolumns/category/index.pug
+++ b/app/archive-twocolumns/category/index.pug
@@ -85,7 +85,7 @@ block body
               +e.date 2018.06.01
             +e.title お知らせの投稿タイトルがここに入ります。
             +e.excerpt 簡単な説明テキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキスト＜続きを読む＞
-      +c_pagination("is-align-left")
+      +c_pagination().is-align-left
 
       +c.card-post.is-tag-hidden.u-mbs.is-top.is-lg
         +loop(4)

--- a/app/archive-twocolumns/index.pug
+++ b/app/archive-twocolumns/index.pug
@@ -86,7 +86,7 @@ block body
               +e.date 2018.06.01
             +e.title お知らせの投稿タイトルがここに入ります。
             +e.excerpt 簡単な説明テキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキスト＜続きを読む＞
-      +c_pagination("is-align-left")
+      +c_pagination().is-align-left
 
       +c.card-post.is-tag-hidden.u-mbs.is-top.is-lg
         +loop(4)

--- a/app/download/index.pug
+++ b/app/download/index.pug
@@ -18,13 +18,16 @@ block page_header
 block body
   section.l-section.is-lg.is-bg-color
     .l-container
-      +c_anchor-nav("u-mbs is-bottom",{
-        link: "#block01",
-        title: "タイトル1",
-      },{
-        link: "#block02",
-        title: "タイトル2",
-      })
+      +c_anchor-nav([
+        {
+          link: "#block01",
+          title: "タイトル1",
+        },
+        {
+          link: "#block02",
+          title: "タイトル2",
+        },
+      ]).u-mbs.is-bottom
       +c.card-download.u-mbs.is-top#block01
         +e.head.c-heading.is-sm.is-mg-level-4: b.is-main タイトル1
         +e.blocks

--- a/app/format/components/_buttons.pug
+++ b/app/format/components/_buttons.pug
@@ -16,31 +16,40 @@ div.u-mbs.is-bottom
 div.u-mbs.is-bottom
   +a("#").c-button.is-xs ボタンテキスト
 
-+c_anchor-nav("u-mbs is-bottom",{
-  link: "#section01",
-  title: "テキストテキスト",
-},{
-  link: "#section02",
-  title: "テキストテキスト",
-},{
-  link: "#section03",
-  title: "テキストテキスト",
-},{
-  link: "#section04",
-  title: "テキストテキスト",
-})
++c_anchor-nav([
+  {
+    link: "#section01",
+    title: "テキストテキスト",
+  },
+  {
+    link: "#section02",
+    title: "テキストテキスト",
+  },
+  {
+    link: "#section03",
+    title: "テキストテキスト",
+  },
+  {
+    link: "#section04",
+    title: "テキストテキスト",
+  }]).u-mbs.is-bottom
 
 section.l-section.is-sm
-  +c_relation("関連するコンテンツ",{
-    link: "/format/",
-    title: "テキストテキスト",
-  },{
-    link: "#",
-    title: "テキストテキスト",
-  },{
-    link: "#",
-    title: "テキストテキスト",
-  },{
-    link: "#",
-    title: "テキストテキスト",
-  })
+  +c_relation("関連するコンテンツ",[
+    {
+      link: "/format/",
+      title: "テキストテキスト",
+    },
+    {
+      link: "#",
+      title: "テキストテキスト",
+    },
+    {
+      link: "#",
+      title: "テキストテキスト",
+    },
+    {
+      link: "#",
+      title: "テキストテキスト",
+    }
+  ])

--- a/app/format/index.pug
+++ b/app/format/index.pug
@@ -19,39 +19,44 @@ block page_header
 block body
   section.l-section.is-lg
     .l-container
-      +c_anchor-nav("u-mbs is-bottom",{
-        link: "#text",
-        title: "テキスト",
-      },
-      {
-        link: "#heading",
-        title: "見出し",
-      },
-      {
-        link: "#hr",
-        title: "区切り線",
-      },
-      {
-        link: "#list",
-        title: "リスト",
-      },
-      {
-        link: "#table",
-        title: "テーブル",
-      },
-      {
-        link: "#button",
-        title: "ボタン",
-      },{
-        link: "#other",
-        title: "その他",
-      },{
-        link: "#tab",
-        title: "タブ",
-      },{
-        link: "#anchor-demo",
-        title: "アンカーのデモ",
-      })
+      +c_anchor-nav([
+        {
+          link: "#text",
+          title: "テキスト",
+        },
+        {
+          link: "#heading",
+          title: "見出し",
+        },
+        {
+          link: "#hr",
+          title: "区切り線",
+        },
+        {
+          link: "#list",
+          title: "リスト",
+        },
+        {
+          link: "#table",
+          title: "テーブル",
+        },
+        {
+          link: "#button",
+          title: "ボタン",
+        },
+        {
+          link: "#other",
+          title: "その他",
+        },
+        {
+          link: "#tab",
+          title: "タブ",
+        },
+        {
+          link: "#anchor-demo",
+          title: "アンカーのデモ",
+        },
+      ]).u-mbs.is-bottom
 
 
       h2#text テキスト

--- a/app/inc/mixins/_misc.pug
+++ b/app/inc/mixins/_misc.pug
@@ -99,16 +99,16 @@ mixin tr(th, td)
     th!= th
     td!= td
 
-mixin c_relation(title,...data)
-  +c.relation
+mixin c_relation(title,data)
+  +c.relation(class=attributes.class)
     .l-container
       +e.title.c-heading.is-sm.is-center !{title}
       +e.buttons
         each itemData in data
           +e.button: +a(itemData.link).c-button.is-xlg.is-primary.js-current-nav !{itemData.title}
 
-mixin c_anchor-nav(style,...data)
-  +c.anchor-nav(class=style)
+mixin c_anchor-nav(data)
+  +c.anchor-nav(class=attributes.class)
     +e.buttons
       each itemData in data
         +e.button: +a(itemData.link).c-button.is-nav.js-anchor !{itemData.title}

--- a/app/inc/mixins/_pagination.pug
+++ b/app/inc/mixins/_pagination.pug
@@ -1,6 +1,6 @@
 //- ページネーション
-mixin c_pagination(data)
-  +c.pagination(class=data)
+mixin c_pagination()
+  +c.pagination(class=attributes.class)
     ul.c-pagination__list
       li.c-pagination__prev: +a("#").c-pagination__num <span class="c-icon-font">chevron_left</span>
       li: span.c-pagination__num.is-current 1

--- a/app/news/index.pug
+++ b/app/news/index.pug
@@ -106,7 +106,7 @@ block body
                 +e.date 2018.06.01
               +e.title お知らせの投稿タイトルがここに入ります。
               +e.excerpt 簡単な説明テキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキスト＜続きを読む＞
-        +c_pagination("is-align-left")
+        +c_pagination().is-align-left
 
         +c.card-post.is-tag-hidden.u-mbs.is-top.is-lg
           +loop(4)

--- a/app/twocolumns/index.pug
+++ b/app/twocolumns/index.pug
@@ -26,19 +26,24 @@ block body
   section.l-section.is-md.is-bg-color
     .l-container
       h2.c-heading.is-lg.is-mg-level-6 セクションタイトル
-      +c_anchor-nav("u-mbs is-bottom",{
-        link: "#section01",
-        title: "テキストテキスト",
-      },{
-        link: "#section02",
-        title: "テキストテキスト",
-      },{
-        link: "#section03",
-        title: "テキストテキスト",
-      },{
-        link: "#section04",
-        title: "テキストテキスト",
-      })
+      +c_anchor-nav([
+        {
+          link: "#section01",
+          title: "テキストテキスト",
+        },
+        {
+          link: "#section02",
+          title: "テキストテキスト",
+        },
+        {
+          link: "#section03",
+          title: "テキストテキスト",
+        },
+        {
+          link: "#section04",
+          title: "テキストテキスト",
+        },
+      ]).u-mbs.is-bottom
       .u-mbs.is-sm
         p
           | 基本文章テキストです。基本文章テキストです。基本文章テキストです。基本文章テキストです。基本文章テキストです。基本文章テキストです。基本文章テキストです。基本文章テキストです。基本文章テキストです。基本文章テキストです。基本文章テキストです。基本文章テキストです。基本文章テキストです。基本文章テキストです。基本文章テキストです。基本文章テキストです。


### PR DESCRIPTION
▼改善事項
https://www.notion.so/growgroup/c-attributes-attributes-2d4eef14914a80b7a654e40d050d5d14

# 変更内容
mixinにclassを渡す方法が、「引数に渡すタイプ」と 「`+c_hoge().is-sm` のようにするタイプ」の2種類あったので
「`+c_hoge().is-sm` のようにするタイプ」に統一しました。

※ 引数部分を修正するついでに、 `...data` の引数を　`data` の引数に統一しました。

## 変更前
```
mixin c_anchor-nav(style,...data)
  +c.anchor-nav(class=style)
```

```
mixin c_pagination(data)
  +c.pagination(class=data)
```

## 変更後

```
mixin c_anchor-nav(data)
  +c.anchor-nav(class=attributes.class)

```

```
mixin c_pagination()
  +c.pagination(class=attributes.class)
```

# 補足
`+c.` は `&attributes(attributes)` を利用しようとするとエラーが出るため、
`(class=attributes.class)` で設定しています。　class以外も受け入れたい場合は変更が必要です。