### PR TITLE
[update] head.pug :  defer script

### DIFF
--- a/app/inc/foundation/_head.pug
+++ b/app/inc/foundation/_head.pug
@@ -57,7 +57,8 @@ html(lang="ja")
 
     //- ヘッダーに組み込むスクリプト
     block head_script
-      | <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.7.1/jquery.min.js"></script>
+      | <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.7.1/jquery.min.js" defer></script>
+      +script('/assets/js/app.js')(defer)
 
   body(class!=current.bodyClass)
     //- スマホメニュー
@@ -67,4 +68,4 @@ html(lang="ja")
 
     //- フッターに組み込むスクリプト
     block footer_scripts
-      +script('/assets/js/app.js')
+


### PR DESCRIPTION
▼改善事項
https://www.notion.so/growgroup/script-defer-284eef14914a807ca231ed077ea50a90

# やりたいこと
body最下部に入れるより、head内でdeferした方がfetchの分だけ少し早くscriptが実行されるので、
head内でdeferする方に変えたい。

<img width="1280" height="209" alt="image" src="https://github.com/user-attachments/assets/3e2e6970-3e36-4c85-a81a-d562bc1fee31" />

<img width="1280" height="338" alt="image" src="https://github.com/user-attachments/assets/df5f3838-8c44-4dc5-8f4b-4e6cc179a29d" />


引用元：https://qiita.com/NovaCat/items/dcbe2f9da646cd0a52fb

# どう変わるか
JSの動作的には、HTMLのパース後に発火するので大きな変化はありません。

ただページ個別のscriptを block append footer_scripts などで書いていると、
実行順が依然と変わる可能性があります。適宜 `DOMContentLoaded` などで実行順を制御しましょう。



## before
### head内
<img width="653" height="49" alt="image" src="https://github.com/user-attachments/assets/9641f42b-42e9-4d9b-a97f-86e940216954" />

### body閉じタグ直前
<img width="333" height="46" alt="image" src="https://github.com/user-attachments/assets/0cf314a0-c86b-4eeb-b8de-c27909c6f9a9" />



## after
### head内
<img width="670" height="85" alt="image" src="https://github.com/user-attachments/assets/92b07d50-2855-4595-849c-cea2079922bf" />

# 補足
pugで属性値を書くと `defer="defer"` で出力されます。
これはHTML上では `defer` と同じ意味です。
