### PR TITLE
[改善事項DB] $color-sns-twitter を $color-sns-xに変える

### DIFF
--- a/app/assets/scss/foundation/_settings.scss
+++ b/app/assets/scss/foundation/_settings.scss
@@ -46,7 +46,7 @@ $color-state-success: #13a83a !default; // 成功
 // # SNS color
 $color-sns-line: #00B900;
 $color-sns-facebook: #1877f2;
-$color-sns-twitter: #1DA1F2;
+$color-sns-x: #000;
 $color-sns-youtube: #DA1725;
 
 // # ファイル種別


### PR DESCRIPTION
## 改善
https://www.notion.so/growgroup/color-sns-twitter-color-sns-x-326eef14914a80ea95ddc52d515192bc?source=copy_link

## 修正内容
$color-sns-twitter を $color-sns-x に変更しました。
設定されているカラーもXのカラーコードに変更しました。