### PR TITLE
[update] tab.js : url parameter

### DIFF
--- a/app/assets/js/app/tab.js
+++ b/app/assets/js/app/tab.js
@@ -7,6 +7,9 @@
  * ====================================================================
  */
 
+import Utils from "./utils";
+
+const utils = new Utils();
 
 var defaultOptions = {
   selector: '.js-tabs', // 実行するタブを包括するセレクタ
@@ -14,14 +17,15 @@ var defaultOptions = {
   navsClass: '.c-tabs__navs,.js-tabs-nav', // ナビゲーションのクラス
   navTargetAttr: 'data-tab-target',
   paneNameAttr: 'data-tab-name',
-  paneClass: '.c-tabs__content,.js-tabs-content'
+  paneClass: '.c-tabs__content,.js-tabs-content',
+  tabParam: 'tabID',
 };
 
 export default class Tab {
 
   constructor(options) {
     this.$tabs = null;
-    this.options = $.extend(options, defaultOptions);
+    this.options = $.extend({}, defaultOptions, options);
     this.init();
   }
 
@@ -29,6 +33,9 @@ export default class Tab {
    * 初期化
    */
   init() {
+    // クエリパラメータからタブIDを取得
+    const tabID = utils.getQueryString(this.options.tabParam);
+
     this.$tabs = $(this.options.selector);
     for (var i = 0; i < this.$tabs.length; i++) {
       var $tab = $(this.$tabs[i]);
@@ -42,6 +49,12 @@ export default class Tab {
       if (!$panes.hasClass(this.options.activeClass)) {
         $panes.eq(0).addClass(this.options.activeClass);
       }
+
+      // クエリパラメータがある場合はそのIDを開く
+      if (tabID !== false) {
+        this.openPanel(tabID, $navs, $panes);
+      }
+
       this.onClick($navs, $panes);
     }
   }
@@ -53,16 +66,55 @@ export default class Tab {
     var self = this;
     $navs.on('click', function(e) {
       e.preventDefault();
-      $panes.removeClass(self.options.activeClass);
-      $navs.removeClass(self.options.activeClass);
-      $(this).addClass(self.options.activeClass);
       var targetName = $(this).attr(self.options.navTargetAttr);
-      for (var i = 0; i < $panes.length; i++) {
-        if (targetName === $($panes[i]).attr(self.options.paneNameAttr)) {
-          $($panes[i]).addClass(self.options.activeClass);
-        }
-      }
+      self.openPanel(targetName, $navs, $panes, $(this));
     });
+  }
+
+  /**
+   * 指定したIDと一致するタブを開く（クリック時と同じ class の付け外し）
+   * @param {string} targetName タブID
+   * @param {object} $navs ナビゲーション
+   * @param {object} $panes パネル
+   * @param {object} [$clickedNav] クリックされたナビ。省略時は targetName に一致する先頭ナビを有効化
+   */
+  openPanel(targetName, $navs, $panes, $clickedNav) {
+    var activeClass = this.options.activeClass;
+    var navTargetAttr = this.options.navTargetAttr;
+    var paneNameAttr = this.options.paneNameAttr;
+
+    // クリック経路ならその要素だけ、クエリ経路なら targetName に一致する先頭ナビを取得
+    var $targetNav = $clickedNav && $clickedNav.length ? $clickedNav : $navs.filter(function() {
+      return $(this).attr(navTargetAttr) === targetName;
+    }).eq(0);
+    var hasTargetPane = false;
+
+    // 名前が一致するパネルがあるか確認
+    for (var i = 0; i < $panes.length; i++) {
+      if (targetName === $($panes[i]).attr(paneNameAttr)) {
+        hasTargetPane = true;
+        break;
+      }
+    }
+
+    // ナビゲーションかパネルがない場合は処理を中断
+    if (!$targetNav.length || !hasTargetPane) {
+      return;
+    }
+
+    // 全ナビとパネルからactiveを外す
+    $panes.removeClass(activeClass);
+    $navs.removeClass(activeClass);
+
+    // ターゲットのナビゲーションにactiveを付与
+    $targetNav.addClass(activeClass);
+
+    // ターゲット名と一致するパネルにactiveを付与
+    for (var j = 0; j < $panes.length; j++) {
+      if (targetName === $($panes[j]).attr(paneNameAttr)) {
+        $($panes[j]).addClass(activeClass);
+      }
+    }
   }
 
 }


### PR DESCRIPTION
▼改善事項
https://www.notion.so/growgroup/3417e28df1dc4c17b4361acd34762db2

## 概要
- [URLパラメーター?tabID=1などで別ページからのリンク時に特定のタブを開かせる](https://www.notion.so/growgroup/URL-tabID-1-1abeef14914a80aea364e8138dbb0142) のスニペットコードを汎用化して取り込み

## 動作テスト方法
1. /format/ページの中央辺りに以下を設置
```
      +c.tabs.js-tabs#paramtest
        ul.c-tabs__navs.js-tabs-nav
          li: +a("#").is-active(data-tab-target="0-0") タブ1
          li: +a("#")(data-tab-target="0-1") タブ2
        .c-tabs__content.is-active.js-tabs-content(data-tab-name="0-0")
          h3.u-text-center タブ1
        .c-tabs__content.js-tabs-content(data-tab-name="0-1")
          h3.u-text-center タブ2
          br
          br
          br
          #paramtest-content
            p aaa
```

2. 以下の通りになれば正しい
- http://localhost:3000/format/?tabID=0-1#paramtest
タブ2が展開し、#paramtest の位置でページが表示されている
- http://localhost:3000/format/?tabID=0-1#paramtest-content
タブ2が展開し、#paramtest-content の位置でページが表示されている

## 注意点
1ページに複数タブあっても動作しますが、
例えば`.js-tabs` が2つあるページで、どちらのタブでも `data-tab-name="1"` を使っていた場合
?tabID=1でアクセスすると、どちらのタブも  `data-tab-name="1"` がアクティブになります。

`data-tab-target` `data-tab-name` に指定する値はそのページ内で一意になるようにすることをおすすめします。

## 備考
タブ in タブの挙動がおかしい問題については変更せず、元と同じ挙動を維持しています。