### PR TITLE
accordion.js : data属性の付き方 / title内のaタグ内のテキストを span 等で囲んだときの挙動

### DIFF
--- a/app/assets/js/app/accordion.js
+++ b/app/assets/js/app/accordion.js
@@ -93,11 +93,6 @@ export default class Accordion {
       } else {
         this.elementInit(target);
       }
-
-      // divかつfalseの時、データ属性を付与
-      if (!target.defaultOpen) {
-        target.attr("data-open", 'true');
-      }
     }
   }
 
@@ -121,11 +116,15 @@ export default class Accordion {
    * ターゲットの破棄
    */
   elementDestroy(target) {
-    target.attr("open", '');
+    if (target.isDetails) {
+      target.attr("open", '');
+    } else {
+      target.attr("data-open", "true");
+    }
 
     target.title.off('click');
     target.title.on('click', (e) => {
-      if (e.target.tagName.toLowerCase() === 'a') {
+      if (e.target.closest('a')) {
         return;
       }
       e.preventDefault(); // デフォルトの動作をキャンセル
@@ -154,6 +153,7 @@ export default class Accordion {
       } else {
         // 通常のアコーディオン (divなど)
         if (el.content.parent().attr("data-open")) {
+          console.log(el.content.parent().attr("data-open"));
           el.content.slideUp(this.options.speed, function () {
             $(this).parent().removeAttr("data-open").show();
           });


### PR DESCRIPTION
▼改善事項
https://www.notion.so/growgroup/js-accordion-details-data-open-328eef14914a8065b88ec65522d8efe0

## 修正したこと
- 閉じている `details.js-accordion` に不要な data-open 属性がついている問題の修正
-> data-open属性の付け外しの処理を調整しました

- `data-accordion-responsive="950"` などPCでアコーディオンを切っていても、
title の中の構造で aの直下にspan等を入れていると aがリンクとして機能しなくなる問題の修正
-> 判定方法を調整しました

## テスト方法
以下のコードが、それぞれ書いてあるとおりに動くようになっていればOK

```
details.js-accordion(open)
  summary(data-accordion-title="title")
    |クリックしたら閉じる動作が起きるパターン
  div(data-accordion-content="content")
    p
      |ページを開いた時点では open 属性がついている。
      br
      |クリックしたら open 属性が消える


details.js-accordion
  summary(data-accordion-title="title")
    |クリックしたら開く動作が起きるパターン
  div(data-accordion-content="content")
    p
      |ページを開いた時点では open 属性がついていない。
      br
      |クリックしたら open 属性がつく

.js-accordion(data-open="true")
  div(data-accordion-title="title")
    |クリックしたら閉じる動作が起きるパターン
  div(data-accordion-content="content")
    p
      |ページを開いた時点では data-open="true" 属性がついている。
      br
      |クリックしたら data-open="true" 属性が消える


.js-accordion
  div(data-accordion-title="title")
    |クリックしたら開く動作が起きるパターン
  div(data-accordion-content="content")
    p
      |ページを開いた時点では data-open="true" 属性がついていない。
      br
      |クリックしたら data-open="true" 属性がつく

.js-accordion(data-accordion-responsive="950")
  div(data-accordion-title="title")
    +a("/company/")
      span
        span PCではリンクが開く動作が起きるパターン
  div(data-accordion-content="content")
    p
      |PCでは data-open="true" 属性がついている。
      |スマホではページを開いた時点では data-open="true" 属性がついていない。
      br
      |PCではリンクが開く動作
      br
      |スマホではアコーディオンの動作
```