### PR TITLE
[add] .u-text-accent

### DIFF
--- a/app/assets/scss/object/utility/text.scss
+++ b/app/assets/scss/object/utility/text.scss
@@ -88,7 +88,15 @@ body.en{
 
 // 用途別テキストカラー
 .u-text-primary {
+  //WordPress上のテキスト色変更機能でも使うため、class名は原則変更しない。
+  //色変数名はデザインに応じて変更してOK。
   color: $color-primary;
+}
+
+.u-text-accent {
+  //WordPress上のテキスト色変更機能でも使うため、class名は原則変更しない。
+  //色変数名はデザインに応じて変更してOK。
+  color: $color-accent;
 }
 
 .u-text-danger {


### PR DESCRIPTION
▼改善事項
https://www.notion.so/growgroup/WP-u-text-accent-35eeef14914a809db16dde27e1ef3fb0

## 概要
- u-text-accent を追加
- u-text-primary / u-text-accent のふたつについて
HTML時点で使っていない場合でも、消さないようにしてほしいことが分かるようにする

https://github.com/growgroup/gg-styleguide/blob/e91adc61d0dfce354cf6730fcbade7bb18661370/app/assets/scss/object/utility/text.scss#L88-L101