### PR TITLE
[update] swiper : pause sample / gallery sample

### DIFF
--- a/app/assets/js/app/swiper.js
+++ b/app/assets/js/app/swiper.js
@@ -77,6 +77,7 @@ export default class SwiperSlider {
       this.MainVisualSlider(); //->メインビジュアル
       this.runCardSlider(); //->カードスライダー
       this.documentSlider(); //->ドキュメントスライダー
+      this.galleryImageSlider(); //->ギャラリーイメージスライダー
     });
   }
 
@@ -101,6 +102,7 @@ export default class SwiperSlider {
     // const next = document.querySelector(targetSelector + '-next');
     const pagination = document.querySelector(targetSelector + '-pagination');
     const bar = document.querySelector(targetSelector + '-bar span');
+    const pause = document.querySelector(targetSelector + '-pause');
     const delayTime = 4000;
 
     const swiper = new Swiper(targetSelector, {
@@ -131,6 +133,22 @@ export default class SwiperSlider {
         },
       },
     });
+
+    //★ポーズボタン実装があるとき
+    if (pause) {
+      pause.addEventListener('click', () => {
+        if (!swiper || !swiper.autoplay) return;
+        if (swiper.autoplay.running) {
+          swiper.autoplay.stop();
+          pause.innerHTML = 'play';
+          pause.classList.add('is-active');
+        } else {
+          swiper.autoplay.start();
+          pause.innerHTML = 'pause';
+          pause.classList.remove('is-active');
+        }
+      });
+    }
   }
 
 
@@ -158,6 +176,13 @@ export default class SwiperSlider {
       loop: true,
       // loopedSlidesLimit:false, //スライドの複製を無制限にする
       // loopedSlides: 2, //スライドの複製数を指定する
+
+      //*ポーズボタンのサンプル用に自動再生を設定しています。要件になければ削除してください。
+      autoplay: {
+        delay: 4000,
+        disableOnInteraction: false,
+      },
+
       navigation: {
         nextEl: next,
         prevEl: prev,
@@ -219,6 +244,24 @@ export default class SwiperSlider {
           swiper = this.initCardSlider(slider, 4);
         }
       );
+
+      //★ポーズボタン実装があるとき
+      const pause = slider.querySelector('.js-card-slider-pause');
+      if (pause) {
+        pause.addEventListener('click', () => {
+          if (!swiper || !swiper.autoplay) return;
+          if (swiper.autoplay.running) {
+            swiper.autoplay.stop();
+            pause.innerHTML = 'play';
+            pause.classList.add('is-active');
+          } else {
+            pause.classList.remove('is-active');
+            pause.innerHTML = 'pause';
+            swiper.autoplay.start();
+          }
+        });
+      }
+
     });
   }
 
@@ -269,4 +312,117 @@ export default class SwiperSlider {
   }
 
 
