### PR TITLE
[update] c-news-header

### DIFF
--- a/app/assets/scss/object/components/news-header.scss
+++ b/app/assets/scss/object/components/news-header.scss
@@ -6,7 +6,7 @@ category: PostContent
 */
 .c-news-header {
   margin-bottom: 32px;
-  @include breakpoint(small only) {
+  @include breakpoint(small down) {
     margin-bottom: 16px;
   }
 
@@ -17,7 +17,7 @@ category: PostContent
     line-height: 1.5;
     margin-bottom: 24px;
     margin-top: 0;
-    @include breakpoint(small only) {
+    @include breakpoint(small down) {
       font-size: 20px;
       margin-bottom: 16px;
     }
@@ -33,8 +33,13 @@ category: PostContent
     }
   }
 
-  &__label {
-
+  &__labels {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+    @include breakpoint(small down) {
+      gap: 4px;
+    }
   }
 
   &__date {
@@ -42,7 +47,9 @@ category: PostContent
   }
 
   &__tag {
-    @include breakpoint(small only) {
+    font-size: 14px;
+
+    @include breakpoint(small down) {
       width: 100%;
     }
 
@@ -51,16 +58,6 @@ category: PostContent
       flex-wrap: wrap;
       align-items: center;
       gap: 8px 16px;
-
-      li {
-
-        a {
-          text-decoration: none;
-          font-weight: 400;
-          font-size: 14px;
-          display: block;
-        }
-      }
     }
   }
 }

--- a/app/news/category/page/index.pug
+++ b/app/news/category/page/index.pug
@@ -28,8 +28,10 @@ block body
       +c.news-header
         h1.c-news-header__title ここに記事のタイトルが入ります。 ここに記事のタイトルが入ります。 ここに記事のタイトルが入ります。
         +e.sup
-          +e.label.c-label カテゴリ
           +e.date 2018.10.10
+          +e.labels
+            span.c-label カテゴリ1
+            span.c-label カテゴリ2
           +e.tag
             ul
               li: +a("#") #タグ


### PR DESCRIPTION
▼改善事項
https://www.notion.so/growgroup/c-news-header-35feef14914a8005ab1ec2675d974514


## 概要
c-news-header__supの中に直接c-news-header__label  c-labelを設置するコードになっているが、
結果的にカテゴリラベルを複数配置した場合にgapの入り方が絶妙におかしくなるため調整

## 詳細
`+e.label.c-label` の箇所を以下のように変えました。
https://github.com/growgroup/gg-styleguide/blob/2095b90ae7610c0bfb9faabb6fa0389518497e8d/app/news/category/page/index.pug#L32-L34

## 備考
ついでに
- [カテゴリ] [日付] の順がデフォルトでしたが、大抵 [日付] [カテゴリ]の順でデザインされてるため入れ替えました。
- `&__tag`の中のaにあてているCSSは要らなそう / 入れ子深すぎだったので調整しました。