### PR TITLE
[update] slidebar.js : bodyの高さが変わったときのキーボードフォーカスを抑制（最小限）

### DIFF
--- a/app/assets/js/app/slidebar.js
+++ b/app/assets/js/app/slidebar.js
@@ -114,6 +114,8 @@ export default class Slidebar {
   }
 
   close() {
+    if(!this.isActive) return;
+
     $("body").removeClass('is-slidebar-active');
     this.isActive = false;
     this.menu.attr("inert", "inert");


### PR DESCRIPTION
# 起きている問題
アコーディオンをキーボード操作で開閉した際に、キーボードフォーカスがbodyに移動している

# 原因と解決
slidebar.jsのキーボードフォーカス移動が、resizeObserverによってbodyのリサイズのたびに発火していることが原因。

`this.close();`内の動作はメニューが閉じているときは発火する必要が無いので、
`if(!this.isActive) return;`で早期リターンすることで、過剰な動作を抑制することで解決した

### 問題の動作
https://github.com/user-attachments/assets/20591c6f-46c8-4fa6-bd69-bdbcd4a08fe4


### 修正後の動作
https://github.com/user-attachments/assets/09519984-8236-482b-a8b4-4e2ad4e274b7

# 動作確認項目
- アコーディオンをキーボードで開閉した際に、キーボードフォーカスがbodyに移動しないこと
- スマホ幅でメニューを開いた後、メニューを開いたままPC幅に変更したとき、メニューが自動的に閉じてbodyがスクロール可能であること

# 備考
以下の課題も併せて直っている可能性がありますが、修正アプローチが異なるため要確認
https://app.notion.com/p/growgroup/slidebar-js-344eef14914a80b4b5fce3537f65b2ac