### PR TITLE
[update].c-button flexible width

### DIFF
--- a/app/assets/scss/object/components/buttons.scss
+++ b/app/assets/scss/object/components/buttons.scss
@@ -14,10 +14,11 @@ category: Buttons
   text-align: center;
   color: $color-white;
   text-decoration: none;
-  width: 100%;
-  max-width: 203px;
+  min-width: min(200px, 100%);
+  max-width: 100%;
   background-color: $color-primary;
-  padding: 13px 24px;
+  padding-block: 13px;
+  padding-inline: 13px 40px 13px 24px;
   border: 1px solid $color-primary;
   @include transition();
   // *アイコン
@@ -25,9 +26,10 @@ category: Buttons
     content: "chevron_right";
     @include icon-font();
     position: absolute;
-    top: 50%;
     right: 16px;
-    transform: translateY(-50%);
+    top: 0;
+    bottom: 0;
+    margin: auto;
   }
 
   // *hover
@@ -73,40 +75,30 @@ category: Buttons
   // サイズ設定
   // -> 大
   &.is-xlg {
-    max-width: 392px;
-    padding: 26px 32px;
+    padding: 26px 40px 26px 24px;
     font-size: 18px;
     @include breakpoint(small only) {
-      max-width: 100%;
-      font-size: 18px*0.9;
       padding: 20px 32px;
     }
 
     &::after {
       font-size: 24px;
-      @include breakpoint(small only) {
-        font-size: 24px*0.9;
-      }
     }
   }
 
   // -> 中
   &.is-lg {
-    max-width: 356px;
-    padding: 16px 24px;
+    padding: 16px 40px 16px 24px;
     @include breakpoint(small only) {
-      max-width: 100%;
     }
   }
 
   // -> 小
   &.is-sm {
-    max-width: 155px;
-    padding: 10px 18px;
+    min-width: 155px;
+    padding: 10px 40px 10px 24px;
     font-size: 14px;
-    letter-spacing: 0.1em;
     @include breakpoint(small only) {
-      font-size: 14px*0.9;
     }
 
     &::after {
@@ -116,16 +108,13 @@ category: Buttons
 
   // -> 極小
   &.is-xs {
-    width: inherit;
-    max-width: 100%;
+    min-width: fit-content;
     background-color: transparent;
     padding: 0 16px 0 0;
     border: none;
     color: $font-base-color;
     font-size: 14px;
-    letter-spacing: 0.1em;
     @include breakpoint(small only) {
-      font-size: 14px*0.9;
     }
 
     &::after {
@@ -143,19 +132,18 @@ category: Buttons
     color: $color-primary;
     background: $color-white;
     border: 1px solid $color-primary;
-    padding: 16px 24px;
-    max-width: 100%;
+    padding: 16px 40px 16px 24px;
     height: 100%;
+    width: 100%;
     border-radius: $border-radius;
 
     @include breakpoint(small only) {
-      padding: 12px 24px;
+      padding: 10px 40px 10px 24px;
     }
 
-    &:after {
+    &::after {
       content: "expand_more";
       right: 16px;
-      transform: translateY(-50%);
       font-size: 18px;
       line-height: 1;
 
@@ -172,8 +160,9 @@ category: Buttons
   }
 
   &.is-arrow-left {
+    padding: 16px 24px 16px 40px;
 
-    &:after {
+    &::after {
       content: "chevron_left";
       right: auto;
       left: 10px;


### PR DESCRIPTION
.c-buttonのwidthの書き方のデフォルトをmax-width固定ではなく「文字の長さにあわせて調整」指定パターンにする

▼改善事項DB
https://www.notion.so/growgroup/c-button-width-max-width-240eef14914a80c5b468d87a2b27c40c?v=3a1267a6dda7402eb247902fd1977c56&source=copy_link