### PR TITLE
[update] c-news-lg

### DIFF
--- a/app/archive-twocolumns/category/index.pug
+++ b/app/archive-twocolumns/category/index.pug
@@ -23,8 +23,8 @@ block page_header
 block body
   section.l-section.is-md
     .l-container
+      h2.c-heading.is-md.is-mg-level-2 すべて
       +c.news
-        h2.c-news__title.c-heading.is-md.is-line-under.is-color-primary すべて
         +e.content
           +e.block
             +e.block-content
@@ -77,14 +77,34 @@ block body
             li: +a("/archive-twocolumns/category/") 2019年01月
             li: +a("/archive-twocolumns/category/") 2019年01月
             li: +a("/archive-twocolumns/category/") 2019年01月
-      +c.news-lg.u-mbs.is-top.is-lg
-        +loop(5)
-          +a("/archive-twocolumns/category/page/").c-news-lg__block
-            +e.sup
-              +e.label.c-label.is-sm お知らせ
-              +e.date 2018.06.01
-            +e.title お知らせの投稿タイトルがここに入ります。
-            +e.excerpt 簡単な説明テキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキスト＜続きを読む＞
+      .u-mbs.is-top.is-lg
+      +c.news-lg
+        +c_news-lg__block([
+          {
+            url: "/news/category/page/",
+            date: "2022.01.01",
+            label: ["カテゴリ"],
+            title: "お知らせの投稿タイトルがここに入ります。",
+            excerpt: "簡単な説明テキストテキストテキストテキストテキストテキストテキストテキストテキストテキスト",
+            icon: "arrow_forward",
+          },
+          {
+            url: "/news/category/page/",
+            img: "img-sample.jpg",
+            date: "2022.01.01",
+            label: ["カテゴリ","カテゴリ2"],
+            title: "お知らせの投稿タイトルがここに入ります。",
+            excerpt: "簡単な説明テキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキスト",
+            icon: "arrow_forward",
+          },
+          {
+            date: "2022.01.01",
+            label: ["カテゴリ","カテゴリ2"],
+            title: "リンク無しのテスト",
+          },
+          undefined
+        ])
+
       +c_pagination().is-align-left
 
       +c.card-post.is-tag-hidden.u-mbs.is-top.is-lg

--- a/app/archive-twocolumns/category/page/index.pug
+++ b/app/archive-twocolumns/category/page/index.pug
@@ -148,23 +148,37 @@ block body
       hr.c-hr
       +c_post_nav("post-twocolumns")
       h3 関連コンテンツ
-      +c.news-lg.is-image-display
-        +a("#").c-news-lg__block
-          +e.image: +img("img-thumbnail-01.jpg")
-          +e.content
-            +e.sup
-              +e.label.c-label.is-sm お知らせ
-              +e.date 2018.06.01
-            +e.title お知らせの投稿タイトルがここに入ります。
-            +e.excerpt 本文内容の一文が抜粋されてここに掲載を行います。本文内容の一文が抜粋されてここに掲載を行います。本文内容の一文が抜粋されてここに掲載を行います。本…[続きを見る]
-        +a("#").c-news-lg__block
-          +e.image: +img("img-thumbnail-01.jpg")
-          +e.content
-            +e.sup
-              +e.label.c-label.is-sm お知らせ
-              +e.date 2018.06.01
-            +e.title お知らせの投稿タイトルがここに入ります。
-            +e.excerpt 本文内容の一文が抜粋されてここに掲載を行います。本文内容の一文が抜粋されてここに掲載を行います。本文内容の一文が抜粋されてここに掲載を行います。本…[続きを見る]
+      +c.news-lg
+        +c_news-lg__block([
+          {
+            url: "/archive-twocolumns/category/page/",
+            img: "img-sample.jpg",
+            date: "2022.01.01",
+            label: ["カテゴリ"],
+            title: "お知らせの投稿タイトルがここに入ります。",
+            excerpt: "簡単な説明テキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキスト",
+            icon: "arrow_forward",
+          },
+          {
+            url: "/archive-twocolumns/category/page/",
+            img: "img-sample.jpg",
+            date: "2022.01.01",
+            label: ["カテゴリ"],
+            title: "お知らせの投稿タイトルがここに入ります。",
+            excerpt: "簡単な説明テキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキスト",
+            icon: "arrow_forward",
+          },
+          {
+            url: "/archive-twocolumns/category/page/",
+            img: "img-sample.jpg",
+            date: "2022.01.01",
+            label: ["カテゴリ"],
+            title: "お知らせの投稿タイトルがここに入ります。",
+            excerpt: "簡単な説明テキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキスト",
+            icon: "arrow_forward",
+          }
+        ])
+
       div.u-mbs.is-top.is-lg
         +c.card-post.is-tag-hidden
           +loop(3)

