### PR TITLE
[add] c-note-list (for wp)

### DIFF
--- a/app/assets/scss/wordpress/components/_index.scss
+++ b/app/assets/scss/wordpress/components/_index.scss
@@ -1,4 +1,5 @@
 @import 'grid';
+@import 'note-list';
 @import 'post-password';
 @import 'search';
 @import 'search-result-aside';

--- a/app/assets/scss/wordpress/components/note-list.scss
+++ b/app/assets/scss/wordpress/components/note-list.scss
@@ -1,0 +1,36 @@
+.c-note-list {
+  padding-left: 1em;
+
+  li {
+    position: relative;
+
+    padding-left: initial; //* l-post-content内のul/ol用スタイルの打ち消し */
+
+    &::before {
+      content: "※";
+      position: absolute;
+      translate: -100% 0;
+
+      //* l-post-content内のul/ol用スタイルの打ち消し */
+      width: auto;
+      height: auto;
+      aspect-ratio: auto;
+      background-color: transparent;
+      border-radius: 0;
+      inset: initial;
+    }
+  }
+
+  &.is-number {
+    counter-reset: note-list;
+    padding-left: 1.8em;
+
+    li {
+      &::before {
+        content: "※" counter(note-list);
+        padding-right: 0.2em;
+        counter-increment: note-list;
+      }
+    }
+  }
+}

--- a/app/format/components/_list.pug
+++ b/app/format/components/_list.pug
@@ -50,3 +50,14 @@ div.u-mbs.is-bottom
           li リスト2の子要素
           li リスト2の子要素<br>リスト2
       li リスト2
+
+// 注釈リスト
+div.u-mbs.is-bottom
+  //- CSSは /wordpress/components/note-list.scss に記載
+  ul.c-note-list
+    li 注釈リスト
+    li テキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキスト
+div.u-mbs.is-bottom
+  ol.c-note-list.is-number
+    li 注釈リスト(番号付き)
+    li テキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキスト


### PR DESCRIPTION
▼改善事項
https://www.notion.so/growgroup/1-2-2-27eeef14914a80baabd5d96b50354b17

## 概要
注釈リストコンポーネントの追加

```
ul.c-note-list
  li 注釈リスト
  li テキストテキスト

ol.c-note-list.is-number
  li 注釈リスト(番号付き)
  li テキストテキストテキスト
```
<img width="383" height="185" alt="image" src="https://github.com/user-attachments/assets/3566157a-eb65-4589-a4ea-2d3c929506cf" />

## 備考
- HTML工程で未使用の場合でも、CSSを削除したくないため
CSSは /wordpress/components/note-list.scss に記載
- l-post-content内で使用することもあるかもなので、念のため打ち消し用のスタイル設定済み