### PR TITLE
[update] c-card-download

### DIFF
--- a/app/assets/scss/object/components/card-download.scss
+++ b/app/assets/scss/object/components/card-download.scss
@@ -1,51 +1,19 @@
 .c-card-download {
 
-  &__head {
-
-    &.c-heading.is-md.is-border-bottom {
-      margin-bottom: 40px;
-
-      @include breakpoint(small only) {
-        margin-bottom: 24px;
-      }
-    }
-  }
-
   &__blocks {
-    display: flex;
-    flex-wrap: wrap;
-    margin: 0 -18px;
-
-    @include breakpoint(small only) {
-      display: block;
-      margin: 0;
-    }
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(min(400px, 100%), 1fr));
+    gap: 36px;
   }
 
   &__block {
     display: block;
-    text-decoration: none;
     color: $font-base-color;
-    width: calc(50% - 36px);
     background: $color-white;
     padding: 24px 24px 32px;
-    margin: 0 18px;
 
-    @include breakpoint(small only) {
-      width: 100%;
+    @include breakpoint(small down) {
       padding: 20px 20px 24px;
-      margin: 0;
-    }
-
-    &:nth-child(n + 3) {
-      margin-top: 32px;
-    }
-
-    &:not(:first-child) {
-
-      @include breakpoint(small only) {
-        margin-top: 24px;
-      }
     }
 
     @include hover() {
@@ -70,7 +38,7 @@
 
     img {
       @include img-option();
-      @include transition();
+      @include transition-transform();
     }
 
     .is-no {
@@ -81,7 +49,7 @@
       font-size: 17px;
       color: rgba($font-base-color,0.5);
 
-      @include breakpoint(small only) {
+      @include breakpoint(small down) {
         font-size: 14px;
       }
     }
@@ -96,7 +64,7 @@
   &__content {
     margin-top: 16px;
 
-    @include breakpoint(small only) {
+    @include breakpoint(small down) {
       margin-top: 12px;
     }
   }
@@ -110,51 +78,14 @@
 
     .c-button {
       max-width: 100%;
-      padding-top: 8px;
-      padding-bottom: 8px;
-
-      &:before {
-        content: none;
-      }
-
-      &:after {
-        transform: translateY(-50%);
-      }
     }
   }
 
 
   &.is-three-col {
 
-    .c-card-download__block {
-      width: calc(33.3% - 36px);
-      margin-top: 0;
-
-      @include breakpoint(medium down) {
-        width: calc(50% - 36px);
-      }
-
-      @include breakpoint(small only) {
-        width: 100%;
-      }
-
-      &:nth-child(n + 4) {
-        margin-top: 32px;
-      }
-
-      &:nth-child(n + 3) {
-
-        @include breakpoint(medium down) {
-          margin-top: 32px;
-        }
-      }
-
-      &:not(:first-child) {
-
-        @include breakpoint(small only) {
-          margin-top: 24px;
-        }
-      }
+    .c-card-download__blocks {
+      grid-template-columns: repeat(auto-fill, minmax(min(300px, 100%), 1fr));
     }
 
     .c-card-download__title {

--- a/app/download/index.pug
+++ b/app/download/index.pug
@@ -8,12 +8,12 @@ block append config
   - current.depth = 2 // ページの階層
 
 block page_header
-  //+l_page_header({
-  //  image: "img-page-header-format.jpg",
-  //  title: "量産ページ",
-  //  subtitle: "parent"
-  //})
-  //+c_breadcrumb()
+  //- +l_page_header({
+  //-  image: "img-page-header-format.jpg",
+  //-  title: "量産ページ",
+  //-  subtitle: "parent"
+  //-})
+  //- +c_breadcrumb()
 
 block body
   section.l-section.is-lg.is-bg-color

--- a/app/download/index.pug
+++ b/app/download/index.pug
@@ -27,9 +27,10 @@ block body
           link: "#block02",
           title: "タイトル2",
         },
-      ]).u-mbs.is-bottom
-      +c.card-download.u-mbs.is-top#block01
-        +e.head.c-heading.is-sm.is-mg-level-4: b.is-main タイトル1
+      ])
+      .u-mbs.is-top
+      h2.c-heading.is-sm.is-mg-level-4#block01 タイトル1
+      +c.card-download
         +e.blocks
           +loop(3)
             +ae("/download/page/").block
@@ -39,8 +40,9 @@ block body
               +e.content
                 +e.title.c-heading.is-xxs テキストテキスト
                 +e.button: .c-button テキストテキスト
-      +c.card-download.is-three-col.u-mbs.is-lg.is-top#block02
-        +e.head.c-heading.is-sm.is-mg-level-4: b.is-main タイトル2
+      .u-mbs.is-top
+      h2.c-heading.is-sm.is-mg-level-4#block02 タイトル2
+      +c.card-download.is-three-col
         +e.blocks
           +loop(6)
             +ae("/download/page/").block


### PR DESCRIPTION
▼改善事項
https://www.notion.so/growgroup/card-download-2ceeef14914a804bb9b7dae2a2dc2b5e

## 概要
c-card-downloadが gridおよび flexのgapが安定する以前の実装になっていたため、今風の作りに全体的に調整。
※案件進行上そのまま使う必要はないコードだが、AIがコードベース全体を参照する可能性があるのでお掃除しているもの

## 詳細
flex + margin で調整していたものを、grid + gap で組み直して不要な記述を削減しました。