--- a/app/archive-twocolumns/index.pug
+++ b/app/archive-twocolumns/index.pug
@@ -24,8 +24,9 @@ block l-main_top
 block body
   section.l-section.is-md
     .l-container
+      h2.c-heading.is-md.is-mg-level-2 すべて
+
       +c.news
-        h2.c-news__title.c-heading.is-md.is-line-under.is-color-primary すべて
         +e.content
           +e.block
             +e.block-content
@@ -78,14 +79,33 @@ block body
             li: +a("/news/category/") 2019年01月
             li: +a("/news/category/") 2019年01月
             li: +a("/news/category/") 2019年01月
-      +c.news-lg.u-mbs.is-top.is-lg
-        +loop(5)
-          +a("/news/category/page/").c-news-lg__block
-            +e.sup
-              +e.label.c-label.is-sm お知らせ
-              +e.date 2018.06.01
-            +e.title お知らせの投稿タイトルがここに入ります。
-            +e.excerpt 簡単な説明テキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキスト＜続きを読む＞
+      .u-mbs.is-top.is-lg
+      +c.news-lg
+        +c_news-lg__block([
+          {
+            url: "/news/category/page/",
+            date: "2022.01.01",
+            label: ["カテゴリ"],
+            title: "お知らせの投稿タイトルがここに入ります。",
+            excerpt: "簡単な説明テキストテキストテキストテキストテキストテキストテキストテキストテキストテキスト",
+            icon: "arrow_forward",
+          },
+          {
+            url: "/news/category/page/",
+            img: "img-sample.jpg",
+            date: "2022.01.01",
+            label: ["カテゴリ","カテゴリ2"],
+            title: "お知らせの投稿タイトルがここに入ります。",
+            excerpt: "簡単な説明テキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキスト",
+            icon: "arrow_forward",
+          },
+          {
+            date: "2022.01.01",
+            label: ["カテゴリ","カテゴリ2"],
+            title: "リンク無しのテスト",
+          },
+          undefined
+        ])
       +c_pagination().is-align-left
 
       +c.card-post.is-tag-hidden.u-mbs.is-top.is-lg