+  // サムネイルもメイン部分も両方スライドするギャラリーのサンプル
+  galleryImageSlider() {
+    const mainMinSlides = 2;
+    const thumbnailMinSlides = 7;
+
+    const galleryGroupSelector = '.js-gallery-image-group';
+    const galleryGroup = document.querySelectorAll(galleryGroupSelector);
+
+    galleryGroup.forEach(group => {
+      const mainTarget = group.querySelector('.js-gallery-image-main');
+      const thumbnailTarget = group.querySelector('.js-gallery-image-thumbnail');
+      const mainPrev = group.querySelector('.js-gallery-image-main-prev');
+      const mainNext = group.querySelector('.js-gallery-image-main-next');
+      const thumbnailPrev = group.querySelector('.js-gallery-image-thumbnail-prev');
+      const thumbnailNext = group.querySelector('.js-gallery-image-thumbnail-next');
+      const mainTargetSlides = mainTarget.querySelectorAll('.swiper-slide');
+      const thumbnailTargetSlides = thumbnailTarget.querySelectorAll('.swiper-slide');
+      let thumbnailLoop = true;
+
+      //メインスライドが少ない場合はそもそも発火しない（サムネイルの方はまた別）
+      if (mainTargetSlides.length < mainMinSlides) {
+        return;
+      }
+
+
+      //メイン側のスライダーを初期化
+      const mainSwiper = new Swiper(mainTarget, {
+        speed: 500,
+        loop: true,
+        loopedSlides: mainTargetSlides.length,
+        slidesPerView: 1,
+        spaceBetween: 4,
+        threshold: 10,
+        navigation: {
+          nextEl: mainNext,
+          prevEl: mainPrev,
+        },
+      });
+
+
+      //サムネイル側のスライダーを初期化
+      if (thumbnailTargetSlides.length >= thumbnailMinSlides) {
+        const thumbnailSwiper = new Swiper(thumbnailTarget, {
+          speed: 500,
+          loop: thumbnailLoop,
+          threshold: 10,
+          slidesPerView: 6,
+
+          slideToClickedSlide: true,
+          spaceBetween: 4,
+          // centeredSlides: true,
+          loopedSlidesLimit: false, //スライドの複製を無制限にする
+          loopedSlides: mainTargetSlides.length, //メインスライダーと同じ複製数に設定
+          controller: {
+            control: mainSwiper,
+          },
+          navigation: {
+            nextEl: thumbnailNext,
+            prevEl: thumbnailPrev,
+          },
+        });
+
+        mainSwiper.controller.control = thumbnailSwiper;
+
+      }
+      else {
+        //サムネイルスライダーの1枚目にactiveクラスを付与する
+        thumbnailTargetSlides[0].classList.add('swiper-slide-active');
+
+        //サムネイルスライダーを初期化せずに、サムネイルリストをクリックしたらメインスライダーを切り替えるようにする
+        thumbnailTargetSlides.forEach((slide, index) => {
+          slide.addEventListener('click', () => {
+            mainSwiper.slideTo(index);
+            thumbnailTargetSlides.forEach((slide, index) => {
+              slide.classList.toggle('swiper-slide-active', index === current);
+            });
+          });
+        });
+        //メインスライダーが切り替わったらサムネイルスライダーを更新する
+        mainSwiper.on('slideChange', () => {
+          const current = mainSwiper.realIndex;
+          thumbnailTargetSlides.forEach((slide, index) => {
+            slide.classList.toggle('swiper-slide-active', index === current);
+          });
+        });
+      }
+
+      // 自動再生するタイプだともしかして以下いるかも
+      // サムネイルスライダーのスライドをクリックした時に実行
+      // thumbnailTarget.addEventListener('click', () => {
+      //   setTimeout(() => {
+      //     thumbnailSwiper.autoplay.start();
+      //   }, 3000);
+      // });
+
+      // メインスライダーを手動で切り替えた時に実行
+      // mainSwiper.on('touchEnd', () => {
+      //   slideChangePermit = true;
+      // });
+
+      // mainSwiper.on('slideChange', () => {
+      //   if (slideChangePermit) {
+      //     const current = mainSwiper.realIndex;
+      //     thumbnailSwiper.slideTo(current);
+      //     setTimeout(() => {
+      //       thumbnailSwiper.autoplay.start();
+      //     }, 3000);
+      //     slideChangePermit = false;
+      //   }
+      // });
+
+    });
+  }
 }

--- a/app/assets/scss/object/components/_index.scss
+++ b/app/assets/scss/object/components/_index.scss
@@ -17,12 +17,14 @@
 @import 'form-head';
 @import 'forms';
 @import 'forms-document-detail';
+@import 'gallery-image';
 @import 'gallery-logo';
 @import 'gallery-text';
 @import 'heading';
 @import 'hero-block-square';
 @import 'hr';
 @import 'icon-font';
+@import 'image-loop';
 @import 'label';
 @import 'lang-selector';
 @import 'lead';

