### PR TITLE
[update]slidebar-menu.scss height

### DIFF
--- a/app/assets/scss/object/components/slidebar-menu.scss
+++ b/app/assets/scss/object/components/slidebar-menu.scss
@@ -6,8 +6,8 @@
 
 
 .c-slidebar-menu {
-  height: calc(100vh - #{$slidebar-header-height}px);
-  padding: 0 0 104px;
+  height: calc(100dvh - #{$slidebar-header-height}px);
+  padding: 0;
   position: fixed;
   background-color: $slidebar-menu-bg;
   z-index: 9980;


### PR DESCRIPTION
.c-slidebar-menu の 100vh ベースで計算してるところを 100dvh に変える

▼改善事項DB
https://www.notion.so/growgroup/c-slidebar-menu-100vh-100dvh-232eef14914a80609ed5c98a5abff798?v=3a1267a6dda7402eb247902fd1977c56&source=copy_link