--- a/app/assets/scss/object/components/news-lg.scss
+++ b/app/assets/scss/object/components/news-lg.scss
@@ -14,6 +14,7 @@ category: News
     @include breakpoint(small down) {
       padding: 16px 0;
       gap: 16px;
+      flex-direction: column;
     }
 
     &:first-child {
@@ -35,7 +36,9 @@ category: News
     aspect-ratio: 200/136;
 
     @include breakpoint(small down) {
-      width: 100px;
+      width: 100%;
+      max-width: 400px;
+      margin: 0 auto;
     }
 
     img {
@@ -46,6 +49,13 @@ category: News
   //============================
   // コンテンツ本体
   //============================
+
+  &__block-content-wrapper {
+    flex-grow: 1;
+    display: flex;
+    align-items: center;
+    gap: inherit;
+  }
 
   &__block-content {
     flex-grow: 1;

--- a/app/assets/scss/object/components/news-lg.scss
+++ b/app/assets/scss/object/components/news-lg.scss
@@ -6,40 +6,68 @@ category: News
 */
 .c-news-lg {
   &__block {
-    display: block;
-    text-decoration: none;
-    font-weight: 400;
-    color: $font-base-color;
+    display: flex;
+    align-items: flex-start;
     padding: 24px 0;
-    @include breakpoint(small only) {
+    gap: 24px;
+
+    @include breakpoint(small down) {
       padding: 16px 0;
+      gap: 16px;
     }
 
     &:first-child {
-      padding-top: 0;
+      // padding-top: 0;
     }
 
     @include hover() {
+      opacity: 1;
       background-color: $color-secondary;
     }
   }
 
-  &__sup {
-    display: flex;
-    align-items: center;
-    margin-bottom: 16px;
-    @include breakpoint(small only) {
-      margin-bottom: 8px;
+  //============================
+  // サムネイル
+  //============================
+  &__block-image {
+    width: calc(200/944 * 100%);
+    flex-shrink: 0;
+    aspect-ratio: 200/136;
+
+    @include breakpoint(small down) {
+      width: 100px;
+    }
+
+    img {
+      @include img-option();
     }
   }
 
-  &__label {
+  //============================
+  // コンテンツ本体
+  //============================
 
+  &__block-content {
+    flex-grow: 1;
   }
 
-  &__date {
+  &__block-data {
+    display: flex;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: 2px 8px;
+    margin-bottom: 8px;
+  }
+
+  &__block-label {
+    display: flex;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: 2px 4px;
+  }
+
+  &__block-date {
     @include news-date();
-    margin-left: 12px;
 
     &::before {
       content: "schedule";
@@ -49,36 +77,26 @@ category: News
     }
   }
 
-  &__title {
+  &__block-text {
     font-size: 24px;
-    margin-bottom: 8px;
     line-height: 1.5;
-    @include breakpoint(small only) {
+    margin-bottom: 8px;
+    @include breakpoint(small down) {
       font-size: 18px;
       margin-bottom: 4px;
     }
   }
 
-  &__excerpt {
+  &__block-excerpt {
     font-size: 12px;
   }
 
-  // サムネイル有り
-  &.is-image-display {
-    .c-news-lg__block {
-      display: flex;
-      align-items: flex-start;
-      border-bottom: 1px solid $border-base-color;
-    }
-
-    .c-news-lg__image {
-      width: 136px;
-      flex-shrink: 0;
-      margin-right: 24px;
-      @include breakpoint(small only) {
-        width: 100px;
-        margin-right: 24px;
-      }
-    }
+  //============================
+  // アイコン
+  //============================
+  &__block-icon {
+    flex-shrink: 0;
+    align-self: center;
+    text-align: center;
   }
 }

--- a/app/inc/mixins/_misc.pug
+++ b/app/inc/mixins/_misc.pug
@@ -63,28 +63,30 @@ mixin c_news-lg__block(data)
       +ae(item.url).block
         if item.img
           +e.block-image: +img(item.img)
-        +e.block-content
-          +e.block-data
-            +e.block-date !{item.date}
-            +e.block-label
-              each label in item.label
-                span.c-label !{label}
-          +e.block-text !{item.title}
-          +e.block-excerpt !{item.excerpt}
-        +e.block-icon
-          span.c-icon-font !{item.icon}
+        +e.block-content-wrapper
+          +e.block-content
+            +e.block-data
+              +e.block-date !{item.date}
+              +e.block-label
+                each label in item.label
+                  span.c-label !{label}
+            +e.block-text !{item.title}
+            +e.block-excerpt !{item.excerpt}
+          +e.block-icon
+            span.c-icon-font !{item.icon}
     else
       +e.block
         if item.img
           +e.block-image: +img(item.img)
-        +e.block-content
-          +e.block-data
-            +e.block-date !{item.date}
-            +e.block-label
-              each label in item.label
-                span.c-label !{label}
-          +e.block-text !{item.title}
-          +e.block-excerpt !{item.excerpt}
+        +e.block-content-wrapper
+          +e.block-content
+            +e.block-data
+              +e.block-date !{item.date}
+              +e.block-label
+                each label in item.label
+                  span.c-label !{label}
+            +e.block-text !{item.title}
+            +e.block-excerpt !{item.excerpt}
 
 
 

--- a/app/inc/mixins/_misc.pug
+++ b/app/inc/mixins/_misc.pug
@@ -46,6 +46,48 @@ mixin c_news__block(data)
         +e.block-icon
           span.c-icon-font !{item.icon}
 
+mixin c_news-lg__block(data)
+  each item in data
+    -
+      if (typeof item === "undefined"){
+        var item = {
+          url: "/news/category/page/",
+          date: "2022.01.01",
+          label: ["カテゴリ"],
+          title: "お知らせの投稿タイトルがここに入ります。お知らせの投稿タイトルがここに入ります。お知らせの投稿タイトルがここに入ります。",
+          excerpt: "簡単な説明テキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキスト",
+          icon: "arrow_forward",
+        }
+      }
+    if item.url
+      +ae(item.url).block
+        if item.img
+          +e.block-image: +img(item.img)
+        +e.block-content
+          +e.block-data
+            +e.block-date !{item.date}
+            +e.block-label
+              each label in item.label
+                span.c-label !{label}
+          +e.block-text !{item.title}
+          +e.block-excerpt !{item.excerpt}
+        +e.block-icon
+          span.c-icon-font !{item.icon}
+    else
+      +e.block
+        if item.img
+          +e.block-image: +img(item.img)
+        +e.block-content
+          +e.block-data
+            +e.block-date !{item.date}
+            +e.block-label
+              each label in item.label
+                span.c-label !{label}
+          +e.block-text !{item.title}
+          +e.block-excerpt !{item.excerpt}
+
+
+
 mixin select-prefectures(optgroup=false)
   -
     //- select-prefectures(optgroup=true) の場合は地域ごとにグループ表示

--- a/app/news/category/page/index.pug
+++ b/app/news/category/page/index.pug
@@ -154,23 +154,37 @@ block body
       hr.c-hr
       +c_post_nav("news")
       h3 関連コンテンツ
-      +c.news-lg.is-image-display
-        +a("#").c-news-lg__block
-          +e.image: +img("img-thumbnail-01.jpg")
-          +e.content
-            +e.sup
-              +e.label.c-label.is-sm お知らせ
-              +e.date 2018.06.01
-            +e.title お知らせの投稿タイトルがここに入ります。
-            +e.excerpt 本文内容の一文が抜粋されてここに掲載を行います。本文内容の一文が抜粋されてここに掲載を行います。本文内容の一文が抜粋されてここに掲載を行います。本…[続きを見る]
-        +a("#").c-news-lg__block
-          +e.image: +img("img-thumbnail-01.jpg")
-          +e.content
-            +e.sup
-              +e.label.c-label.is-sm お知らせ
-              +e.date 2018.06.01
-            +e.title お知らせの投稿タイトルがここに入ります。
-            +e.excerpt 本文内容の一文が抜粋されてここに掲載を行います。本文内容の一文が抜粋されてここに掲載を行います。本文内容の一文が抜粋されてここに掲載を行います。本…[続きを見る]
+      +c.news-lg
+        +c_news-lg__block([
+          {
+            url: "/news/category/page/",
+            img: "img-sample.jpg",
+            date: "2022.01.01",
+            label: ["カテゴリ"],
+            title: "お知らせの投稿タイトルがここに入ります。",
+            excerpt: "簡単な説明テキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキスト",
+            icon: "arrow_forward",
+          },
+          {
+            url: "/news/category/page/",
+            img: "img-sample.jpg",
+            date: "2022.01.01",
+            label: ["カテゴリ","カテゴリ2"],
+            title: "お知らせの投稿タイトルがここに入ります。",
+            excerpt: "簡単な説明テキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキスト",
+            icon: "arrow_forward",
+          },
+          {
+            url: "/news/category/page/",
+            img: "img-sample.jpg",
+            date: "2022.01.01",
+            label: ["カテゴリ"],
+            title: "お知らせの投稿タイトルがここに入ります。",
+            excerpt: "簡単な説明テキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキスト",
+            icon: "arrow_forward",
+          },
+        ])
+
       div.u-mbs.is-top.is-lg
         +c.card-post.is-tag-hidden
           +loop(3)

--- a/app/news/index.pug
+++ b/app/news/index.pug
@@ -98,14 +98,33 @@ block body
               li: +a("/news/category/") 2019年01月
               li: +a("/news/category/") 2019年01月
               li: +a("/news/category/") 2019年01月
-        +c.news-lg.u-mbs.is-top.is-lg
-          +loop(5)
-            +a("/news/category/page/").c-news-lg__block
-              +e.sup
-                +e.label.c-label.is-sm お知らせ
-                +e.date 2018.06.01
-              +e.title お知らせの投稿タイトルがここに入ります。
-              +e.excerpt 簡単な説明テキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキスト＜続きを読む＞
+        .u-mbs.is-top.is-lg
+        +c.news-lg
+          +c_news-lg__block([
+            {
+              url: "/news/category/page/",
+              date: "2022.01.01",
+              label: ["カテゴリ"],
+              title: "お知らせの投稿タイトルがここに入ります。",
+              excerpt: "簡単な説明テキストテキストテキストテキストテキストテキストテキストテキストテキストテキスト",
+              icon: "arrow_forward",
+            },
+            {
+              url: "/news/category/page/",
+              img: "img-sample.jpg",
+              date: "2022.01.01",
+              label: ["カテゴリ","カテゴリ2"],
+              title: "お知らせの投稿タイトルがここに入ります。",
+              excerpt: "簡単な説明テキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキスト",
+              icon: "arrow_forward",
+            },
+            {
+              date: "2022.01.01",
+              label: ["カテゴリ","カテゴリ2"],
+              title: "リンク無しのテスト",
+            },
+            undefined
+          ])
         +c_pagination().is-align-left
 
         +c.card-post.is-tag-hidden.u-mbs.is-top.is-lg


### PR DESCRIPTION
▼改善事項
https://www.notion.so/growgroup/c-news-lg-news-122eef14914a80138d1dddfbc0097cb1

## 概要
古い書き方になっていた c-news-lg を、今風の作りに全体的に調整。
※案件進行上そのまま使う必要はないコードだが、AIがコードベース全体を参照する可能性があるのでお掃除しているもの

## 詳細
- `c_news__block()` を参考にmixin化 -> `c_news-lg__block()`
- サムネイル画像の有無を `is-image-display` classで制御していたものを、追加class不要に変更
- カテゴリラベル複数設置前提のコードに調整
- 各flex内での余白制御をmargin -> gap に変更

## 注意点
- `c_news__block()` とは異なり、「ファイルリンク」に対応する仕様にはなっていないため、対応させる必要がある案件ではHTML / CSSの調整が必要です。