--- a/app/assets/scss/object/components/gallery-image.scss
+++ b/app/assets/scss/object/components/gallery-image.scss
@@ -1,0 +1,215 @@
+.c-gallery-image {
+
+  //============================
+  // メインスライダー
+  //============================
+
+  &__main-slider-outer {
+    position: relative;
+  }
+
+  &__main-slider {
+
+
+  }
+
+
+  &__main-slider-item {}
+
+  &__main-slider-image {
+    aspect-ratio: 944 / 300;
+    overflow: hidden;
+
+    img {
+      @include img-option();
+    }
+  }
+
+  &__main-slider-caption {
+    margin-top: 8px;
+    font-size: 12px;
+  }
+
+  &__main-slider:not(.swiper-initialized) + &__main-slider-nav {
+    display: none;
+  }
+
+  &__main-slider-nav {
+    aspect-ratio: 944 / 300;//*メインスライダーのアスペクト比にあわせる
+    pointer-events: none;
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+  }
+
+  &__main-slider-prev,
+  &__main-slider-next {
+    pointer-events: auto;
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    margin: auto;
+    background-color: rgba($color-white, 0.5);
+    border: none;
+    border-radius: 4px;
+    width: 38px;
+    height: 148px;
+    display: grid;
+    place-items: center;
+    cursor: pointer;
+    z-index: 10;
+    @include transition-colors();
+
+    @include hover() {
+      background-color: rgba($color-white, 0.8);
+    }
+
+    @include breakpoint(small only) {
+      width: 38px;
+      height: 38px;
+      padding: 0;
+    }
+
+
+    &::before {
+      content: "chevron_right";
+      @include icon-font();
+      color: $color-primary;
+    }
+  }
+
+  &__main-slider-prev {
+    left: 0;
+
+    @include breakpoint(small only) {
+      left: -20px;
+    }
+
+    &::before {
+      transform: scaleX(-1);
+    }
+  }
+
+  &__main-slider-next {
+    right: 0;
+
+    @include breakpoint(small only) {
+      right: -20px;
+    }
+  }
+
+
+  //============================
+  // サムネイルスライダー
+  //============================
+
+  &__thumbnail-slider-outer {
+    margin-top: 20px;
+    display: flex;
+    align-items: center;
+    gap: 13px;
+
+    &:not(:has(.swiper-initialized)) {
+
+      .c-gallery-image__thumbnail-slider-prev,
+      .c-gallery-image__thumbnail-slider-next {
+        display: none;
+      }
+    }
+  }
+
+  &__thumbnail-slider {
+    width: calc(100% - 100px);
+    margin: 0;
+    order: 2;
+    padding:2px;
+
+    @include breakpoint(small down) {
+      max-width: 100%;
+      width: 100%;
+    }
+  }
+
+  &__thumbnail-slider-wrapper {
+    display: flex;
+    gap: 4px;
+
+    @at-root .swiper-initialized & {
+      gap: 0;
+    }
+  }
+
+  &__thumbnail-slider-item {
+    width: calc(100% / 6 - (4px / 6 * 5));/* 6枚のサムネイルを表示するための幅 */
+    cursor: pointer;
+    opacity: 0.7;
+    transition: opacity 0.4s;
+
+    &:hover {
+      opacity: 0.5;
+    }
+
+    @at-root .swiper-initialized & {
+      width: initial;
+    }
+
+    &.swiper-slide-active,
+    &.swiper-slide-duplicate-active {
+      opacity: 1;
+      box-shadow: 0 0 0 2px $color-black;
+    }
+  }
+
+  &__thumbnail-slider-image {
+    aspect-ratio: 120 / 60;
+    overflow: hidden;
+
+    @include breakpoint(small down) {
+      aspect-ratio: 4/3;
+    }
+
+    img {
+      @include img-option();
+    }
+  }
+
+  &__thumbnail-slider-prev,
+  &__thumbnail-slider-next {
+    @include breakpoint(small down) {
+      display: none;
+    }
+
+    &.swiper-button-lock {
+      display: none;
+    }
+  }
+
+  &__thumbnail-slider-prev,
+  &__thumbnail-slider-next {
+    width: 40px;
+    height: 40px;
+    border-radius: 4px;
+    cursor: pointer;
+    z-index: 10;
+
+    &::before {
+      content: "chevron_right";
+      @include icon-font();
+      color: $color-primary;
+    }
+
+  }
+
+  &__thumbnail-slider-prev {
+    order: 1;
+
+    &::before {
+      scale: -1 1;
+    }
+  }
+
+  &__thumbnail-slider-next {
+    order: 3;
+  }
+}

--- a/app/assets/scss/object/components/image-loop.scss
+++ b/app/assets/scss/object/components/image-loop.scss
@@ -1,0 +1,26 @@
+.c-image-loop {
+  width: 100%;
+  height: 400px;
+  container-type: inline-size;
+  .bg-img {
+    width: 100%;
+    height: 100%;
+    background-repeat: repeat-x;
+    background-size: 100% auto;
+    background-position: left center;
+    animation: image-loop 10s linear infinite;
+
+    //逆向きにしたいとき
+    // animation: image-loop 10s linear infinite reverse;
+  }
+}
+
+
+@keyframes image-loop {
+  0% {
+    background-position: left center;
+  }
+  100% {
+    background-position: left calc(-100cqw - 100%) center;
+  }
+}

--- a/app/format/components/_other.pug
+++ b/app/format/components/_other.pug
@@ -21,64 +21,6 @@ div.u-mbs.is-bottom
       },
     ])
 
