### PR TITLE
@mixin c-list-ol 数値が10以上でも崩れないように

### DIFF
--- a/app/assets/scss/foundation/_mixin-post-content.scss
+++ b/app/assets/scss/foundation/_mixin-post-content.scss
@@ -301,31 +301,31 @@
 // c-list-ol （.c-list.is-outline）
 @mixin c-list-ol { //l-post-content 用に > が必要
   counter-reset: list-counter;
+  padding-left: 16px;
+
 
   > li {
-    padding-left: 16px;
-
     &::before {
       content: counter(list-counter) ".";
       counter-increment: list-counter;
-      width: 16px;
-      height: 1lh;
+      position: absolute;
+      translate: -100% 0;
     }
   }
 
   //l-post-content 用に > を使ったので ol > liも必要
   ol {
     counter-reset: list-counter;
+    padding-left: 16px;
 
     > li {
-      padding-left: 16px;
 
       &::before {
-        //content: counters(list-counter, "-")".";//2-1のようなカウンター用
+        // content: counters(list-counter, "-")".";//2-1のようなカウンター用
         content: counter(list-counter) ".";
         counter-increment: list-counter;
-        width: 16px;
-        height: 1lh;
+        position: absolute;
+        translate: -100% 0;
       }
     }
   }


### PR DESCRIPTION
▼改善事項
https://www.notion.so/growgroup/c-list-is-outline-10-25beef14914a80fe9f84e3fedca5bca2

## 概要
デフォルトのコードがolの数値が10以上に対応できていなかったので、10以上でも崩れないコードに変更
（ `::marker` ではなく `::before` を使っていることに変わりは無いです）

※ 実際の制作時には、デザインに応じて細かいスタイリングは適宜変更してください。

### 何をしたか
- `::before` のwidthを消す
- 位置を左端に移動するために`translate: -100% 0;` を使う
- ↑↑のためにpaddingをつける位置を `li` ではなく `ol` にする

|  before   |  after  | 
| --- | --- | 
|  <img width="186" height="383" alt="image" src="https://github.com/user-attachments/assets/741ee7af-4340-4215-8502-dc9df1281ed5" /> <img width="175" height="699" alt="image" src="https://github.com/user-attachments/assets/9500e619-d8d7-471a-9275-36504d60a8f2" />   |  <img width="221" height="393" alt="image" src="https://github.com/user-attachments/assets/0ec11ffd-3065-406d-8156-00dba55ef1a7" /> <img width="227" height="694" alt="image" src="https://github.com/user-attachments/assets/2434b1de-5fcd-45b2-829b-0ec7a84b1005" />   | 

▼テストコード
```
  .l-post-content
    ul
      li リスト1
      li リスト2
        ol
          li リスト2の子要素
          li リスト2の子要素
          li リスト2の子要素
          li リスト2の子要素
          li リスト2の子要素
          li リスト2の子要素
          li リスト2の子要素
          li リスト2の子要素
          li リスト2の子要素
          li リスト2の子要素

    ol
      li リスト1
      li リスト2
        ul
          li リスト2の子要素
          li リスト2の子要素
      li リスト3
      li リスト4
        ol
          li リスト4-1
          li リスト4-2
          li リスト4-3
          li リスト4-4
          li リスト4-5
          li リスト4-6
          li リスト4-7
          li リスト4-8
          li リスト4-9
          li リスト4-10
      li リスト5
      li リスト6
      li リスト7
      li リスト8
      li リスト9
      li リスト10
```