### PR TITLE
[update] upgrade Swiper v8 → v14 (security fix, v14 migration)

### DIFF
--- a/app/assets/js/app/swiper.js
+++ b/app/assets/js/app/swiper.js
@@ -1,27 +1,30 @@
-// core version + navigation, pagination modules:
-import Swiper, {
+// Swiper v9 以降、モジュールは 'swiper/modules' から読み込み、
+// 各インスタンスの modules オプションに渡す（v8 までの Swiper.use() は廃止）
+import Swiper from 'swiper';
+import {
   Navigation,
   Pagination,
   Autoplay,
   Controller,
   Keyboard,
   EffectFade,
+  Thumbs,
   // EffectCreative,
   // Scrollbar,
-  // Thumbs,
-} from 'swiper';
+} from 'swiper/modules';
 
-Swiper.use([
+// 各スライダーで利用するモジュール（new Swiper の modules オプションに渡す）
+const modules = [
   Pagination,
   Navigation,
   Autoplay,
   Controller,
   Keyboard,
   EffectFade,
+  Thumbs,
   // EffectCreative,
-  // Scrollbar,
-  // Thumbs
-]);
+  // Scrollbar
+];
 // import Swiper and modules styles
 import 'swiper/css';
 import 'swiper/css/autoplay';
@@ -106,6 +109,7 @@ export default class SwiperSlider {
     const delayTime = 4000;
 
     const swiper = new Swiper(targetSelector, {
+      modules,
       loop: true,
       //loopedSlidesLimit:false, //スライドの複製を無制限にする
       //loopedSlides: 2, //スライドの複製数を指定する
@@ -153,9 +157,44 @@ export default class SwiperSlider {
 
 
 
+  // ループに必要な枚数を満たすようスライドを複製する（v8 の loopedSlides 相当）。
+  // v14 のループは実スライドを並べ替える方式で、少数枚数＋見切れ表示では
+  // 左右の隣スライドが不足して端が空き、シームレスにループできない。
+  // そこで要件を満たすまで元スライドを丸ごと複製して補い、無限ループを成立させる。
+  prepareLoopSlides(target, minSlides) {
+    const wrapper = target.querySelector('.swiper-wrapper');
+    if (!wrapper) {
+      return;
+    }
+    // 既存の複製を除去してオリジナルだけに戻してから複製し直す（レスポンシブ再初期化での累積防止）
+    this.resetLoopSlides(target);
+    const originals = Array.from(wrapper.querySelectorAll('.swiper-slide'));
+    if (originals.length === 0 || originals.length >= minSlides) {
+      return;
+    }
+    // 末尾で同じスライドが隣り合わないよう、オリジナル枚数の倍数になるまで複製する
+    const multiple = Math.ceil(minSlides / originals.length);
+    for (let m = 1; m < multiple; m += 1) {
+      originals.forEach(slide => {
+        const clone = slide.cloneNode(true);
+        clone.setAttribute('data-card-slide-clone', '');
+        wrapper.appendChild(clone);
+      });
+    }
+  }
+
+  // prepareLoopSlides で追加した複製スライドを取り除く（オリジナルのみに戻す）
+  resetLoopSlides(target) {
+    const wrapper = target.querySelector('.swiper-wrapper');
+    if (!wrapper) {
+      return;
+    }
+    wrapper.querySelectorAll('[data-card-slide-clone]').forEach(el => el.remove());
+  }
+
   // スマホとPCで最低限必要なスライド数が異なる場合のサンプル
   //initとrunを分ける（init側は、スライダーの初期化のみを行う）
-  initCardSlider(target, minSlides) {
+  initCardSlider(target, minSlides, originalCount) {
     // ターゲット要素が存在しない場合、nullを返して処理を終了する
     if (!target) {
       return null;
@@ -171,11 +210,18 @@ export default class SwiperSlider {
       return null;
     }
 
+    // pagination を type:'custom' にするとコンテナに swiper-pagination-bullets が付かず、
+    // Swiper 標準CSSのドット間マージン（.swiper-pagination-bullets .swiper-pagination-bullet）が
+    // 効かなくなる。手動で付与して標準の余白を維持する。
+    if (pagination) {
+      pagination.classList.add('swiper-pagination-bullets');
+    }
+
     return new Swiper(target, {
+      modules,
       spaceBetween: 40,
+      // 枚数は呼び出し前に prepareLoopSlides で複製して確保しているため、常に無限ループさせる
       loop: true,
-      // loopedSlidesLimit:false, //スライドの複製を無制限にする
-      // loopedSlides: 2, //スライドの複製数を指定する
 
       //*ポーズボタンのサンプル用に自動再生を設定しています。要件になければ削除してください。
       autoplay: {
@@ -190,6 +236,19 @@ export default class SwiperSlider {
       pagination: {
         el: pagination,
         clickable: false,
+        // prepareLoopSlides で複製した分だけドットが増えてしまうため、
+        // 元スライド枚数（originalCount）だけドットを描画する。複製は同じ並びの
+        // 繰り返しなので realIndex % originalCount で対応する元スライドを特定できる。
+        type: 'custom',
+        renderCustom: (sw) => {
+          const count = originalCount || sw.slides.length;
+          const active = sw.realIndex % count;
+          let html = '';
+          for (let i = 0; i < count; i += 1) {
+            html += `<span class="swiper-pagination-bullet${i === active ? ' swiper-pagination-bullet-active' : ''}"></span>`;
+          }
+          return html;
+        },
       },
       threshold: 10, // allowTouchMoveがtrueのとき、スライド内のリンクがクリックできない問題の解決
       keyboard: {
@@ -202,10 +261,12 @@ export default class SwiperSlider {
           centeredSlides: true,
           spaceBetween: 16,
         },
-        950: {
+        750: {
           spaceBetween: 40,
           slidesPerView: 3,
-          loopAdditionalSlides: 3,
+          // v14 の loop は「slidesPerView + slidesPerGroup + loopAdditionalSlides」枚以上ないと
+          // 無効化される。loopAdditionalSlides を足すと必要枚数が増えるだけで、スライド数が
+          // 少ないと逆に loop が壊れる（「次へ」が途中で止まる）ため指定しない。
         }
       },
     });
@@ -217,16 +278,40 @@ export default class SwiperSlider {
     const targetSelector = '.js-card-slider';
     const sliders = document.querySelectorAll(targetSelector);
 
+    // v14 のループは「実スライド数 >= slidesPerView + loopedSlides」でないと成立しない。
+    // ブレークポイントで必要枚数が異なるため、満たない場合は prepareLoopSlides で
+    // スライドを複製してから初期化し、少数枚数でも見切れ表示のまま無限ループさせる。
+    //   - SP : slidesPerView 1.25 + centeredSlides → 5枚以上必要
+    //   - PC : slidesPerView 3                     → 4枚以上必要
+    const spLoopMinSlides = 5;
+    const pcLoopMinSlides = 4;
+
+    // スライダー化する最低枚数（これ未満はスライダーにせず素の表示のまま）
+    //   - SP : 2枚以上でスライダー化
+    //   - PC : 4枚以上でスライダー化（未満は 3カラムグリッド表示のまま）
+    const spMinSlides = 2;
+    const pcMinSlides = 4;
+
     sliders.forEach(slider => {
       let swiper = null;
+      // オリジナル枚数（複製前）。responsiveMatch より前に取得するのでクローンは含まない
+      const slideCount = slider.querySelectorAll('.swiper-slide').length;
 
       utils.responsiveMatch(
         // SP (mobile) の場合の処理
         () => {
           if (swiper) {
             swiper.destroy();
+            swiper = null;
           }
-          swiper = this.initCardSlider(slider, 2);
+          // SP の最低枚数に満たなければスライダー化しない
+          if (slideCount < spMinSlides) {
+            this.resetLoopSlides(slider);
+            return;
+          }
+          // 無限ループに必要な枚数まで複製してから初期化する
+          this.prepareLoopSlides(slider, spLoopMinSlides);
+          swiper = this.initCardSlider(slider, spMinSlides, slideCount);
           // ナビゲーション表示非表示方法参考
           //  &__slider-nav {
           //     display: none;
@@ -240,9 +325,18 @@ export default class SwiperSlider {
         () => {
           if (swiper) {
             swiper.destroy();
+            swiper = null;
           }
-          swiper = this.initCardSlider(slider, 4);
-        }
+          // PC の最低枚数未満はスライダー化しない（グリッド表示のまま）
+          // （.swiper-initialized が付かないため .c-card__slider は既定の 3カラムグリッド表示に戻る）
+          if (slideCount < pcMinSlides) {
+            this.resetLoopSlides(slider);
+            return;
+          }
+          // 無限ループに必要な枚数まで複製してから初期化する
+          this.prepareLoopSlides(slider, pcLoopMinSlides);
+          swiper = this.initCardSlider(slider, pcMinSlides, slideCount);
+        },
       );
 
       //★ポーズボタン実装があるとき
@@ -292,9 +386,8 @@ export default class SwiperSlider {
       const delayTime = 4000;
 
       const swiper = new Swiper(target, {
+        modules,
         loop: true,
-        //loopedSlidesLimit:false, //スライドの複製を無制限にする
-        //loopedSlides: 2, //スライドの複製数を指定する
         effect: 'slide',
         autoplay: {
           delay: delayTime, // ４秒後に次の画像へ
@@ -315,7 +408,6 @@ export default class SwiperSlider {
   // サムネイルもメイン部分も両方スライドするギャラリーのサンプル
   galleryImageSlider() {
     const mainMinSlides = 2;
-    const thumbnailMinSlides = 7;
 
     const galleryGroupSelector = '.js-gallery-image-group';
     const galleryGroup = document.querySelectorAll(galleryGroupSelector);
@@ -329,19 +421,42 @@ export default class SwiperSlider {
       const thumbnailNext = group.querySelector('.js-gallery-image-thumbnail-next');
       const mainTargetSlides = mainTarget.querySelectorAll('.swiper-slide');
       const thumbnailTargetSlides = thumbnailTarget.querySelectorAll('.swiper-slide');
-      let thumbnailLoop = true;
+      const thumbnailPerView = 6;
 
-      //メインスライドが少ない場合はそもそも発火しない（サムネイルの方はまた別）
+      //メインスライドが少ない場合はそもそも発火しない
       if (mainTargetSlides.length < mainMinSlides) {
         return;
       }
 
+      // v14 の loop は実スライドを動的に並べ替える方式（旧 loopedSlidesLimit のような
+      // 無制限クローンは不可）。slidesPerView + 1 枚以上ないと loop が無効化され警告が出るため、
+      // 枚数が足りるときだけ loop を有効にする。
+      const thumbnailLoop = thumbnailTargetSlides.length >= thumbnailPerView + 1;
 
-      //メイン側のスライダーを初期化
+      // メイン↔サムネの連携は Thumbs モジュールで行う。
+      // Swiper v9 以降、双方向 controller での連携はアンチパターン。特に v11+ の動的 loop や
+      // slidesPerView が異なるスライダー同士では controller の translate 補間で同期がずれ、
+      // メイン操作時にサムネのアクティブ表示・位置が破綻するため Thumbs に統一する。
+      // next で1枚ずつ送るため freeMode は使わず、slidesPerGroup は既定の 1 のままにする。
+      // ※ Thumbs で参照するため、サムネ側をメイン側より先に初期化すること。
+      const thumbnailSwiper = new Swiper(thumbnailTarget, {
+        modules,
+        speed: 500,
+        loop: thumbnailLoop,
+        threshold: 10,
+        slidesPerView: thumbnailPerView,
+        spaceBetween: 4,
+        watchSlidesProgress: true,
+        slideToClickedSlide: true,
+        // サムネの前へ/次へは「メインを送る」ために使うため、サムネ自身の navigation には割り当てない
+        // （Thumbs ではサムネ nav は本来ストリップのスクロール用で、メインとは同期しないため）。
+      });
+
+      //メイン側のスライダーを初期化（サムネと Thumbs で連携）
       const mainSwiper = new Swiper(mainTarget, {
+        modules,
         speed: 500,
         loop: true,
-        loopedSlides: mainTargetSlides.length,
         slidesPerView: 1,
         spaceBetween: 4,
         threshold: 10,
@@ -349,54 +464,17 @@ export default class SwiperSlider {
           nextEl: mainNext,
           prevEl: mainPrev,
         },
+        thumbs: {
+          swiper: thumbnailSwiper,
+        },
       });
 
-
-      //サムネイル側のスライダーを初期化
-      if (thumbnailTargetSlides.length >= thumbnailMinSlides) {
-        const thumbnailSwiper = new Swiper(thumbnailTarget, {
-          speed: 500,
-          loop: thumbnailLoop,
-          threshold: 10,
-          slidesPerView: 6,
-
-          slideToClickedSlide: true,
-          spaceBetween: 4,
-          // centeredSlides: true,
-          loopedSlidesLimit: false, //スライドの複製を無制限にする
-          loopedSlides: mainTargetSlides.length, //メインスライダーと同じ複製数に設定
-          controller: {
-            control: mainSwiper,
-          },
-          navigation: {
-            nextEl: thumbnailNext,
-            prevEl: thumbnailPrev,
-          },
-        });
-
-        mainSwiper.controller.control = thumbnailSwiper;
-
+      // サムネの前へ/次へでもメインを1枚ずつ送る（サムネのハイライト・スクロールは Thumbs が追従する）
+      if (thumbnailNext) {
+        thumbnailNext.addEventListener('click', () => mainSwiper.slideNext());
       }
-      else {
-        //サムネイルスライダーの1枚目にactiveクラスを付与する
-        thumbnailTargetSlides[0].classList.add('swiper-slide-active');
-
-        //サムネイルスライダーを初期化せずに、サムネイルリストをクリックしたらメインスライダーを切り替えるようにする
-        thumbnailTargetSlides.forEach((slide, index) => {
-          slide.addEventListener('click', () => {
-            mainSwiper.slideTo(index);
-            thumbnailTargetSlides.forEach((slide, index) => {
-              slide.classList.toggle('swiper-slide-active', index === current);
-            });
-          });
-        });
-        //メインスライダーが切り替わったらサムネイルスライダーを更新する
-        mainSwiper.on('slideChange', () => {
-          const current = mainSwiper.realIndex;
-          thumbnailTargetSlides.forEach((slide, index) => {
-            slide.classList.toggle('swiper-slide-active', index === current);
-          });
-        });
+      if (thumbnailPrev) {
+        thumbnailPrev.addEventListener('click', () => mainSwiper.slidePrev());
       }
 
       // 自動再生するタイプだともしかして以下いるかも

--- a/app/assets/scss/object/components/gallery-image.scss
+++ b/app/assets/scss/object/components/gallery-image.scss
@@ -154,8 +154,8 @@
       width: initial;
     }
 
-    &.swiper-slide-active,
-    &.swiper-slide-duplicate-active {
+    // Thumbs モジュールはアクティブなサムネイルに .swiper-slide-thumb-active を付与する
+    &.swiper-slide-thumb-active {
       opacity: 1;
       box-shadow: 0 0 0 2px $color-black;
     }

--- a/app/format/components/_slider.pug
+++ b/app/format/components/_slider.pug
@@ -60,7 +60,7 @@ h3 サムネイル付きギャラリー
     +e.main-slider-outer
       +e.main-slider.swiper.js-gallery-image-main
         +e.main-slider-wrapper.swiper-wrapper
-          +loop(7)
+          +loop(10)
             +e.main-slider-item.swiper-slide
               +e.main-slider-image
                 +img("img-card-01.jpg")
@@ -72,7 +72,7 @@ h3 サムネイル付きギャラリー
     +e.thumbnail-slider-outer
       +e.thumbnail-slider.swiper.js-gallery-image-thumbnail
         +e.thumbnail-slider-wrapper.swiper-wrapper
-          +loop(7)
+          +loop(10)
             +e.thumbnail-slider-item.swiper-slide
               +e.thumbnail-slider-image
                 +img("img-card-01.jpg")

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,7 @@
         "scroll-hint": "^1.2.9",
         "simple-parallax-js": "^5.6.2",
         "slick-carousel": "^1.8.1",
-        "swiper": "^8.4.7"
+        "swiper": "^14.0.6"
       },
       "devDependencies": {
         "@babel/cli": "^7.27.2",
@@ -75,12 +75,6 @@
       "engines": {
         "node": ">=20.12.2"
       }
-    },
-    "build/stylelint-replace-assets-path.js": {
-      "extraneous": true
-    },
-    "config/stylelint-replace-assets-path.js": {
-      "extraneous": true
     },
     "node_modules/@ampproject/remapping": {
       "version": "2.3.0",
@@ -4532,14 +4526,6 @@
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "dev": true
-    },
-    "node_modules/dom7": {
-      "version": "4.0.6",
-      "resolved": "https://registry.npmjs.org/dom7/-/dom7-4.0.6.tgz",
-      "integrity": "sha512-emjdpPLhpNubapLFdjNL9tP06Sr+GZkrIHEXLWvOGsytACUrkbeIdjO5g77m00BrHTznnlcNqgmn7pCN192TBA==",
-      "dependencies": {
-        "ssr-window": "^4.0.0"
-      }
     },
     "node_modules/dot-case": {
       "version": "2.1.1",
@@ -10658,11 +10644,6 @@
       "dev": true,
       "license": "BSD-3-Clause"
     },
-    "node_modules/ssr-window": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/ssr-window/-/ssr-window-4.0.2.tgz",
-      "integrity": "sha512-ISv/Ch+ig7SOtw7G2+qkwfVASzazUnvlDTwypdLoPoySv+6MqlOV10VwPSE6EWkGjhW50lUmghPmpYZXMu/+AQ=="
-    },
     "node_modules/statuses": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.3.1.tgz",
@@ -11303,24 +11284,20 @@
       }
     },
     "node_modules/swiper": {
-      "version": "8.4.7",
-      "resolved": "https://registry.npmjs.org/swiper/-/swiper-8.4.7.tgz",
-      "integrity": "sha512-VwO/KU3i9IV2Sf+W2NqyzwWob4yX9Qdedq6vBtS0rFqJ6Fa5iLUJwxQkuD4I38w0WDJwmFl8ojkdcRFPHWD+2g==",
+      "version": "14.0.6",
+      "resolved": "https://registry.npmjs.org/swiper/-/swiper-14.0.6.tgz",
+      "integrity": "sha512-ArptjmcZMBvpLCbvzSKuqvQpjjITCbZdymiGOrbZQffQ3ZSjgpvMByXX0WZBUt+FV4PPIumdYfZ9ZdBbFsdH6g==",
       "funding": [
         {
-          "type": "patreon",
-          "url": "https://www.patreon.com/swiperjs"
+          "type": "custom",
+          "url": "https://sponsors.nolimits4web.com"
         },
         {
-          "type": "open_collective",
-          "url": "http://opencollective.com/swiper"
+          "type": "github",
+          "url": "https://github.com/sponsors/nolimits4web"
         }
       ],
-      "hasInstallScript": true,
-      "dependencies": {
-        "dom7": "^4.0.4",
-        "ssr-window": "^4.0.2"
-      },
+      "license": "MIT",
       "engines": {
         "node": ">= 4.7.0"
       }

--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
     "scroll-hint": "^1.2.9",
     "simple-parallax-js": "^5.6.2",
     "slick-carousel": "^1.8.1",
-    "swiper": "^8.4.7"
+    "swiper": "^14.0.6"
   },
   "skipInheritances": [
     "node_modules"


### PR DESCRIPTION
## 概要
`swiper` を **v8.4.7 → v14.0.6** に更新し、Critical の脆弱性（プロトタイプ汚染）を解消しました。あわせて v8→v14 の破壊的変更への追随と、各スライダーの不具合修正を行っています。

## ⚠️ 要確認
今回の変更は脆弱性の解消を最優先に据えて対応しています。実案件での実装については、以下の方針でお願いします。
- `v14`のSwiperの仕様で前提に進めてください。どうしてもデザイン・要求に応えられない場合は、`Embla Carousel`など（今後、Swiperから移行可能か否かといった視点では、実際に導入テスト運用後、確定すること。）
- TOPメインビジュアル、フォーマットページのスライダーサンプルのリプレイスについては、ほぼ同様の実装が可能なことは確認できています。ただし、これまでの標準とされてきた細かい部分（Cloneして無限ループするなど）を実現するには、独自のメソッドが必要になっています。
- 上記の文脈で移行後は多少不便さが出る可能性はありますが、フォーマットの再現性 + AIは最新の仕様を把握できることを一定考慮し、`v14`で運用可能と判断しています。

## 背景 / 目的
- `swiper@8.4.7` に **Critical: Prototype Pollution**（`GHSA-hmx5-qpq5-p643` / 影響範囲 `>=6.5.1 <12.1.2`）。
- v8→v14 はメジャー跨ぎで破壊的変更があり、モジュール読み込み・loop 仕様・スライダー連携方式の修正が必要でした。

## 変更内容

### 依存関係
- `swiper`: `^8.4.7` → `^14.0.6`

### モジュール読み込み方式（v9〜）
- `Swiper.use()` は廃止。`swiper/modules` から import し、各インスタンスに `modules` オプションを渡す方式へ変更。

### サムネイル付きギャラリー（`galleryImageSlider`）
- メイン↔サムネの連携を、双方向 `controller` から **Thumbs モジュール**へ統一（v11+ の動的 loop ＋ `slidesPerView` 差により controller の translate 補間で同期が破綻し、メイン操作でサムネが崩れていたため）。
- サムネの「前へ/次へ」を `mainSwiper.slideNext()/slidePrev()` に割り当て、サムネクリック→メイン連動も維持。
- アクティブサムネの装飾を `.swiper-slide-active` → **`.swiper-slide-thumb-active`** に変更（`gallery-image.scss`）。
- 新バージョンでは `loopedSlides` / `loopedSlidesLimit` が存在しないため除去。

#### 備考
- サムネイルの部分については、以下の挙動でOKとした。（むしろ、常に一番左側にアクティブ状態のアイテムが来る状態は違和感がある）

https://www.awesomescreenshot.com/video/54856784?key=63967ab8f4f567cc0954ab4908d53ac0

### カードスライダー（`runCardSlider` / `initCardSlider`)
- v14 の loop 要件（実スライド不足で無効化＆警告）に対応するため、`prepareLoopSlides()`
で不足分のスライドを複製。少数枚数でも見切れ表示（`sliSlides`）を保ったまま**無限ループ**を成立
- ページネーションのドットは複製分を除き、**元スライド枚数**で描画（`pagination.renderCustom`）。
- `loopAdditionalSlides: 3` を除去（v14 の loop は、実スライドが `slidesPerView + slidesPerGroup + loopAdditionalSlides` 枚以上ないと成立しないため）

#### 備考
- フォーマット確認用カードスライダーの`breakpoints`はv14の挙動に合わせ、`0, 750` とした。実際に使う際は、`utils.responsiveMatch` にて調整 or 新規メソッドで設計していただければと思います。

## 動作確認
- [x] `npm audit`：`swiper` の脆弱性解消が解消されていること
- [x] webpack（JS/CSS）・pug ビルドともに成功
- 各スライダーを検証：
  - [x] **メインビジュアル**
  - [x] **カード**：PC / タブレット /モバイル各幅で無限ループ・端の空白なし・警告なし。レスポンシブ再初期化でクローンが累積しないことを確認
  - [x] **ギャラリー**：メイン↔サムネ同期（ループ一周含む）、サムネ next・スライドクリックのメイン連動を確認