-
-
-h3 カードスライダー
-div.u-mbs.is-bottom
-  +c.card.js-card-slider.swiper
-    +e.slider.swiper-wrapper
-      +e.block.swiper-slide
-        +e.image: +img("img-card-01.jpg","",712,420)
-        +e.content
-          h3.c-card__title スマホでスライダーになるサンプル
-          p.c-card__text ここにテキストが入ります。ここにテキストが入ります。ここにテキストが入ります。ここにテキストが入ります。ここにテキストが入ります。
-      +e.block.swiper-slide
-        +e.image: +img("img-card-01.jpg","",712,420)
-        +e.content
-          h3.c-card__title スマホでスライダーになるサンプル
-          p.c-card__text ここにテキストが入ります。ここにテキストが入ります。ここにテキストが入ります。ここにテキストが入ります。ここにテキストが入ります。
-
-    +e.slider-nav
-      +button.button-prev.js-card-slider-prev < 前へ
-      +button.button-next.js-card-slider-next > 次へ
-    +e.slider-pagination.js-card-slider-pagination
-div.u-mbs.is-bottom
-  +c.card.js-card-slider.swiper
-    +e.slider.swiper-wrapper
-      +e.block.swiper-slide
-        +e.image: +img("img-card-01.jpg","",712,420)
-        +e.content
-          h3.c-card__title スマホでスライダーになるサンプル
-          p.c-card__text ここにテキストが入ります。ここにテキストが入ります。ここにテキストが入ります。ここにテキストが入ります。ここにテキストが入ります。
-      +e.block.swiper-slide
-        +e.image: +img("img-card-01.jpg","",712,420)
-        +e.content
-          h3.c-card__title スマホでスライダーになるサンプル
-          p.c-card__text ここにテキストが入ります。ここにテキストが入ります。ここにテキストが入ります。ここにテキストが入ります。ここにテキストが入ります。
-
-    +e.slider-nav
-      +button.button-prev.js-card-slider-prev < 前へ
-      +button.button-next.js-card-slider-next > 次へ
-    +e.slider-pagination.js-card-slider-pagination
-
-  h3 横に流れ続けるスライダー
-  div.u-mbs.is-bottom
-    +c.gallery-text.js-infinite-slider(data-infinite-speed="10000")
-      +e.track.js-infinite-slider-track
-        +e.item TEXTGALLERY
-
-    +c.gallery-logo.js-infinite-slider(data-infinite-speed="5000")
-      +e.track.js-infinite-slider-track
-        for num in [1,2]
-          - var img = "https://placehold.jp/3d4070/ffffff/300x80.png?text=" + num + ".png"
-          +e.image: +img(img)
-
-    +c.gallery-logo.js-infinite-slider(data-infinite-speed="5000" data-infinite-direction="reverse")
-      +e.track.js-infinite-slider-track
-        for num in [1,2,3,4,5,6]
-          - var img = "https://placehold.jp/3d4070/ffffff/300x80.png?text=" + num + ".png"
-          +e.image: +img(img)
-
 h3 画面幅が狭いとき横スクロールする画像やテーブル
 
 div.u-mbs.is-bottom

