### PR TITLE
[改善事項DB] mixin select-nums()のunitに値を渡したときoptionのvalueにも入るようにしたい

### DIFF
--- a/app/inc/mixins/_misc.pug
+++ b/app/inc/mixins/_misc.pug
@@ -174,7 +174,7 @@ mixin select-nums(name="age", start=18, end=50,selected="選択してくださ�
   select(name=name)&attributes(attributes)
     option(disabled,selected) !{selected}
     - for (let i = start; i <= end; i++)
-      <option value="#{i}">#{i}#{unit || ""}</option>
+      <option value="#{i}#{unit || ''}">#{i}#{unit || ''}</option>
 
 mixin c_cookie
   +c.block-cookie.js-cookie#cookie


### PR DESCRIPTION
## 改善
https://www.notion.so/growgroup/mixin-select-nums-unit-option-value-31beef14914a80c19ffdf75089758636?source=copy_link

## 修正内容
app/inc/mixins/_misc.pug を編集

- unitに値を渡した時にvalueにもunitがつくようにしました。