--- a/app/format/components/_slider.pug
+++ b/app/format/components/_slider.pug
@@ -1,0 +1,82 @@
+h3 カードスライダー
+div.u-mbs.is-bottom
+  +c.card.js-card-slider.swiper
+    +e.slider.swiper-wrapper
+      +loop(4)
+        +e.block.swiper-slide
+          +e.image: +img("img-card-01.jpg","",712,420)
+          +e.content
+            h3.c-card__title 一次停止ボタンサンプル
+            p.c-card__text ここにテキストが入ります。ここにテキストが入ります。ここにテキストが入ります。ここにテキストが入ります。ここにテキストが入ります。
+
+    +e.slider-nav
+      +button.button-prev.js-card-slider-prev < 前へ
+      +button.button-next.js-card-slider-next > 次へ
+    +e.slider-pagination.js-card-slider-pagination
+    +button.button-pause.js-card-slider-pause pause
+
+div.u-mbs.is-bottom
+  +c.card.js-card-slider.swiper
+    +e.slider.swiper-wrapper
+      +loop(2)
+        +e.block.swiper-slide
+          +e.image: +img("img-card-01.jpg","",712,420)
+          +e.content
+            h3.c-card__title スマホでスライダーになるサンプル
+            p.c-card__text ここにテキストが入ります。ここにテキストが入ります。ここにテキストが入ります。ここにテキストが入ります。ここにテキストが入ります。
+
+    +e.slider-nav
+      +button.button-prev.js-card-slider-prev < 前へ
+      +button.button-next.js-card-slider-next > 次へ
+    +e.slider-pagination.js-card-slider-pagination
+
+  h3 横に流れ続けるスライダー（小さい画像やテキストを自動複製したいとき）
+  div.u-mbs.is-bottom
+    +c.gallery-text.js-infinite-slider(data-infinite-speed="10000")
+      +e.track.js-infinite-slider-track
+        +e.item TEXTGALLERY
+
+    +c.gallery-logo.js-infinite-slider(data-infinite-speed="5000")
+      +e.track.js-infinite-slider-track
+        for num in [1,2]
+          - var img = "https://placehold.jp/3d4070/ffffff/300x80.png?text=" + num + ".png"
+          +e.image: +img(img)
+
+    +c.gallery-logo.js-infinite-slider(data-infinite-speed="5000" data-infinite-direction="reverse")
+      +e.track.js-infinite-slider-track
+        for num in [1,2,3,4,5,6]
+          - var img = "https://placehold.jp/3d4070/ffffff/300x80.png?text=" + num + ".png"
+          +e.image: +img(img)
+
+h3 横に流れ続けるスライダー（大きい画像1点を動かしたいとき:CSS）
+div.u-mbs.is-bottom
+  +c.image-loop
+    +bgimg("img-sample.jpg").bg-img
+
+
+h3 サムネイル付きギャラリー
+.l-container.is-sm
+  +c.gallery-image.js-gallery-image-group
+    +e.main-slider-outer
+      +e.main-slider.swiper.js-gallery-image-main
+        +e.main-slider-wrapper.swiper-wrapper
+          +loop(7)
+            +e.main-slider-item.swiper-slide
+              +e.main-slider-image
+                +img("img-card-01.jpg")
+
+      +e.main-slider-nav
+        +button.main-slider-prev.js-gallery-image-main-prev(aria-label="前へ")
+        +button.main-slider-next.js-gallery-image-main-next(aria-label="次へ")
+
+    +e.thumbnail-slider-outer
+      +e.thumbnail-slider.swiper.js-gallery-image-thumbnail
+        +e.thumbnail-slider-wrapper.swiper-wrapper
+          +loop(7)
+            +e.thumbnail-slider-item.swiper-slide
+              +e.thumbnail-slider-image
+                +img("img-card-01.jpg")
+
+      +button.thumbnail-slider-prev.js-gallery-image-thumbnail-prev.c-button-icon.is-sm(aria-label="前へ")
+      +button.thumbnail-slider-next.js-gallery-image-thumbnail-next.c-button-icon.is-sm(aria-label="次へ")
+

--- a/app/format/index.pug
+++ b/app/format/index.pug
@@ -86,6 +86,7 @@ block body
 
       h2#other その他
       include /format/components/_other.pug
+      include /format/components/_slider.pug
       include /format/components/_modal.pug
 
 

--- a/app/inc/mixins/_main-visual.pug
+++ b/app/inc/mixins/_main-visual.pug
@@ -16,6 +16,7 @@ mixin c_main-visual
       +e.animation
         +e.bar.js-main-visual-bar: span
         +e.pagination.js-main-visual-pagination
+        +button.button-pause.js-main-visual-pause pause
       +e.inner
         .l-container
           +e.title: +img("img-main-visual-text.png","キャッチコピーが入ります",1048,118)


### PR DESCRIPTION
▼改善事項
https://www.notion.so/growgroup/Swiper-183eef14914a80f1bbd1f6f08f814e58

# 概要
スライダーのサンプルを追加しました

・TOP
https://a-kobayashi.grgr.blue/test/gg-styleguide/slider-sample/
<img width="469" height="239" alt="image (2)" src="https://github.com/user-attachments/assets/f8d938bb-8956-4c87-ba1e-d22561d23e11" />




・format
https://a-kobayashi.grgr.blue/test/gg-styleguide/slider-sample/format/#other

<img width="590" height="260" alt="image (3)" src="https://github.com/user-attachments/assets/953726fd-1268-461c-8940-344bb8e0198c" />
<img width="484" height="400" alt="image (4)" src="https://github.com/user-attachments/assets/562782da-2d76-466c-a6fc-7285f629a2ff" />

## 説明
### ポーズボタンのサンプル
メインビジュアル用と、カードのようなPC/SPで最小発火枚数が違うとき用で
書く場所が違うので2カ所に用意してあります。


### CSSで1枚の巨大画像を無限ループするときのやつ
巨大画像ループを、.js-infinite-sliderで実装すると挙動が重いのでCSS版もサンプルを足しました
https://github.com/growgroup/gg-styleguide/blob/fbbe9bdd066cd7982abf1b39cf120b6c773f35c5/app/format/components/_slider.pug#L51-L54

### サムネイル付きギャラリー
毎回なにかしら実装にハマりがちなので、比較的挙動が安定してるバージョンを暫定で置いてみました。